### PR TITLE
Remove checkboxes from new/edit company views

### DIFF
--- a/app/views/business_categories/_as_list.html.haml
+++ b/app/views/business_categories/_as_list.html.haml
@@ -1,5 +1,4 @@
-%h4 Typ av företag
-%strong
-  %ul
-    - categories.each do | business_category |
+.post-category
+  %ul.post-categories
+    - @company.categories.each do | business_category |
       %li= business_category.name

--- a/app/views/companies/_form.html.haml
+++ b/app/views/companies/_form.html.haml
@@ -29,12 +29,9 @@
   = f.label :region, 'Verksamhetslän', class: 'required'
   = f.text_field :region, class: 'wpcf7-form-control'
   %em Skriv Sverige om företaget är verksamt i flera delar av landet
+  %br
 
   = f.label :website, 'Webbsida', class: 'required'
   = f.text_field :website, class: 'wpcf7-form-control'
-
-  -# # ActiveRecord::Assocations::CollectionAssociation us to use .size
-  - unless assocation_empty?(@all_business_categories)
-    = render 'business_categories/form_collection_checkboxes', f: f, business_categories: @all_business_categories
 
   = f.submit 'Submit'

--- a/app/views/companies/edit.html.haml
+++ b/app/views/companies/edit.html.haml
@@ -1,10 +1,12 @@
 %header.entry-header
   %h1.entry-title= 'Editing Company: ' "#{@company.name}"
-.post-title-divider
-  %span
+  .post-title-divider
+    %span
+  - unless assocation_empty?(@all_business_categories)
+    = render 'business_categories/as_list'
 .entry-content.wpcf7
   = render 'form'
-.center
-  = link_to 'Show', @company
-  \|
-  = link_to 'Back', companies_path
+  .center
+    = link_to 'Show', @company
+    \|
+    = link_to 'Back', companies_path

--- a/app/views/companies/new.html.haml
+++ b/app/views/companies/new.html.haml
@@ -1,8 +1,8 @@
 %header.entry-header
   %h1.entry-title New Company
-.post-title-divider
-  %span
+  .post-title-divider
+    %span
 .entry-content.wpcf7
   = render 'form'
-.center
-  = link_to ' All Companies', companies_path
+  .center
+    = link_to ' All Companies', companies_path

--- a/app/views/companies/show.html.haml
+++ b/app/views/companies/show.html.haml
@@ -1,10 +1,10 @@
 %header.entry-header
   %h1.entry-title= @company.name
-.post-title-divider
-  %span
-.entry-content
+  .post-title-divider
+    %span
   - unless @categories.nil?
     = render 'business_categories/as_list', categories: @categories
+.entry-content
   %p
     %b Name:
     = @company.name

--- a/features/admin_creates_company.feature
+++ b/features/admin_creates_company.feature
@@ -66,13 +66,10 @@ Feature: As an admin
 
   Scenario: Admin edits a company
     Given I am logged in as "admin@shf.se"
-    When I am on the "all companies" page
-    And I click the "Edit" action for the row with "5560360793"
-    And I fill in the form with data :
+    And I am on the edit company page for "5560360793"
+    When I fill in the form with data :
       | Email                | Webbsida                     |
       | kicki@gladajyckar.se | http://www.snarkybarkbark.se |
-    And I select "Groomer" Category
-    And I select "Trainer" Category
     And I click on "Submit"
     Then I should see "The company was successfully updated."
     And I should see "kicki@gladajyckar.se"
@@ -80,8 +77,7 @@ Feature: As an admin
 
   Scenario Outline: Admin edits a company - when things go wrong (sad case)
     Given I am logged in as "admin@shf.se"
-    When I am on the "all companies" page
-    And I click the "Edit" action for the row with "5560360793"
+    And I am on the edit company page for "5560360793"
     And I fill in the form with data :
       | Företagsnamn | Org nr       | Email   | Telefon | Gata     | Post nr     | Ort   | Verksamhetslän | Webbsida  |
       | <name>       | <org_number> | <email> | <phone> | <street> | <post_code> | <city> | <region>       | <website> |

--- a/features/member_edits_company_page.feature
+++ b/features/member_edits_company_page.feature
@@ -45,8 +45,6 @@ Feature: As a member
     And I fill in the form with data :
       | Företagsnamn | Org nr     | Gata           | Post nr | Ort    | Verksamhetslän | Email                | Webbsida                  |
       | Happy Mutts  | 5562252998 | Ålstensgatan 4 | 123 45  | Bromma | Stockholm      | kicki@gladajyckar.se | http://www.gladajyckar.se |
-    And I select "Groomer" Category
-    And I select "Trainer" Category
     And I click on "Submit"
     And I am Logged out
     And I am logged in as "applicant_2@random.com"

--- a/features/step_definitions/company_steps.rb
+++ b/features/step_definitions/company_steps.rb
@@ -8,3 +8,13 @@ And(/^I am the page for company number "([^"]*)"$/) do |company_number|
   company = Company.find_by_company_number(company_number)
   visit company_path company
 end
+
+Then(/^I should be on the edit company page for "([^"]*)"$/) do |company_number|
+  company = Company.find_by_company_number(company_number)
+  expect(current_path).to eq company_path(company)
+end
+
+When(/^I am on the edit company page for "([^"]*)"$/) do |company_number|
+  company = Company.find_by_company_number(company_number)
+  visit edit_company_path company
+end

--- a/features/step_definitions/company_steps.rb
+++ b/features/step_definitions/company_steps.rb
@@ -9,11 +9,6 @@ And(/^I am the page for company number "([^"]*)"$/) do |company_number|
   visit company_path company
 end
 
-Then(/^I should be on the edit company page for "([^"]*)"$/) do |company_number|
-  company = Company.find_by_company_number(company_number)
-  expect(current_path).to eq company_path(company)
-end
-
 When(/^I am on the edit company page for "([^"]*)"$/) do |company_number|
   company = Company.find_by_company_number(company_number)
   visit edit_company_path company


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/135475111

As an admin,
I can create a new/edit a company. 
But I shouldn't be able to set the categories for it.

On the new/edit company page, the categories should be read only.  

Changes proposed in this pull request:
1. Refactoring of _as_list
2. Removing all_business_categories checkboxes from company forms
3. Prettified views slightly
4. Added a step for faster getting to the edit page as an admin
4. Removed the steps for choosing categories for businesses

