### PR TITLE
fix: Accept 

### DIFF
--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -92,17 +92,18 @@ class MembershipApplicationsController < ApplicationController
   def accept_application
 
     @membership_application.user.is_member = true
+    @membership_application.user.save
+
     unless (company = Company.find_by_company_number(@membership_application.company_number))
       company = Company.create!(company_number: @membership_application.company_number,
                                 email: @membership_application.contact_email)
     end
 
-    @membership_application.company = company
-    @membership_application.save!
+    @membership_application.update(company:company)
+    @membership_application.save
 
     helpers.flash_message(:notice,
                           'Var god ange medlemsnummer och spara.')
-
   end
 
 

--- a/features/approve-member.feature
+++ b/features/approve-member.feature
@@ -62,6 +62,18 @@ Feature: As an admin
     And I should see "902"
     And I am on the "all companies" page
     And I should see "No More Snarky Barky"
+    And I am Logged out
+    And I am on the "landing" page
+    And I should see "No More Snarky Barky"
+    And I should see "Rehab"
+    And I am logged in as "anna@nosnarkybarky.se"
+    And I am on the "landing" page
+    Then I should see "Hantera företag"
+    And I am on the "edit my application" page for "anna@nosnarkybarky.se"
+    Then I should see "Medlemsnummer"
+    And I should see "902"
+    And I am on the "edit my company" page for "anna@nosnarkybarky.se"
+    Then I should see "No More Snarky Barky"
 
   Scenario: Admin approves, but then changes it to Rejected
     Given I am on "Emma" application page
@@ -84,6 +96,6 @@ Feature: As an admin
     And I am logged in as "emma@happymutts.se"
     And I navigate to the edit page for "Emma"
     Then I should be on "Edit My Application" page
-    And I should not see "MMedlemsnummer"
+    And I should not see "Medlemsnummer"
 
 


### PR DESCRIPTION
PT Story: Accept a membership: user.is_member is not correct and company is not associated with the membership application
https://www.pivotaltracker.com/story/show/136073447

In reviewing and testing PR 75, I discovered that when an admin accepts a membership application, the user was not always set to 'is member' and the company was not being correctly associated with the membership_application.
The associated objects (company, user) must be explicitly saved when the membership was updated.

Changes proposed in this pull request:
1.  update a scenario to ensure we are testing and verifying that a user is set to 'is_member' and that the company is being correctly associated with the membership_application
2.  explicitly save the user after is_membership is changed; explicitly save the membership application after associating the company
3.  Fix spelling error in scenario "MMedlemsnummer"

Ready for review:
@thesuss 
