### PR TITLE
Seed data only once

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,12 +11,13 @@ require 'csv'
 csv_text = File.read(Rails.root.join('lib', 'seeds', 'user_table.csv'))
 csv = CSV.parse(csv_text, :headers => true, :encoding => 'ISO-8859-1')
 csv.each do |row|
-  User.create(email: row['email'], password: 'whatever')
-  puts row['email'] + ' saved'
+  User.find_or_create_by(email: row['email']) do | user |
+    user.password = 'whatever'
+  end
 end
 
 business_categories = %w(Träning Psykologi Rehab Butik Trim Friskvård Dagis Pensionat Skola)
-business_categories.each { |b_category| BusinessCategory.create(name: b_category)}
-BusinessCategory.create(name: 'Sociala tjänstehundar', description: 'Terapi-, vård- & skolhund dvs hundar som jobbar tillsammans med sin förare/ägare inom vård, skola och omsorg.')
-BusinessCategory.create(name: 'Civila tjänstehundar', description: 'Assistanshundar dvs hundar som jobbar åt sin ägare som service-, signal, diabetes, PH-hund mm')
+business_categories.each { |b_category| BusinessCategory.find_or_create_by(name: b_category)}
+BusinessCategory.find_or_create_by(name: 'Sociala tjänstehundar', description: 'Terapi-, vård- & skolhund dvs hundar som jobbar tillsammans med sin förare/ägare inom vård, skola och omsorg.')
+BusinessCategory.find_or_create_by(name: 'Civila tjänstehundar', description: 'Assistanshundar dvs hundar som jobbar åt sin ägare som service-, signal, diabetes, PH-hund mm')
 

--- a/features/seeding_business_categories.feature
+++ b/features/seeding_business_categories.feature
@@ -10,10 +10,18 @@ Feature: As an Admin
 
     And I am logged in as "admin@shf.com"
 
-  Scenario:
+  Scenario: 11 business categories are created when it's initially seeded
     Given There are no "BusinessCategories" records in the db
     When the system is seeded with initial data
     And I am on the "business categories" page
     Then I should see "Business Categories"
     And I should see 11 business_category rows
+
+  Scenario: only 11 business categories are ever created, even if it's seeded multiple times
+    Given There are no "BusinessCategories" records in the db
+    And the system is seeded with initial data
+    And the system is seeded with initial data
+    When the system is seeded with initial data
+    And I am on the "business categories" page
+    Then I should see 11 business_category rows
 


### PR DESCRIPTION
PT Story: Ensure data is only written once even if db:seed is run multiple times
https://www.pivotaltracker.com/story/show/135469391

Changes proposed in this pull request:
1.  feature scenario added to test if too many business_categories are written
2. all calls in `seed.rb` now use `find_or_create_by`

Ready for review:
@thesuss 