### PR TITLE
Import connect membership app and companies

### DIFF
--- a/lib/tasks/shf.rake
+++ b/lib/tasks/shf.rake
@@ -3,6 +3,8 @@ require 'active_support/logger'
 
 namespace :shf do
 
+  ACCEPTED_STATUS = 'Godkänd'
+
   desc 'recreate db (current env): drop, setup, migrate, seed the db.'
   task :db_recreate => [:environment] do
     tasks = ['db:drop', 'db:setup', 'db:migrate', 'db:seed']
@@ -18,7 +20,6 @@ namespace :shf do
     usage = 'rake shf:import_membership_apps["./spec/fixtures/test-import-files/member-companies-sanitized-small.csv"]'
 
     DEFAULT_PASSWORD = 'whatever'
-    ACCEPTED_STATUS = 'Godkänd'
 
     headers_to_columns_mapping = {
         membership_number: :membership_number,
@@ -116,7 +117,8 @@ namespace :shf do
                                                  contact_email: user.email,
                                                  status: ACCEPTED_STATUS,
                                                  membership_number: row[:membership_number],
-                                                 user: user
+                                                 user: user,
+                                                 company: company
       )
 
       puts_created('Membership application', " org number: #{row[:company_number]}, status: #{row[:status]}")
@@ -135,8 +137,6 @@ namespace :shf do
     end
 
   end
-
-
 
 
   def find_or_create_category(category_name, membership)

--- a/lib/tasks/shf.rake
+++ b/lib/tasks/shf.rake
@@ -12,10 +12,14 @@ namespace :shf do
   end
 
 
+  # This will associate ALL membership_applications
+  #   where status == '#{ACCEPTED_STATUS}' in the DB with their companies.
+  # It will set the membership_application.company_id
+  # It will OVERWRITE the existing membership_application.company_id
+  # Use this in case you don't want to import again and you need to
+  # fix the imported data.
   desc 'connect membership to company'
-  task :connect_membership_to_company => [:environment] do |t|
-
-    usage = "rake shf:connect_membership_to_company\n  This will associate ALL membership_applications where status == '#{ACCEPTED_STATUS}' in the DB with their companies.\n It will set the membership_application.company_id ."
+  task :connect_membership_to_company => [:environment] do
 
     logfile = 'log/import.log'
     start_time = Time.now


### PR DESCRIPTION
PT Story: **Import data: rake task is not connecting companies to membership_applications** 
https://www.pivotaltracker.com/story/show/136134121

Changes proposed in this pull request:
1. fixed import task:  was not associating a membership_application with the company
2. added another task that will just go through all membership_applications and look up their company by company_number, and associate them (sets company_id = the id of the company found by company_number

Ready for review:
@thesuss 
