### PR TITLE
Reject duplicate company numbers

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -3,7 +3,7 @@ class Company < ApplicationRecord
   include HasSwedishOrganization
 
   validates_presence_of :company_number
-  validates_uniqueness_of :company_number, message: "Detta företag (org nr) finns redan i systemet"
+  validates_uniqueness_of :company_number, message: "Detta företag (org nr) finns redan i systemet."
   validates_length_of :company_number, is: 10
   validates_format_of :email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: [:create, :update]
   validate :swedish_organisationsnummer

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -3,6 +3,7 @@ class Company < ApplicationRecord
   include HasSwedishOrganization
 
   validates_presence_of :company_number
+  validates_uniqueness_of :company_number, message: "The organization number has already been taken."
   validates_length_of :company_number, is: 10
   validates_format_of :email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: [:create, :update]
   validate :swedish_organisationsnummer

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -3,7 +3,7 @@ class Company < ApplicationRecord
   include HasSwedishOrganization
 
   validates_presence_of :company_number
-  validates_uniqueness_of :company_number, message: "The organization number has already been taken."
+  validates_uniqueness_of :company_number, message: "Detta företag (org nr) finns redan i systemet"
   validates_length_of :company_number, is: 10
   validates_format_of :email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: [:create, :update]
   validate :swedish_organisationsnummer

--- a/db/migrate/20161206020021_add_company_number_index_to_company.rb
+++ b/db/migrate/20161206020021_add_company_number_index_to_company.rb
@@ -1,0 +1,5 @@
+class AddCompanyNumberIndexToCompany < ActiveRecord::Migration[5.0]
+  def change
+    add_index :companies, :company_number, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161202101242) do
+ActiveRecord::Schema.define(version: 20161206020021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20161202101242) do
     t.string   "website"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
+    t.index ["company_number"], name: "index_companies_on_company_number", unique: true, using: :btree
   end
 
   create_table "membership_applications", force: :cascade do |t|
@@ -63,6 +64,7 @@ ActiveRecord::Schema.define(version: 20161202101242) do
     t.string   "membership_number"
     t.integer  "company_id"
     t.index ["company_id"], name: "index_membership_applications_on_company_id", using: :btree
+    t.index ["company_number"], name: "index_membership_applications_on_company_number", unique: true, using: :btree
     t.index ["user_id"], name: "index_membership_applications_on_user_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,10 +61,9 @@ ActiveRecord::Schema.define(version: 20161206020021) do
     t.string   "first_name"
     t.string   "last_name"
     t.string   "contact_email"
-    t.string   "membership_number"
     t.integer  "company_id"
+    t.string   "membership_number"
     t.index ["company_id"], name: "index_membership_applications_on_company_id", using: :btree
-    t.index ["company_number"], name: "index_membership_applications_on_company_number", unique: true, using: :btree
     t.index ["user_id"], name: "index_membership_applications_on_user_id", using: :btree
   end
 

--- a/features/admin_creates_company.feature
+++ b/features/admin_creates_company.feature
@@ -62,7 +62,7 @@ Feature: As an admin
       | Happy Mutts | 00         | 0706898525 | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@gladajyckar.se | http://www.gladajyckar.se | "Company number is the wrong length (should be 10 characters)"        |
       | Happy Mutts | 5562252998 |            | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kickiimmi.nu         | http://www.gladajyckar.se | "Email is invalid"                                                    |
       | Happy Mutts | 5562252998 |            | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@imminu         | http://www.gladajyckar.se | "Email is invalid"                                                    |
-      | Happy Mutts | 5560360793 | 0706898525 | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@imminu.se      | http://www.gladajyckar.se | "The organization number has already been taken." |
+      | Happy Mutts | 5560360793 | 0706898525 | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@imminu.se      | http://www.gladajyckar.se | "Detta företag (org nr) finns redan i systemet." |
 
 
   Scenario: Admin edits a company

--- a/features/admin_creates_company.feature
+++ b/features/admin_creates_company.feature
@@ -38,7 +38,7 @@ Feature: As an admin
     When I am on the "create a new company" page
     And I fill in the form with data :
       | Företagsnamn | Org nr     | Gata           | Post nr | Ort    | Verksamhetslän | Email                | Webbsida                  |
-      | Happy Mutts  | 5562252998 | Ålstensgatan 4 | 123 45  | Bromma | Stockholm      | kicki@gladajyckar.se | http://www.gladajyckar.se |
+      | Happy Mutts  | 5569467466 | Ålstensgatan 4 | 123 45  | Bromma | Stockholm      | kicki@gladajyckar.se | http://www.gladajyckar.se |
     And I click on "Submit"
     Then I should see "The company was successfully created."
     And I should see "Happy Mutts"

--- a/features/admin_creates_company.feature
+++ b/features/admin_creates_company.feature
@@ -58,10 +58,11 @@ Feature: As an admin
     And I should see "A problem prevented the company from being created."
 
     Scenarios:
-      | name        | org_number | phone      | street         | post_code | city   | region    | email                | website                   | error                                                          |
-      | Happy Mutts | 00         | 0706898525 | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@gladajyckar.se | http://www.gladajyckar.se | "Company number is the wrong length (should be 10 characters)" |
-      | Happy Mutts | 5562252998 |            | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kickiimmi.nu         | http://www.gladajyckar.se | "Email is invalid"                                             |
-      | Happy Mutts | 5562252998 |            | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@imminu         | http://www.gladajyckar.se | "Email is invalid"                                             |
+      | name        | org_number | phone      | street         | post_code | city   | region    | email                | website                   | error                                                                 |
+      | Happy Mutts | 00         | 0706898525 | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@gladajyckar.se | http://www.gladajyckar.se | "Company number is the wrong length (should be 10 characters)"        |
+      | Happy Mutts | 5562252998 |            | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kickiimmi.nu         | http://www.gladajyckar.se | "Email is invalid"                                                    |
+      | Happy Mutts | 5562252998 |            | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@imminu         | http://www.gladajyckar.se | "Email is invalid"                                                    |
+      | Happy Mutts | 5560360793 | 0706898525 | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@imminu.se      | http://www.gladajyckar.se | "The organization number has already been taken." |
 
 
   Scenario: Admin edits a company


### PR DESCRIPTION
PT Story: **don't create a company with same Org Nbr**
https://www.pivotaltracker.com/story/show/135485381

Changes proposed in this pull request:
1.  add unique index in companies table for company_number to catch the particular timing of 2 users creating a new company, and ActiveRecord validates and saves them close enough in time that ActiveRecord thinks all is ok
2. validate the uniqueness of a company_number in the company table

Ready for review:
@thesuss  anyone
