### PR TITLE
in production, get admin email and password from ENV, not in the seeds.rb file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ public/system/
 public/storage
 
 /lib/seeds/imported-data
+
+# do not put config/secrets.yml into repository
+config/secrets.yml

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,3 @@ public/system/
 public/storage
 
 /lib/seeds/imported-data
-
-# do not put config/secrets.yml into repository
-config/secrets.yml

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,19 +5,38 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-User.create(email: 'admin@sverigeshundforetagare.se', password: 'hundapor', admin: true)
+
+class SeedAdminENVError < StandardError
+end
+
+SEED_ERROR_MSG = 'Seed ERROR: Could not load either admin email or password. NO ADMIN was created!'
+
+private def env_invalid_blank(env_key)
+  raise SeedAdminENVError, SEED_ERROR_MSG if (env_val = ENV.fetch(env_key)).blank?
+  env_val
+end
+
+
+begin
+  email = env_invalid_blank('SHF_ADMIN_EMAIL')
+  pwd = env_invalid_blank('SHF_ADMIN_PWD')
+
+  User.create(email: email, password: pwd, admin: true)
+rescue
+  raise SeedAdminENVError, SEED_ERROR_MSG
+end
+
 require 'csv'
 
 csv_text = File.read(Rails.root.join('lib', 'seeds', 'user_table.csv'))
 csv = CSV.parse(csv_text, :headers => true, :encoding => 'ISO-8859-1')
 csv.each do |row|
-  User.find_or_create_by(email: row['email']) do | user |
+  User.find_or_create_by(email: row['email']) do |user|
     user.password = 'whatever'
   end
 end
 
 business_categories = %w(Träning Psykologi Rehab Butik Trim Friskvård Dagis Pensionat Skola)
-business_categories.each { |b_category| BusinessCategory.find_or_create_by(name: b_category)}
+business_categories.each { |b_category| BusinessCategory.find_or_create_by(name: b_category) }
 BusinessCategory.find_or_create_by(name: 'Sociala tjänstehundar', description: 'Terapi-, vård- & skolhund dvs hundar som jobbar tillsammans med sin förare/ägare inom vård, skola och omsorg.')
 BusinessCategory.find_or_create_by(name: 'Civila tjänstehundar', description: 'Assistanshundar dvs hundar som jobbar åt sin ägare som service-, signal, diabetes, PH-hund mm')
-

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,14 +17,21 @@ private def env_invalid_blank(env_key)
 end
 
 
-begin
-  email = env_invalid_blank('SHF_ADMIN_EMAIL')
-  pwd = env_invalid_blank('SHF_ADMIN_PWD')
+if Rails.env.production?
+  begin
+    email = env_invalid_blank('SHF_ADMIN_EMAIL')
+    pwd = env_invalid_blank('SHF_ADMIN_PWD')
 
+    User.create(email: email, password: pwd, admin: true)
+  rescue
+    raise SeedAdminENVError, SEED_ERROR_MSG
+  end
+else
+  email = 'admin@sverigeshundforetagare.se'
+  pwd = 'hundapor'
   User.create(email: email, password: pwd, admin: true)
-rescue
-  raise SeedAdminENVError, SEED_ERROR_MSG
 end
+
 
 require 'csv'
 

--- a/spec/db/seed_spec.rb
+++ b/spec/db/seed_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'seeds' do
+
+  env_shf_email = 'SHF_ADMIN_EMAIL'
+  env_shf_pwd = 'SHF_ADMIN_PWD'
+  admin_email = 'the-shfadmin@shf.org'
+  admin_pwd = 'insecure-password'
+
+  SEED_ERROR = 'Seed ERROR: Could not load either admin email or password. NO ADMIN was created!'
+
+
+  describe 'happy path - all is valid' do
+
+    before(:each) do
+      stub_const('ENV', {env_shf_email => admin_email, env_shf_pwd => admin_pwd})
+      Rails.application.load_seed # loading seeds
+    end
+
+    let(:admin_in_db) { User.find_by_email(admin_email) }
+
+    it "#{admin_email} is in the db" do
+      expect(admin_in_db).not_to be_nil
+    end
+
+    it "#{admin_email} is an admin (admin=true) in db" do
+      expect(admin_in_db.admin).to be_truthy
+    end
+
+    it "admin email is = ENV['SHF_ADMIN_EMAIL']" do
+      expect(admin_in_db.email).to eq(admin_email)
+    end
+
+    it "admin email is = ENV['SHF_ADMIN_PWD']" do
+      # User.find(1).valid_password?('password123')
+      expect(admin_in_db.valid_password?(admin_pwd)).to be_truthy
+    end
+
+  end
+
+
+  describe 'sad path - things go wrong' do
+
+    it "ENV[#{env_shf_email}] not found" do
+      stub_const('ENV', { env_shf_pwd => admin_pwd})
+
+      expect{Rails.application.load_seed}.to raise_exception SEED_ERROR
+    end
+
+    it "ENV[#{env_shf_email}] is an empty string" do
+      stub_const('ENV', {env_shf_email => '', env_shf_pwd => admin_pwd})
+
+      expect{Rails.application.load_seed}.to raise_exception SEED_ERROR
+    end
+
+    it "ENV[#{env_shf_pwd}] not found" do
+      stub_const('ENV', {env_shf_email => admin_email})
+
+      expect{Rails.application.load_seed}.to raise_exception SEED_ERROR
+    end
+
+    it "ENV[#{env_shf_pwd}] is an empty string" do
+      stub_const('ENV', {env_shf_email => admin_email, env_shf_pwd => ''})
+
+      expect{Rails.application.load_seed}.to raise_exception SEED_ERROR
+    end
+  end
+
+ end

--- a/spec/db/seed_spec.rb
+++ b/spec/db/seed_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'seeds' do
+RSpec.describe 'load admin.email and admin.password from ENV in production' do
 
   env_shf_email = 'SHF_ADMIN_EMAIL'
   env_shf_pwd = 'SHF_ADMIN_PWD'
@@ -13,6 +13,7 @@ RSpec.describe 'seeds' do
   describe 'happy path - all is valid' do
 
     before(:each) do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
       stub_const('ENV', {env_shf_email => admin_email, env_shf_pwd => admin_pwd})
       Rails.application.load_seed # loading seeds
     end
@@ -40,6 +41,10 @@ RSpec.describe 'seeds' do
 
 
   describe 'sad path - things go wrong' do
+
+    before(:each) do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+    end
 
     it "ENV[#{env_shf_email}] not found" do
       stub_const('ENV', { env_shf_pwd => admin_pwd})

--- a/spec/db/seed_spec.rb
+++ b/spec/db/seed_spec.rb
@@ -47,28 +47,28 @@ RSpec.describe 'load admin.email and admin.password from ENV in production' do
     end
 
     it "ENV[#{env_shf_email}] not found" do
-      stub_const('ENV', { env_shf_pwd => admin_pwd})
+      stub_const('ENV', {env_shf_pwd => admin_pwd})
 
-      expect{Rails.application.load_seed}.to raise_exception SEED_ERROR
+      expect { Rails.application.load_seed }.to raise_exception SEED_ERROR
     end
 
     it "ENV[#{env_shf_email}] is an empty string" do
       stub_const('ENV', {env_shf_email => '', env_shf_pwd => admin_pwd})
 
-      expect{Rails.application.load_seed}.to raise_exception SEED_ERROR
+      expect { Rails.application.load_seed }.to raise_exception SEED_ERROR
     end
 
     it "ENV[#{env_shf_pwd}] not found" do
       stub_const('ENV', {env_shf_email => admin_email})
 
-      expect{Rails.application.load_seed}.to raise_exception SEED_ERROR
+      expect { Rails.application.load_seed }.to raise_exception SEED_ERROR
     end
 
     it "ENV[#{env_shf_pwd}] is an empty string" do
       stub_const('ENV', {env_shf_email => admin_email, env_shf_pwd => ''})
 
-      expect{Rails.application.load_seed}.to raise_exception SEED_ERROR
+      expect { Rails.application.load_seed }.to raise_exception SEED_ERROR
     end
   end
 
- end
+end


### PR DESCRIPTION
PT Story: **Remove admin login from seed file**
https://www.pivotaltracker.com/story/show/135469409

Changes proposed in this pull request:
**IF Rails.environment.production?**
1.  load the admin's email address from `ENV['SHF_ADMIN_EMAIL']`
2. load the admin's password from `ENV['SHF_ADMIN_PWD']`
3. raise an error if either of those environment variables can't be found _or_ if they are set to empty strings

Else load the admin.email and admin.password from the seeds.rb file  just as we have been doing

(FYI: setting ENV variables on heroku: https://devcenter.heroku.com/articles/config-vars 
  _You set the heroku config vars, and then your app sees them as ENV vars._
)

Ready for review:
@thesuss @diraulo 
