### PR TITLE
Membership number

### DIFF
--- a/app/views/membership_applications/_membership_number.html.haml
+++ b/app/views/membership_applications/_membership_number.html.haml
@@ -1,0 +1,2 @@
+- if @membership_application.status == 'Accepted'
+  %p.membership_number Membership number: #{@membership_application.membership_number}

--- a/app/views/membership_applications/edit.html.haml
+++ b/app/views/membership_applications/edit.html.haml
@@ -3,6 +3,9 @@
 .post-title-divider
   %span
 .entry-content.wpcf7
+
+  = render 'membership_number'
+
   = form_for @membership_application, html: {multipart: true}, url: membership_application_path do |f|
     - if @membership_application.errors.any?
       - @membership_application.errors.full_messages.each do |msg|

--- a/app/views/membership_applications/show.html.haml
+++ b/app/views/membership_applications/show.html.haml
@@ -6,6 +6,8 @@
 
   %h2= member_full_name
 
+  = render 'membership_number'
+
   %p= mail_to @membership_application.contact_email, @membership_application.contact_email
 
   - if @membership_application.phone_number

--- a/db/migrate/20161202101242_add_membership_number_to_membership_application.rb
+++ b/db/migrate/20161202101242_add_membership_number_to_membership_application.rb
@@ -1,0 +1,5 @@
+class AddMembershipNumberToMembershipApplication < ActiveRecord::Migration[5.0]
+  def change
+    add_column :membership_applications, :membership_number, :string, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161201061301) do
+ActiveRecord::Schema.define(version: 20161202101242) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,13 +53,14 @@ ActiveRecord::Schema.define(version: 20161201061301) do
   create_table "membership_applications", force: :cascade do |t|
     t.string   "company_number"
     t.string   "phone_number"
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.integer  "user_id"
-    t.string   "status",         default: "Pending"
+    t.string   "status",            default: "Pending"
     t.string   "first_name"
     t.string   "last_name"
     t.string   "contact_email"
+    t.string   "membership_number"
     t.index ["user_id"], name: "index_membership_applications_on_user_id", using: :btree
   end
 

--- a/features/admin_creates_company.feature
+++ b/features/admin_creates_company.feature
@@ -24,7 +24,7 @@ Feature: As an admin
 
     And the following applications exist:
       | first_name | user_email                 | company_number | status   |
-      | Emma       | applicant_1@happymutts.com | 5562252998     | approved |
+      | Emma       | applicant_1@happymutts.com | 5562252998     | Accepted |
 
     And the following business categories exist
       | name         |

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -63,6 +63,11 @@ Feature: As a user
     Then I should be on the landing page
     And I should see "Thank you, Your application has been submitted"
 
+  Scenario: Applicant not see membership number when submitting
+    Given I am on the "landing" page
+    And I click on "Ansök om medlemsskap"
+    Then I should not see "Membership Number"
+
   Scenario: Applicant can see which fields are required
     Given I am on the "landing" page
     And I click on "Ansök om medlemsskap"

--- a/features/show_membership_application.feature
+++ b/features/show_membership_application.feature
@@ -19,10 +19,10 @@ Feature: As an Admin
       | admin@sgf.com          | true  |
 
     And the following applications exist:
-      | first_name | user_email             | company_number |
-      | Emma       | applicant_1@random.com | 5562252998     |
-      | Hans       | applicant_2@random.com | 5560360793     |
-      | Anna       | applicant_3@random.com | 2120000142     |
+      | first_name | user_email             | company_number | status   |
+      | Emma       | applicant_1@random.com | 5562252998     | approved |
+      | Hans       | applicant_2@random.com | 5560360793     | pending  |
+      | Anna       | applicant_3@random.com | 2120000142     | pending  |
 
     And the following business categories exist
       | name         |
@@ -75,6 +75,12 @@ Feature: As an Admin
     And I should see "Trainer"
     And I should see "Psychologist"
     And I should not see "Groomer"
+
+  Scenario: Approved member should see membership number
+    Given I am logged in as "applicant_1@random.com"
+    And I am on the "landing" page
+    And I click on "Min ansökan"
+    Then I should see "Membership number"
 
   Scenario: Listing incoming Applications restricted for Non-admins
     Given I am logged in as "applicant_2@random.com"

--- a/features/show_membership_application.feature
+++ b/features/show_membership_application.feature
@@ -20,7 +20,7 @@ Feature: As an Admin
 
     And the following applications exist:
       | first_name | user_email             | company_number | status   |
-      | Emma       | applicant_1@random.com | 5562252998     | approved |
+      | Emma       | applicant_1@random.com | 5562252998     | Accepted |
       | Hans       | applicant_2@random.com | 5560360793     | pending  |
       | Anna       | applicant_3@random.com | 2120000142     | pending  |
 

--- a/spec/factories/membership_applications.rb
+++ b/spec/factories/membership_applications.rb
@@ -5,6 +5,8 @@ FactoryGirl.define do
     company_number '5562252998'
     phone_number 'MyString'
     contact_email 'MyString@email.com'
+    status 'pending'
+
     association :user
   end
 end

--- a/spec/models/membership_application_spec.rb
+++ b/spec/models/membership_application_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe MembershipApplication, type: :model do
     it { is_expected.to have_db_column :phone_number }
     it { is_expected.to have_db_column :contact_email }
     it { is_expected.to have_db_column :status }
+    it { is_expected.to have_db_column :membership_number }
   end
 
   describe 'Validations' do


### PR DESCRIPTION
PT Story:  **Add Membership number**
PT https://www.pivotaltracker.com/story/show/135396531


Changes proposed in this pull request:
1.  added `membership_number` to membership_application
2. show the membership number _only if_ the membership_application is **Accepted**
3. (fixed some features: they were using 'approved' as the status; it should be 'Accepted'

Ready for review:
@thesuss 
