### PR TITLE
check authorization policy for new, create a business category

### DIFF
--- a/app/controllers/business_categories_controller.rb
+++ b/app/controllers/business_categories_controller.rb
@@ -14,6 +14,7 @@ class BusinessCategoriesController < ApplicationController
 
 
   def new
+    authorize BusinessCategory
     @business_category = BusinessCategory.new
   end
 
@@ -23,6 +24,7 @@ class BusinessCategoriesController < ApplicationController
 
 
   def create
+    authorize BusinessCategory
     @business_category = BusinessCategory.new(business_category_params)
 
     if @business_category.save

--- a/app/policies/business_category_policy.rb
+++ b/app/policies/business_category_policy.rb
@@ -1,6 +1,14 @@
 class BusinessCategoryPolicy < ApplicationPolicy
 
 
+  def new?
+    is_admin?
+  end
+
+  def create?
+    new?
+  end
+
   def show?
     true
   end

--- a/spec/policies/business_category_policy_spec.rb
+++ b/spec/policies/business_category_policy_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe BusinessCategoryPolicy do
     it { is_expected.to permit_action :edit }
     it { is_expected.to permit_action :update }
     it { is_expected.to permit_action :destroy }
+    it { is_expected.to permit_action :new }
+    it { is_expected.to permit_action :create }
   end
 
   describe 'For a user (logged in)' do
@@ -24,6 +26,8 @@ RSpec.describe BusinessCategoryPolicy do
     it { is_expected.to forbid_action :edit }
     it { is_expected.to forbid_action :update }
     it { is_expected.to forbid_action :destroy }
+    it { is_expected.to forbid_action :new }
+    it { is_expected.to forbid_action :create }
   end
 
   describe 'For a visitor (not logged in)' do
@@ -34,5 +38,7 @@ RSpec.describe BusinessCategoryPolicy do
     it { is_expected.to forbid_action :edit }
     it { is_expected.to forbid_action :update }
     it { is_expected.to forbid_action :destroy }
+    it { is_expected.to forbid_action :new }
+    it { is_expected.to forbid_action :create }
   end
 end


### PR DESCRIPTION
PT Story: only an admin can create a business category
  controller wasn't checking authorization with `new` or `create`
https://www.pivotaltracker.com/story/show/135209601

Changes proposed in this pull request:
1.  check authorization for `new` and `create` actions
2. spec (tests) for `new` and `create` actions

Ready for review:
@thesuss 

