### PR TITLE
Uploaded file name links to file

### DIFF
--- a/app/views/membership_applications/_uploaded_files_list.html.haml
+++ b/app/views/membership_applications/_uploaded_files_list.html.haml
@@ -13,5 +13,7 @@
     %tbody
       - membership_application.uploaded_files.each do |uploaded_file|
         %tr.uploaded-files
-          %td.uploaded-file= uploaded_file.actual_file_file_name
-          %td{class: "delete-uploaded-file-#{uploaded_file.id}"}= link_to icon('trash'), membership_application_path(membership_application.id, membership_application: { uploaded_files_attributes: { id: uploaded_file.id, "_destroy" => true }}), method: :put, id: "uploaded-file-#{uploaded_file.id}", class: "action-delete", data: { confirm: "Are you sure you want to delete #{uploaded_file.actual_file_file_name}" }
+          %td.uploaded-file= link_to uploaded_file.actual_file_file_name, uploaded_file.actual_file.url
+          %td{class: "delete-uploaded-file-#{uploaded_file.id}"}
+          = link_to icon('trash'),
+          membership_application_path(membership_application.id, membership_application: { uploaded_files_attributes: { id: uploaded_file.id, "_destroy" => true }}), method: :put, id: "uploaded-file-#{uploaded_file.id}", class: "action-delete", data: { confirm: "Are you sure you want to delete #{uploaded_file.actual_file_file_name}" }

--- a/app/views/membership_applications/_uploaded_files_list.html.haml
+++ b/app/views/membership_applications/_uploaded_files_list.html.haml
@@ -15,5 +15,5 @@
         %tr.uploaded-files
           %td.uploaded-file= link_to uploaded_file.actual_file_file_name, uploaded_file.actual_file.url
           %td{class: "delete-uploaded-file-#{uploaded_file.id}"}
-          = link_to icon('trash'),
-          membership_application_path(membership_application.id, membership_application: { uploaded_files_attributes: { id: uploaded_file.id, "_destroy" => true }}), method: :put, id: "uploaded-file-#{uploaded_file.id}", class: "action-delete", data: { confirm: "Are you sure you want to delete #{uploaded_file.actual_file_file_name}" }
+            = link_to icon('trash'),
+              membership_application_path(membership_application.id, membership_application: { uploaded_files_attributes: { id: uploaded_file.id, "_destroy" => true }}), method: :put, id: "uploaded-file-#{uploaded_file.id}", class: "action-delete", data: { confirm: "Are you sure you want to delete #{uploaded_file.actual_file_file_name}" }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,11 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # location for where Paperclip will store files, and the url for them:
+  attachment_folder = "/storage/#{ Rails.env}_paperclip_files/:class/:id_partition/:style/:filename"
+  config.paperclip_defaults = { url: attachment_folder,
+                                path: ":rails_root/public/:url"
+  }
+
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,11 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # location for where Paperclip will store files, and the url for them:
+  attachment_folder = "/storage/paperclip/:class/:id_partition/:style/:filename"
+  config.paperclip_defaults = { url: attachment_folder,
+                                path: ":rails_root/public/:url"
+  }
+
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,7 +40,11 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # location for where Paperclip will store files:
-  Paperclip::Attachment.default_options[:path] = "#{Rails.root}/spec/test_paperclip_files/:class/:id_partition/:style.:extension"
+
+  # location for where Paperclip will store files, and the url for them:
+  attachment_folder = "/storage/#{ Rails.env}_paperclip_files/:class/:id_partition/:style/:filename"
+  config.paperclip_defaults = { url: attachment_folder,
+                                path: ":rails_root/public/:url"
+  }
 
 end

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -5,9 +5,10 @@ Feature: As an applicant
 
   Background:
     Given the following users exists
-      | email                  |
-      | applicant_1@random.com |
-      | applicant_2@random.com |
+      | email                  | admin |
+      | applicant_1@random.com |       |
+      | applicant_2@random.com |       |
+      | admin@shf.com          | true  |
 
 
     And the following applications exist:
@@ -74,14 +75,14 @@ Feature: As an applicant
     Then I should see "Sorry, this is not a file type you can upload."
     And I should not see "not-accepted.exe" uploaded for this membership application
 
-  Scenario: User deletes a file that was uploaded
-    Given I am logged in as "applicant_1@random.com"
-    And I am on the "edit my application" page
-    When I choose a file named "diploma.pdf" to upload
-    And I click on "Submit"
-    And I am on the "edit my application" page
-    And I click on trash icon for "diploma.pdf"
-    Then I should not see "diploma.pdf" uploaded for this membership application
+ # Scenario: User deletes a file that was uploaded
+ #   Given I am logged in as "applicant_1@random.com"
+ #   And I am on the "edit my application" page
+ #   When I choose a file named "diploma.pdf" to upload
+ #   And I click on "Submit"
+ #   And I am on the "edit my application" page
+ #   And I click on trash icon for "diploma.pdf"
+ #   Then I should not see "diploma.pdf" uploaded for this membership application
 
   Scenario: User uploads a file to an existing membership application
     Given I am logged in as "applicant_1@random.com"
@@ -90,3 +91,24 @@ Feature: As an applicant
     And I click on "Submit"
     Then I should see "Files uploaded for this application:"
     And I should see "diploma.pdf" uploaded for this membership application
+
+
+  Scenario: User can click on a file name to see the file
+    Given I am logged in as "applicant_1@random.com"
+    And I am on the "edit my application" page
+    And I choose a file named "diploma.pdf" to upload
+    And I click on "Submit"
+    And I click on "diploma.pdf"
+
+
+  Scenario: Admin can click on a file name to see the file
+    Given I am logged in as "applicant_1@random.com"
+    And I am on the "edit my application" page
+    And I choose a file named "diploma.pdf" to upload
+    And I click on "Submit"
+    And I am Logged out
+    And I am logged in as "admin@shf.com"
+    And I am on the list applications page
+    And I click the "Manage" action for the row with "5562252998"
+    And I click on "diploma.pdf"
+

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -75,14 +75,14 @@ Feature: As an applicant
     Then I should see "Sorry, this is not a file type you can upload."
     And I should not see "not-accepted.exe" uploaded for this membership application
 
- # Scenario: User deletes a file that was uploaded
- #   Given I am logged in as "applicant_1@random.com"
- #   And I am on the "edit my application" page
- #   When I choose a file named "diploma.pdf" to upload
- #   And I click on "Submit"
- #   And I am on the "edit my application" page
- #   And I click on trash icon for "diploma.pdf"
- #   Then I should not see "diploma.pdf" uploaded for this membership application
+  Scenario: User deletes a file that was uploaded
+    Given I am logged in as "applicant_1@random.com"
+    And I am on the "edit my application" page
+    When I choose a file named "diploma.pdf" to upload
+    And I click on "Submit"
+    And I am on the "edit my application" page
+    And I click on trash icon for "diploma.pdf"
+    Then I should not see "diploma.pdf" uploaded for this membership application
 
   Scenario: User uploads a file to an existing membership application
     Given I am logged in as "applicant_1@random.com"


### PR DESCRIPTION
PT Story: User can upload a file with their membership application; admins can see the files by clicking on the link
https://www.pivotaltracker.com/story/show/133109591
https://www.pivotaltracker.com/story/show/135227493

Changes proposed in this pull request:

set Paperclip configuration for each environment (where files are stored)
link the filename to the actual file
Ready for review:
@thesuss
