### PR TITLE
Solves the åäö problem when running the rake import task

### DIFF
--- a/lib/tasks/shf.rake
+++ b/lib/tasks/shf.rake
@@ -42,7 +42,7 @@ namespace :shf do
         headers_in_file: true,
         remove_empty_values: false,
         remove_zero_values: false,
-        file_encoding: 'ISO-8859-1',
+        file_encoding: 'UTF-8',
         key_mapping: headers_to_columns_mapping
     }
 

--- a/spec/fixtures/test-import-files/member-companies-sanitized-small.csv
+++ b/spec/fixtures/test-import-files/member-companies-sanitized-small.csv
@@ -1,4 +1,4 @@
-membership_number;email;company_number;first_name;last_name;company_name;street;post_code;stad;region;phone_number;website;category;category
+membership_number;email;company_number;first_name;last_name;company_name;street;post_code;stad;region;phone_number;website;category1;category2
 3;info@doggies.com;9697391424;Emma;Svensson;Hundlycka;Hagalundsvägen 9;632 30;Eskilstuna;Södermanland;;http://www.hundlycka.com;Träning;
 38;info@gogzz.se;9697241538;Anna;Larsson;Hundkurser för Alla;Fagerängsgatan 11;521 41;Falköping;Västra Götaland;;http://www.hundkurserforalla.se;Träning;
 43;info@hund.se;9697668466;Hans;Knutsson;Heart of gold Hundcenter;Arremdevägen 9, 4 tr;175 94;Järfälla;Stockholm;;http://www.heartofgold.se;Träning;Psykologi


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/135489351
I set it as done as it was not important, but now while looking at something else I found the problem. 

Changes proposed in this pull request:
1. Set csv_options to utf-8
2. Make sure the csv is saved as utf-8
3. amended the csv from category;category to category1;category2

Screenshots (Optional):
<img width="1265" alt="skarmavbild 2016-12-14 kl 20 30 37" src="https://cloud.githubusercontent.com/assets/7266909/21197588/46a9f376-c23c-11e6-970b-7b4ec5ebc1e0.png">


Ready for review:
@AgileVentures/shf-project-team 

