### PR TITLE
Only admin sees make new company

### DIFF
--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -1,7 +1,7 @@
 %header.entry-header
-  -unless current_user.try(:admin)
+  - unless current_user.try(:admin)
     %h1.entry-title Hitta SHF-medlem
-  -if current_user.try(:admin)
+  - if current_user.try(:admin)
     %h1.entry-title Redigera medlemsföretag
 .post-title-divider
   %span
@@ -16,29 +16,24 @@
     %thead
       %tr
         %th Namn
-        %th Tel
-        %th Mail
         %th Län
-        %th Hemsida
         %th Org nr
-        -if current_user.try(:admin)
+        %th
+        - if current_user.try(:admin)
           %th
           %th
-          %th
+
     %tbody
       - @companies.each do |company|
         %tr.company
           %td= company.name
-          %td= company.phone_number
-          %td= company.email
           %td= company.region
-          %td= company.website
           %td= company.company_number
+          %td= link_to 'Visa företag', company
           - if current_user.try(:admin)
-            %td= link_to 'Show', company
             %td= link_to 'Edit', edit_company_path(company)
             %td= link_to 'Delete', company, method: :delete, data: { :confirm => 'Are you sure?' }
   %br
-  .center
-    - if current_user.try(:admin)
+  - if current_user && current_user.try(:admin)
+    .center
       = link_to 'Skapa nytt företag', new_company_path

--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -34,6 +34,6 @@
             %td= link_to 'Edit', edit_company_path(company)
             %td= link_to 'Delete', company, method: :delete, data: { :confirm => 'Are you sure?' }
   %br
-  - if current_user && current_user.try(:admin)
+  - if current_user.try(:admin)
     .center
       = link_to 'Skapa nytt företag', new_company_path

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -9,9 +9,9 @@ Feature: As a visitor,
       | Bowsers              | 2120000142     | bowwow@bowsersy.com    |
 
     And the following users exists
-      | email               | admin | is_member |
-      | emma@happymutts.com |       |     false      |
-      | admin@shf.se        | true  | true      |
+      | email               | admin |
+      | emma@happymutts.com |       |
+      | admin@shf.se        | true  |
 
 
   Scenario: Visitor sees all companies

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -1,0 +1,33 @@
+Feature: As a visitor,
+  so that I can find companies that can offer me services,
+  I want to see all companies
+
+  Background:
+    Given the following companies exist:
+      | name                 | company_number | email                  |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.com |
+      | Bowsers              | 2120000142     | bowwow@bowsersy.com    |
+
+    And the following users exists
+      | email               | admin | is_member |
+      | emma@happymutts.com |       |     false      |
+      | admin@shf.se        | true  | true      |
+
+
+  Scenario: Visitor sees all companies
+    Given I am Logged out
+    And I am on the "landing" page
+    Then I should see "Hitta SHF-medlem"
+    And I should see "Bowsers"
+    And I should see "No More Snarky Barky"
+    And I should not see "Skapa nytt företag"
+
+  Scenario: User sees all the companies
+    Given I am logged in as "emma@happymutts.com"
+    And I am on the "landing" page
+    Then I should see "Hitta SHF-medlem"
+    And I should see "Bowsers"
+    And I should see "No More Snarky Barky"
+    And I should not see "Skapa nytt företag"
+
+


### PR DESCRIPTION
PT Story: **visitor and user shouldn't see 'new company' on landing page** 
https://www.pivotaltracker.com/story/show/135397031

Changes proposed in this pull request:
1.  create a feature for view all companies on the landing page (is very minimal right now)
2. fixed the code  (should not have been a '!' where there was one)

Ready for review:  by anyone
@
