### PR TITLE
Add semaphore badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ _This is a project of [AgileVentures](http://www.agileventures.org), a non-profi
 
 Sempahore status: [![Build Status](https://semaphoreci.com/api/v1/lollypop27/shf-project/branches/develop/badge.svg)](https://semaphoreci.com/lollypop27/shf-project)
 
-Travis C. I. [![Build Status](https://travis-ci.org/AgileVentures/LocalSupport.png)]()
-
-CodeClimate [![Code Climate](https://codeclimate.com/github/AgileVentures/LocalSupport.png)]()
-
 
 ## Requirements and Dependencies
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The main project documentation is on the [page for this project at the AgileVent
 _This is a project of [AgileVentures](http://www.agileventures.org), a non-profit organization dedicated to crowdsourced learning and project development._  
 
 
-[![Build Status](https://semaphoreci.com/api/v1/projects/6c49e6ca-8220-41c6-b04f-67ed15252723/1030083/badge.svg)](https://semaphoreci.com/shf-project/shf-project)
+[![Build Status](https://semaphoreci.com/api/v1/projects/6c49e6ca-8220-41c6-b04f-67ed15252723/1030083/shields_badge.svg)](https://semaphoreci.com/shf-project/shf-project)
 Travis C. I. [![Build Status](https://travis-ci.org/AgileVentures/LocalSupport.png)](https://travis-ci.org/AgileVentures/LocalSupport)
 CodeClimate [![Code Climate](https://codeclimate.com/github/AgileVentures/LocalSupport.png)](https://codeclimate.com/github/AgileVentures/LocalSupport)
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ The main project documentation is on the [page for this project at the AgileVent
 _This is a project of [AgileVentures](http://www.agileventures.org), a non-profit organization dedicated to crowdsourced learning and project development._  
 
 
-[![Build Status](https://semaphoreci.com/api/v1/projects/6c49e6ca-8220-41c6-b04f-67ed15252723/1030083/shields_badge.svg)](https://semaphoreci.com/shf-project/shf-project)
+Sempahore status: [![Build Status](https://semaphoreci.com/api/v1/projects/6c49e6ca-8220-41c6-b04f-67ed15252723/1030083/shields_badge.svg)](https://semaphoreci.com/shf-project/shf-project) 
+
 Travis C. I. [![Build Status](https://travis-ci.org/AgileVentures/LocalSupport.png)](https://travis-ci.org/AgileVentures/LocalSupport)
+
 CodeClimate [![Code Climate](https://codeclimate.com/github/AgileVentures/LocalSupport.png)](https://codeclimate.com/github/AgileVentures/LocalSupport)
 
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ The main project documentation is on the [page for this project at the AgileVent
 _This is a project of [AgileVentures](http://www.agileventures.org), a non-profit organization dedicated to crowdsourced learning and project development._  
 
 
-Sempahore status: [![Build Status](https://semaphoreci.com/api/v1/projects/6c49e6ca-8220-41c6-b04f-67ed15252723/1030083/shields_badge.svg)](https://semaphoreci.com/shf-project/shf-project) 
+Sempahore status: [![Build Status](https://semaphoreci.com/api/v1/lollypop27/shf-project/branches/develop/badge.svg)](https://semaphoreci.com/lollypop27/shf-project)
 
-Travis C. I. [![Build Status](https://travis-ci.org/AgileVentures/LocalSupport.png)](https://travis-ci.org/AgileVentures/LocalSupport)
+Travis C. I. [![Build Status](https://travis-ci.org/AgileVentures/LocalSupport.png)]()
 
-CodeClimate [![Code Climate](https://codeclimate.com/github/AgileVentures/LocalSupport.png)](https://codeclimate.com/github/AgileVentures/LocalSupport)
+CodeClimate [![Code Climate](https://codeclimate.com/github/AgileVentures/LocalSupport.png)]()
 
 
 ## Requirements and Dependencies


### PR DESCRIPTION
PT Story: 
So that developers can quickly see whether the whole system is successfully passing all tests
Hook up the Semaphore badge to the Semaphore project account for this project

*[This is a duplicate of PR #8.  Except this time I'm going to be sure to apply the PR to the 'develop' branch!]*

Changes proposed in this pull request:
1. pasted the URL that points to the Semaphore system to the link for the badge (as required and defined by Semaphore)

2. formatting: put each badge on it's own line.  (They were running together without any whitespace between them.)  This is minor.  I'm totally fine keeping them on 1 line.
3.

Ready for review:
@lollypop27 @tochman 
