### PR TITLE
removed shared_examples; put code into each describe group

### DIFF
--- a/spec/policies/membership_application_policy_spec.rb
+++ b/spec/policies/membership_application_policy_spec.rb
@@ -3,42 +3,6 @@ require 'rails_helper'
 
 describe MembershipApplicationPolicy do
 
-  shared_examples_for 'cannot change or destroy status' do
-    describe 'cannot edit, update, or destroy status' do
-      subject { described_class.new(this_user, this_application) }
-
-      it 'cannot edit the status' do
-        is_expected.to forbid_mass_assignment_of(:status).for_action(:edit)
-      end
-      it 'cannot update the status' do
-        is_expected.to forbid_mass_assignment_of(:status).for_action(:update)
-      end
-      it 'cannot destroy the status' do
-        is_expected.to forbid_mass_assignment_of(:status).for_action(:destroy)
-      end
-
-    end
-  end
-
-  shared_examples_for 'can create status' do
-    describe 'can create status' do
-      subject { described_class.new(this_user, this_application) }
-      it 'can create a status' do
-        is_expected.to permit_mass_assignment_of(:status).for_action(:create)
-      end
-    end
-  end
-
-  shared_examples_for 'can see the status' do
-    describe 'can show status' do
-      subject { described_class.new(this_user, this_application) }
-      it 'can show the status' do
-        is_expected.to permit_mass_assignment_of(:status).for_action(:show)
-      end
-    end
-  end
-
-
   describe 'policy for the status attribute' do
 
     let(:application_owner) { create(:user, email: 'user_1@random.com') }
@@ -50,51 +14,72 @@ describe MembershipApplicationPolicy do
 
 
     describe 'For the MembershipApplication creator' do
-      it_behaves_like 'can see the status' do
-        let(:this_application) { application }
-        let(:this_user) { application_owner }
+
+      subject { described_class.new(application_owner, application) }
+
+      it 'can show the status' do
+        is_expected.to permit_mass_assignment_of(:status).for_action(:show)
       end
 
-      it_behaves_like 'can create status' do
-        let(:this_application) { application }
-        let(:this_user) { application_owner }
+      it 'can create a status' do
+        is_expected.to permit_mass_assignment_of(:status).for_action(:create)
       end
 
-      it_behaves_like 'cannot change or destroy status' do
-        let(:this_application) { application }
-        let(:this_user) { application_owner }
+      it 'cannot edit the status' do
+        is_expected.to forbid_mass_assignment_of(:status).for_action(:edit)
       end
+
+      it 'cannot update the status' do
+        is_expected.to forbid_mass_assignment_of(:status).for_action(:update)
+      end
+
+      it 'cannot destroy the status' do
+        is_expected.to forbid_mass_assignment_of(:status).for_action(:destroy)
+      end
+
     end
+
 
     describe 'for user not the owner' do
       subject { described_class.new(not_the_owner, application) }
 
-      it_behaves_like 'can see the status' do
-        let(:this_application) { application }
-        let(:this_user) { not_the_owner }
+      it 'can show the status' do
+        is_expected.to permit_mass_assignment_of(:status).for_action(:show)
       end
 
-      it_behaves_like 'can create status' do
-        let(:this_application) { application }
-        let(:this_user) { not_the_owner }
+      it 'can create a status' do
+        is_expected.to permit_mass_assignment_of(:status).for_action(:create)
       end
 
-      it_behaves_like 'cannot change or destroy status' do
-        let(:this_application) { application }
-        let(:this_user) { not_the_owner }
+      it 'cannot edit the status' do
+        is_expected.to forbid_mass_assignment_of(:status).for_action(:edit)
+      end
+
+      it 'cannot update the status' do
+        is_expected.to forbid_mass_assignment_of(:status).for_action(:update)
+      end
+
+      it 'cannot destroy the status' do
+        is_expected.to forbid_mass_assignment_of(:status).for_action(:destroy)
       end
     end
+
 
     describe 'for a visitor' do
       subject { described_class.new(nil, application) }
 
-      it 'can create #status' do
+      it 'can create a status' do
         is_expected.to permit_mass_assignment_of(:status).for_action(:create)
       end
 
-      it_behaves_like 'cannot change or destroy status' do
-        let(:this_application) { application }
-        let(:this_user) { nil }
+      it 'cannot edit the status' do
+        is_expected.to forbid_mass_assignment_of(:status).for_action(:edit)
+      end
+      it 'cannot update the status' do
+        is_expected.to forbid_mass_assignment_of(:status).for_action(:update)
+      end
+      it 'cannot destroy the status' do
+        is_expected.to forbid_mass_assignment_of(:status).for_action(:destroy)
       end
 
       it 'cannot see (show) the status' do
@@ -105,14 +90,12 @@ describe MembershipApplicationPolicy do
     describe 'For admins' do
       subject { described_class.new(admin, application) }
 
-      it_behaves_like 'can see the status' do
-        let(:this_application) { application }
-        let(:this_user) { admin }
+      it 'can show the status' do
+        is_expected.to permit_mass_assignment_of(:status).for_action(:show)
       end
 
-      it_behaves_like 'can create status' do
-        let(:this_application) { application }
-        let(:this_user) { admin }
+      it 'can create a status' do
+        is_expected.to permit_mass_assignment_of(:status).for_action(:create)
       end
 
       it 'can do all actions with #status' do


### PR DESCRIPTION
PT Story: clarify RSpec tests for MembershipApplicationPolicy
https://www.pivotaltracker.com/story/show/134525573

Changes proposed in this pull request:
1.  refactored: removed shared_examples.  Moved code down into describe groups

Ready for review:
@thesuss @tochman 

