### PR TITLE
Admin nav fixup

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -258,6 +258,5 @@ select {
     margin:0 !important;
 }
 .admin {
-    padding-top:80px;
+    padding-top:40px;
 }
-/* FROM SHF SITE */

--- a/app/views/partials/_navigation.html.haml
+++ b/app/views/partials/_navigation.html.haml
@@ -76,6 +76,8 @@
             %ul.menu#menu-menu-2
               %li.menu-item
                 = link_to 'SHF-sajten', 'http://sverigeshundforetagare.se/'
+              %li.menu-item
+                = link_to 'SHF-företag', root_path
               - if current_user.try(:membership_applications).try(:any?) && current_user.try(:membership_applications).try(:last).try(:persisted?)
                 %li.menu-item.menu-item-has-children
                   = link_to 'Medlemssidor', page_path('index')
@@ -84,7 +86,7 @@
                       - unless page == 'index'
                         %li.menu-item
                           = link_to page.capitalize, page_path(page)
-                %li.menu-item
+                %li.menu-item.menu-item-has-children
                   = link_to 'Min ansökan', edit_membership_application_path(current_user.membership_applications.last)
                 - if member_has_company?
                   %li.menu-item.menu-item-has-children
@@ -117,7 +119,7 @@
                 = link_to 'Företag', companies_path
                 %ul.sub-menu
                   %li.menu-item
-                    = link_to 'Lista kategorier', companies_path
+                    = link_to 'Lista företag', companies_path
                   %li.menu-item
-                    = link_to 'Ny kategori', new_company_path
+                    = link_to 'Nytt företag', new_company_path
         = render 'partials/social_nav'

--- a/app/views/partials/_navigation.html.haml
+++ b/app/views/partials/_navigation.html.haml
@@ -86,7 +86,7 @@
                       - unless page == 'index'
                         %li.menu-item
                           = link_to page.capitalize, page_path(page)
-                %li.menu-item.menu-item-has-children
+                %li.menu-item
                   = link_to 'Min ansökan', edit_membership_application_path(current_user.membership_applications.last)
                 - if member_has_company?
                   %li.menu-item.menu-item-has-children


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/135476393
sub-menu item labels were duplicated (copy-paste-accident)

Also fixes a minor issue with padding when logged in as admin. 
