### PR TITLE
Switch language; start of I18n

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'devise'
 gem 'pundit'
 gem 'paperclip', '~> 5.0.0'
 
+gem 'routing-filter'   # for handling locale filters around routes
+
 group :development, :test do
   gem 'rspec-rails'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,9 @@ GEM
       ffi (>= 0.5.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
+    routing-filter (0.6.0)
+      actionpack (>= 4.2, < 5.1)
+      activesupport (>= 4.2, < 5.1)
     rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -356,6 +359,7 @@ DEPENDENCIES
   pundit-matchers
   rails (~> 5.0.0, >= 5.0.0.1)
   rake
+  routing-filter
   rspec-rails
   sass-rails (~> 5.0)
   shoulda-matchers

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
     I18n.locale = locale.to_s
   end
 
-  def default_url_options(options = {})
+  def default_url_options
     {locale: I18n.locale}
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,14 +2,26 @@ class ApplicationController < ActionController::Base
   include Pundit
 
   protect_from_forgery with: :exception
+  before_action :set_locale
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
 
   def index
 
   end
 
   private
+
+  def set_locale
+    locale = I18n.default_locale
+    locale = params[:locale] if params[:locale].present?
+    I18n.locale = locale.to_s
+  end
+
+  def default_url_options(options = {})
+    {locale: I18n.locale}
+  end
 
   def after_sign_in_path_for(resource)
     if resource.admin?

--- a/app/views/application/_bottom.html.haml
+++ b/app/views/application/_bottom.html.haml
@@ -1,7 +1,7 @@
 %footer#colophon.container-fluid.site-footer{role: 'contentinfo'}
   .container-fluid.site-info
     .container
-      © 2017 Theme by Theme Feeder. All Rights Reserved.
+      = t('theme_copyright')
   .footer-social
     %a.facebook{href: 'http://www.facebook.com/sverigeshundforetagare', target: '_blank'}
       = icon('facebook')

--- a/app/views/application/_navigation.html.haml
+++ b/app/views/application/_navigation.html.haml
@@ -67,3 +67,5 @@
               = render 'navigation_admin'
 
         = render 'social_nav'
+
+        = render 'select_language'

--- a/app/views/application/_select_language.html.haml
+++ b/app/views/application/_select_language.html.haml
@@ -1,0 +1,4 @@
+- if locale == :sv
+  = link_to 'English flag', {locale: :en}, class: 'language.en', id: 'change-lang-to-english'
+- else
+  = link_to 'Swedish flag', {locale: :sv}, class: 'language.sv', id: 'change-lang-to-svenska'

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,14 +18,17 @@ Bundler.require(*Rails.groups)
 module SHFProject
   class Application < Rails::Application
     # Disable generation of helpers, javascripts, css, and view, helper, routing and controller specs
-config.generators do |generate|
-  generate.helper false
-  generate.assets false
-  generate.view_specs false
-  generate.helper_specs false
-  generate.routing_specs false
-  generate.controller_specs false
-end
+    config.generators do |generate|
+      generate.helper false
+      generate.assets false
+      generate.view_specs false
+      generate.helper_specs false
+      generate.routing_specs false
+      generate.controller_specs false
+    end
+
+    config.i18n.default_locale = :sv
+    config.i18n.fallbacks = true
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/initializers/routing_filter.rb
+++ b/config/initializers/routing_filter.rb
@@ -1,0 +1,2 @@
+# Do not include default locale in generated URLs
+RoutingFilter::Locale.include_default_locale = false

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,7 +12,7 @@ en:
 
   apply_for_membership: 'Apply for membership'
 
-  theme_copyright: "2017 Theme by Theme Feeder. All rights reserved."
+  theme_copyright: "© 2017 Theme by Theme Feeder. All Rights Reserved."
 
   memberships:
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,23 +1,242 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
+---
 en:
-  hello: "Hello world"
+
+  title: "SWEDEN'S DOG-EMPLOYED"
+
+  home: 'Home'
+  about: 'About'
+  more: 'More'
+
+  show_in_english: "In English"
+  show_in_swedish: "I Svenska"
+
+  apply_for_membership: 'Apply for membership'
+
+  theme_copyright: "2017 Theme by Theme Feeder. All rights reserved."
+
+  memberships:
+    new:
+      title: 'Apply for a Membership'
+      company_name: 'Company Name'
+      company_number: 'Company Number'
+      contact_person: 'Contact Person'
+      company_email: 'Company Email'
+      phone_number: 'Phone Number'
+      submit: 'Submit'
+    create:
+      submit_acknowledgement: 'Thank You. Your membership application has been submitted.'
+
+  activerecord:
+    models:
+      membership:
+        one: Membership
+        other: Memberships
+
+    errors:
+       messages:
+         record_invalid: "Validation failed: %{errors}"
+         restrict_dependent_destroy:
+           has_one: "Cannot delete record because a dependent %{record} exists"
+           has_many: "Cannot delete record because dependent %{record} exist"
+  date:
+    abbr_day_names:
+    - Sun
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    abbr_month_names:
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - May
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Oct
+    - Nov
+    - Dec
+    day_names:
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday
+    formats:
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: about 1 hour
+        other: about %{count} hours
+      about_x_months:
+        one: about 1 month
+        other: about %{count} months
+      about_x_years:
+        one: about 1 year
+        other: about %{count} years
+      almost_x_years:
+        one: almost 1 year
+        other: almost %{count} years
+      half_a_minute: half a minute
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
+      less_than_x_seconds:
+        one: less than 1 second
+        other: less than %{count} seconds
+      over_x_years:
+        one: over 1 year
+        other: over %{count} years
+      x_days:
+        one: 1 day
+        other: "%{count} days"
+      x_minutes:
+        one: 1 minute
+        other: "%{count} minutes"
+      x_months:
+        one: 1 month
+        other: "%{count} months"
+      x_years:
+        one: 1 year
+        other: "%{count} years"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
+    prompts:
+      day: Day
+      hour: Hour
+      minute: Minute
+      month: Month
+      second: Seconds
+      year: Year
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: must be accepted
+      blank: can't be blank
+      present: must be blank
+      confirmation: doesn't match %{attribute}
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: "Validation failed: %{errors}"
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      required: must exist
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is 1 character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is 1 character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be 1 character)
+        other: is the wrong length (should be %{count} characters)
+      other_than: must be other than %{count}
+    template:
+      body: 'There were problems with the following fields:'
+      header:
+        one: 1 error prohibited this %{model} from being saved
+        other: "%{count} errors prohibited this %{model} from being saved"
+  helpers:
+    select:
+      prompt: Please select
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: pm

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,30 @@ en:
         one: Membership
         other: Memberships
 
+      attributes:
+        membership_application:
+          company_number: Company number
+          first_name: First name
+          last_name: Last name
+          contact_email: Email
+          status: Status
+          phone_number: Phone Number
+
+        company:
+          company_number: Company number
+          name: Name
+          phone_number: Phone Number
+          email: Email
+          street: Street
+          post_code: Post code
+          city: City
+          region: Region
+          website: Website
+
+        business_category:
+          name: Name
+          description: Description
+
     errors:
        messages:
          record_invalid: "Validation failed: %{errors}"
@@ -171,7 +195,7 @@ en:
     template:
       body: 'There were problems with the following fields:'
       header:
-        one: 1 error prohibited this %{model} from being saved
+        one: 1 error kept this %{model} from being saved
         other: "%{count} errors prohibited this %{model} from being saved"
   helpers:
     select:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,14 +1,14 @@
 ---
 en:
 
-  title: "SWEDEN'S DOG-EMPLOYED"
+  title: "SWEDEN'S ETHICAL DOG COMPANIES"
 
   home: 'Home'
   about: 'About'
   more: 'More'
 
   show_in_english: "In English"
-  show_in_swedish: "I Svenska"
+  show_in_swedish: "På Svenska"
 
   apply_for_membership: 'Apply for membership'
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -32,6 +32,30 @@ sv:
         one: Medlemskap
         other: Medlemskap
 
+      attributes:
+        membership_application:
+          company_number: Company number
+          first_name: First name
+          last_name: Last name
+          contact_email: Contact email
+          status: Status
+          phone_number: Phone Number
+
+        company:
+          company_number: Company number
+          name: Name
+          phone_number: Phone Number
+          email: Email
+          street: Street
+          post_code: Post code
+          city: City
+          region: Region
+          website: Website
+
+        business_category:
+          name: Name
+          description: Description
+
     errors:
       messages:
         record_invalid: 'Ett fel uppstod: %{errors}'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -12,7 +12,7 @@ sv:
 
   apply_for_membership: 'Ansök om medlemskap'
 
-  theme_copyright: "2017 Tema av Theme Feeder. Alla rättigheter förbehållna."
+  theme_copyright: "© 2017 Tema av Theme Feeder. Alla rättigheter förbehållna."
 
   memberships:
     new:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,14 +1,14 @@
 ---
 sv:
 
-  title: 'OM SVERIGES HUNDFÖRETAGARE'
+  title: 'Medlemmar i Sveriges Hundföretagare'
 
   home: 'Hem'
   about: 'Om'
   more: 'Mer'
 
   show_in_english: "In English"
-  show_in_swedish: "I Svenska"
+  show_in_swedish: "På Svenska"
 
   apply_for_membership: 'Ansök om medlemskap'
 
@@ -20,11 +20,11 @@ sv:
       company_name: 'Företagsnamn'
       company_number: 'Organisationsnummer'
       contact_person: 'Kontaktperson'
-      company_email: 'Företagets e'
+      company_email: 'Företagets e-postadress'
       phone_number: 'Telefonnummer'
       submit: 'Skicka'
     create:
-      submit_acknowledgement: 'Tack, Din ansökan har lämnats in'
+      submit_acknowledgement: 'Tack, Din ansökan har skickats.'
 
   activerecord:
     models:
@@ -144,25 +144,25 @@ sv:
         one: en minut
         other: "%{count} minuter"
       x_months:
-        one: 1 month
-        other: "%{count} months"
+        one: en månad
+        other: "%{count} månader"
       x_years:
-        one: 1 År
-        other: "%{count} År"
+        one: ett år
+        other: "%{count} år"
       x_seconds:
         one: en sekund
         other: "%{count} sekunder"
     prompts:
-      day: Dag
-      hour: Timme
-      minute: Minut
-      month: Månad
-      second: Sekund
-      year: År
+      day: dag
+      hour: timme
+      minute: minut
+      month: månad
+      second: sekund
+      year: år
   errors:
     format: "%{attribute} %{message}"
     messages:
-      accepted: måste vara accepterad
+      accepted: måste accepteras
       blank: måste anges
       present: får inte anges
       confirmation: stämmer inte överens
@@ -176,7 +176,7 @@ sv:
       invalid: har fel format
       less_than: måste vara mindre än %{count}
       less_than_or_equal_to: måste vara mindre än eller lika med %{count}
-      model_invalid: "Validation failed: %{errors}"
+      model_invalid: "Validering lyckades inte: %{errors}"
       not_a_number: är inte ett nummer
       not_an_integer: måste vara ett heltal
       odd: måste vara udda
@@ -195,8 +195,8 @@ sv:
     template:
       body: 'Det var problem med följande fält:'
       header:
-        one: Ett fel förhindrade denna %{model} från att sparas
-        other: "%{count} fel förhindrade denna %{model} från att sparas"
+        one: Ett fel förhindrade %{model} från att sparas
+        other: "%{count} fel förhindrade %{model} från att sparas"
   helpers:
     select:
       prompt: Välj

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,0 +1,242 @@
+---
+sv:
+
+  title: 'OM SVERIGES HUNDFÖRETAGARE'
+
+  home: 'Hem'
+  about: 'Om'
+  more: 'Mer'
+
+  show_in_english: "In English"
+  show_in_swedish: "I Svenska"
+
+  apply_for_membership: 'Ansök om medlemskap'
+
+  theme_copyright: "2017 Tema av Theme Feeder. Alla rättigheter förbehållna."
+
+  memberships:
+    new:
+      title: 'Ansök om medlemskap'
+      company_name: 'Företagsnamn'
+      company_number: 'Organisationsnummer'
+      contact_person: 'Kontaktperson'
+      company_email: 'Företagets e'
+      phone_number: 'Telefonnummer'
+      submit: 'Skicka'
+    create:
+      submit_acknowledgement: 'Tack, Din ansökan har lämnats in'
+
+  activerecord:
+    models:
+      membership:
+        one: Medlemskap
+        other: Medlemskap
+
+    errors:
+      messages:
+        record_invalid: 'Ett fel uppstod: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Kan inte ta bort post då beroende %{record} finns
+          has_many: Kan inte ta bort poster då beroende %{record} finns
+  date:
+    abbr_day_names:
+    - sön
+    - mån
+    - tis
+    - ons
+    - tor
+    - fre
+    - lör
+    abbr_month_names:
+    - jan
+    - feb
+    - mar
+    - apr
+    - maj
+    - jun
+    - jul
+    - aug
+    - sep
+    - okt
+    - nov
+    - dec
+    day_names:
+    - söndag
+    - måndag
+    - tisdag
+    - onsdag
+    - torsdag
+    - fredag
+    - lördag
+    formats:
+      default: "%Y-%m-%d"
+      long: "%e %B %Y"
+      short: "%e %b"
+    month_names:
+    - januari
+    - februari
+    - mars
+    - april
+    - maj
+    - juni
+    - juli
+    - augusti
+    - september
+    - oktober
+    - november
+    - december
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: ungefär en timme
+        other: ungefär %{count} timmar
+      about_x_months:
+        one: ungefär en månad
+        other: ungefär %{count} månader
+      about_x_years:
+        one: ungefär ett år
+        other: ungefär %{count} år
+      almost_x_years:
+        one: nästan ett år
+        other: nästan %{count} år
+      half_a_minute: en halv minut
+      less_than_x_minutes:
+        one: mindre än en minut
+        other: mindre än %{count} minuter
+      less_than_x_seconds:
+        one: mindre än en sekund
+        other: mindre än %{count} sekunder
+      over_x_years:
+        one: mer än ett år
+        other: mer än %{count} år
+      x_days:
+        one: en dag
+        other: "%{count} dagar"
+      x_minutes:
+        one: en minut
+        other: "%{count} minuter"
+      x_months:
+        one: 1 month
+        other: "%{count} months"
+      x_years:
+        one: 1 År
+        other: "%{count} År"
+      x_seconds:
+        one: en sekund
+        other: "%{count} sekunder"
+    prompts:
+      day: Dag
+      hour: Timme
+      minute: Minut
+      month: Månad
+      second: Sekund
+      year: År
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: måste vara accepterad
+      blank: måste anges
+      present: får inte anges
+      confirmation: stämmer inte överens
+      empty: får ej vara tom
+      equal_to: måste vara samma som
+      even: måste vara jämnt
+      exclusion: är reserverat
+      greater_than: måste vara större än %{count}
+      greater_than_or_equal_to: måste vara större än eller lika med %{count}
+      inclusion: finns inte i listan
+      invalid: har fel format
+      less_than: måste vara mindre än %{count}
+      less_than_or_equal_to: måste vara mindre än eller lika med %{count}
+      model_invalid: "Validation failed: %{errors}"
+      not_a_number: är inte ett nummer
+      not_an_integer: måste vara ett heltal
+      odd: måste vara udda
+      required: must exist
+      taken: används redan
+      too_long:
+        one: är för lång (max är ett tecken)
+        other: är för lång (maximum är %{count} tecken)
+      too_short:
+        one: är för kort (minimum är ett tecken)
+        other: är för kort (minimum är %{count} tecken)
+      wrong_length:
+        one: är fel längd (ska vara ett tecken)
+        other: har fel längd (ska vara %{count} tecken)
+      other_than: måste vara annat än %{count}
+    template:
+      body: 'Det var problem med följande fält:'
+      header:
+        one: Ett fel förhindrade denna %{model} från att sparas
+        other: "%{count} fel förhindrade denna %{model} från att sparas"
+  helpers:
+    select:
+      prompt: Välj
+    submit:
+      create: Skapa %{model}
+      submit: Spara %{model}
+      update: Ändra %{model}
+  number:
+    currency:
+      format:
+        delimiter: ''
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: kr
+    format:
+      delimiter: ''
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Miljard
+          million: Miljon
+          quadrillion: Biljard
+          thousand: Tusen
+          trillion: Biljon
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " och "
+      two_words_connector: " och "
+      words_connector: ", "
+  time:
+    am: ''
+    formats:
+      default: "%a, %e %b %Y %H:%M:%S %z"
+      long: "%e %B %Y %H:%M"
+      short: "%e %b %H:%M"
+    pm: ''

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  filter :locale
+
   devise_for :users
 
   as :user do

--- a/features/admin_creates_company.feature
+++ b/features/admin_creates_company.feature
@@ -69,18 +69,18 @@ Feature: As an admin
     Given I am logged in as "admin@shf.se"
     When I am on the "create a new company" page
     And I fill in the form with data :
-      | Företagsnamn | Org nr       | Email   | Telefon | Gata     | Post nr     | Ort   | Verksamhetslän | Webbsida  |
+      | Företagsnamn | Org nr       | Email   | Telefon | Gata     | Post nr     | Ort    | Verksamhetslän | Webbsida  |
       | <name>       | <org_number> | <email> | <phone> | <street> | <post_code> | <city> | <region>       | <website> |
     When I click on "Submit"
     Then I should see <error>
     And I should see "Ett eller flera problem hindrade företaget från att skapas."
 
     Scenarios:
-      | name        | org_number | phone      | street         | post_code | city   | region    | email                | website                   | error                                                                 |
-      | Happy Mutts | 00         | 0706898525 | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@gladajyckar.se | http://www.gladajyckar.se | "Company number is the wrong length (should be 10 characters)"        |
-      | Happy Mutts | 5562252998 |            | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kickiimmi.nu         | http://www.gladajyckar.se | "Email is invalid"                                                    |
-      | Happy Mutts | 5562252998 |            | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@imminu         | http://www.gladajyckar.se | "Email is invalid"                                                    |
-      | Happy Mutts | 5560360793 | 0706898525 | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@imminu.se      | http://www.gladajyckar.se | "Detta företag (org nr) finns redan i systemet." |
+      | name        | org_number | phone      | street         | post_code | city   | region    | email                | website                   | error                                                     |
+      | Happy Mutts | 00         | 0706898525 | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@gladajyckar.se | http://www.gladajyckar.se | t("errors.messages.wrong_length", count: 10), locale: :sv |
+      | Happy Mutts | 5562252998 |            | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kickiimmi.nu         | http://www.gladajyckar.se | t("errors.messages.invalid")                              |
+      | Happy Mutts | 5562252998 |            | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@imminu         | http://www.gladajyckar.se | t("errors.messages.invalid")                              |
+      | Happy Mutts | 5560360793 | 0706898525 | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@imminu.se      | http://www.gladajyckar.se | "Detta företag (org nr) finns redan i systemet."          |
 
 
   Scenario: Admin edits a company
@@ -99,17 +99,32 @@ Feature: As an admin
     Given I am logged in as "admin@shf.se"
     And I am on the edit company page for "5560360793"
     And I fill in the form with data :
-      | Företagsnamn | Org nr       | Email   | Telefon | Gata     | Post nr     | Ort   | Verksamhetslän | Webbsida  |
+      | Företagsnamn | Org nr       | Email   | Telefon | Gata     | Post nr     | Ort    | Verksamhetslän | Webbsida  |
+      | <name>       | <org_number> | <email> | <phone> | <street> | <post_code> | <city> | <region>       | <website> |
+    When I click on "Submit"
+    Then I should see translated error <model_attribute> <error>
+    And I should see "Ett problem förhindrade uppdatering av företaget."
+
+    Scenarios:
+      | name        | org_number | phone | street         | post_code | city   | region    | email        | website                   | model_attribute                              | error                   |
+      | Happy Mutts | 5560360793 |       | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kickiimmi.nu | http://www.gladajyckar.se | activerecord.models.attributes.company.email | errors.messages.invalid |
+      | Happy Mutts | 5560360793 |       | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@imminu | http://www.gladajyckar.se | activerecord.models.attributes.company.email | errors.messages.invalid |
+
+
+  Scenario Outline: Admin edits a company: company number is wrong length
+    Given I am logged in as "admin@shf.se"
+    And I am on the edit company page for "5560360793"
+    And I fill in the form with data :
+      | Företagsnamn | Org nr       | Email   | Telefon | Gata     | Post nr     | Ort    | Verksamhetslän | Webbsida  |
       | <name>       | <org_number> | <email> | <phone> | <street> | <post_code> | <city> | <region>       | <website> |
     When I click on "Submit"
     Then I should see <error>
     And I should see "Ett problem förhindrade uppdatering av företaget."
 
     Scenarios:
-      | name        | org_number | phone      | street         | post_code | city   | region    | email                | website                   | error                                                          |
-      | Happy Mutts | 00         | 0706898525 | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@gladajyckar.se | http://www.gladajyckar.se | "Company number is the wrong length (should be 10 characters)" |
-      | Happy Mutts | 5560360793 |            | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kickiimmi.nu         | http://www.gladajyckar.se | "Email is invalid"                                             |
-      | Happy Mutts | 5560360793 |            | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@imminu         | http://www.gladajyckar.se | "Email is invalid"                                             |
+      | name        | org_number | phone      | street         | post_code | city   | region    | email                | website                   | error                                                     |
+      | Happy Mutts | 00         | 0706898525 | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@gladajyckar.se | http://www.gladajyckar.se | t("errors.messages.wrong_length", count: 10), locale: :sv |
+
 
   Scenario: Website path is incomplete (does not include http://)
     Given I am logged in as "admin@shf.se"
@@ -125,7 +140,7 @@ Feature: As an admin
     Given I am logged in as "admin@shf.se"
     And I am on the edit company page for "5560360793"
     When I fill in the form with data :
-      | Webbsida              |
+      | Webbsida                     |
       | http://www.snarkybarkbark.se |
     And I click on "Submit"
     Then I should see "Företaget har uppdaterats."

--- a/features/create_business_category.feature
+++ b/features/create_business_category.feature
@@ -41,8 +41,8 @@ Feature: As an admin
 
     Scenarios:
       | category_name | category_description | error                 |
-      |               |                      | "Name can't be blank" |
-      |               | some description     | "Name can't be blank" |
+      |               |                      | t("errors.messages.blank") |
+      |               | some description     | t("errors.messages.blank") |
 
   Scenario: Indicate required field
     Given I am on the "business categories" page

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -85,14 +85,27 @@ Feature: As a user
       | Förnamn  | Efternamn | Org nr     | E-post    | Telefon |
       | <f_name> | <l_name>  | <c_number> | <c_email> | <phone> |
     When I click on "Submit"
-    Then I should see <error>
+    Then I should see translated error <model_attribute> <error>
 
     Scenarios:
-      | f_name | c_number   | l_name    | c_email       | phone      | error                                                       |
-      | Kicki  | 00         | Andersson | kicki@immi.nu | 0706898525 | "Company number 00 är inte ett svenskt organisationsnummer" |
-      | Kicki  |            | Andersson | kicki@immi.nu | 0706898525 | "Company number can't be blank"                             |
-      | Kicki  | 5562252998 |           | kicki@immi.nu | 0706898525 | "Last name can't be blank"                                  |
-      | Kicki  | 5562252998 | Andersson |               | 0706898525 | "Contact email can't be blank"                                      |
-      |        | 5562252998 | Andersson | kicki@immi.nu | 0706898525 | "First name can't be blank"                                 |
-      | Kicki  | 5562252998 | Andersson | kicki@imminu  | 0706898525 | "Contact email is invalid"                                          |
-      | Kicki  | 5562252998 | Andersson | kickiimmi.nu  | 0706898525 | "Contact email is invalid"                                          |
+      | f_name | c_number   | l_name    | c_email       | phone      | model_attribute                                                      | error                   |
+      | Kicki  |            | Andersson | kicki@immi.nu | 0706898525 | activerecord.models.attributes.membership_application.company_number | errors.messages.blank   |
+      | Kicki  | 5562252998 |           | kicki@immi.nu | 0706898525 | activerecord.models.attributes.membership_application.last_name      | errors.messages.blank   |
+      | Kicki  | 5562252998 | Andersson |               | 0706898525 | activerecord.models.attributes.membership_application.contact_email  | errors.messages.blank   |
+      |        | 5562252998 | Andersson | kicki@immi.nu | 0706898525 | activerecord.models.attributes.membership_application.first_name     | errors.messages.blank   |
+      | Kicki  | 5562252998 | Andersson | kicki@imminu  | 0706898525 | activerecord.models.attributes.membership_application.contact_email  | errors.messages.invalid |
+      | Kicki  | 5562252998 | Andersson | kickiimmi.nu  | 0706898525 | activerecord.models.attributes.membership_application.contact_email  | errors.messages.invalid |
+
+
+  Scenario Outline: Apply for membership: company number wrong length
+    Given I am on the "landing" page
+    And I click on "Ansök om medlemsskap"
+    When I fill in the form with data :
+      | Förnamn  | Efternamn | Org nr     | E-post    | Telefon |
+      | <f_name> | <l_name>  | <c_number> | <c_email> | <phone> |
+    When I click on "Submit"
+    Then I should see <error>
+# Company number har fel längd (ska vara 10 tecken) Company number 00 är inte ett svenskt organisationsnummer
+    Scenarios:
+      | f_name | c_number | l_name    | c_email       | phone      | error                                                     |
+      | Kicki  | 00       | Andersson | kicki@immi.nu | 0706898525 | t("errors.messages.wrong_length", count: 10), locale: :sv |

--- a/features/edit_business_category.feature
+++ b/features/edit_business_category.feature
@@ -37,8 +37,7 @@ Feature: As an admin
     Then I should see "Redigerar: dog crooning"
     And I fill in "Category Name" with ""
     And I click on "Save"
-    Then I should see "Name can't be blank"
-
+    Then I should see translated error activerecord.models.attributes.business_category.name errors.messages.blank
 
   Scenario: A non-admin user cannot edit business categories
     Given I am logged in as "applicant_1@random.com"

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -23,40 +23,40 @@ Feature: As a registered user
     When I fill in "Email" with "emma@random.com"
     And I fill in "Password" with "password"
     And I click on "Logga in" button
-    Then I should see "Signed in successfully"
+    Then I should see t("devise.sessions.signed_in")
 
   Scenario: Not proper e-mail
     Given I am on the "login" page
     When I fill in "Email" with "emmarandom.com"
     And I fill in "Password" with "password"
     And I click on "Logga in" button
-    Then I should see "Invalid Email or password"
+    Then I should see t("devise.failure.invalid")
 
   Scenario: No input of email
     Given I am on the "login" page
     When I leave the "Password" field empty
     And I click on "Logga in" button
-    Then I should see "Invalid Email or password"
+    Then I should see t("devise.failure.invalid")
 
   Scenario: No input of password
     Given I am on the "login" page
     When I leave the "Password" field empty
     And I click on "Logga in" button
-    Then I should see "Invalid Email or password"
+    Then I should see t("devise.failure.invalid")
 
   Scenario: Not registered user
     Given I am on the "login" page
     When I fill in "Email" with "anna@random.com"
     And I fill in "Password" with "password"
     And I click on "Logga in" button
-    Then I should see "Invalid Email or password"
+    Then I should see t("devise.failure.invalid")
 
   Scenario: Not accessing protected page
     Given I am on the "login" page
     When I fill in "Email" with "anna@random.com"
     And I fill in "Password" with "password"
     And I click on "Logga in" button
-    Then I should see "Invalid Email or password"
+    Then I should see t("devise.failure.invalid")
     When I fail to visit the "applications index" page
     Then I should see "Du har inte behörighet att göra detta."
     And I should be on "landing" page
@@ -69,7 +69,7 @@ Feature: As a registered user
     When I fill in "Email" with "arne@random.com"
     And I fill in "Password" with "password"
     And I click on "Logga in" button
-    Then I should see "Signed in successfully"
+    Then I should see t("devise.sessions.signed_in")
     And I should see "Admin:"
     And I should not see "Välkommen"
     And I should not see "Hej, kul att du är intresserad"

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -12,12 +12,28 @@ And(/^I should not see "([^"]*)"$/) do |content|
   expect(page).not_to have_content content
 end
 
+And(/^I should see t\("([^"]*)"\)$/) do |content|
+  expect(page).to have_content i18n_content(content)
+end
+
 And(/^I should see t\("([^"]*)", locale: :(.*)\)$/) do |content, l|
-  expect(page).to have_content I18n.t("#{content}", locale: l.to_sym)
+  expect(page).to have_content i18n_content(content, l)
 end
 
 And(/^I should not see t\("([^"]*)", locale: :(.*)\)$/) do |content, l|
-  expect(page).not_to have_content I18n.t("#{content}", locale: l.to_sym)
+  expect(page).not_to have_content i18n_content(content, l)
+end
+
+And(/^I should see t\("([^"]*)"\), locale: :sv$/) do |content|
+  expect(page).to have_content i18n_content(content)
+end
+
+And(/^I should see t\("([^"]*)", ([^:]*): ([^)]*)\), locale: :(.*)\)$/) do |content, key, value, l|
+  expect(page).to have_content I18n.t("#{content}", key.to_sym => value, locale: l.to_sym)
+end
+
+And(/^I should see t\("([^"]*)", ([^:]*): (\d+)\), locale: :(.*)$/) do |content, key, value, locale|
+  expect(page).to have_content I18n.t("#{content}", key.to_sym => value, locale: locale.to_sym)
 end
 
 And(/^I should not see button "([^"]*)"$/) do |button|
@@ -88,3 +104,12 @@ end
 And(/^I should be on the applications page$/) do
   expect(current_path).to eq membership_applications_path
 end
+
+Then(/^I should see translated error (.*) (.*)$/) do |model_attribute, error|
+  expect(page).to have_content("#{i18n_content(model_attribute)} #{i18n_content(error)}")
+end
+
+def i18n_content(content, locale='sv')
+  I18n.t(content, locale: locale.to_sym)
+end
+

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -12,6 +12,14 @@ And(/^I should not see "([^"]*)"$/) do |content|
   expect(page).not_to have_content content
 end
 
+And(/^I should see t\("([^"]*)", locale: :(.*)\)$/) do |content, l|
+  expect(page).to have_content I18n.t("#{content}", locale: l.to_sym)
+end
+
+And(/^I should not see t\("([^"]*)", locale: :(.*)\)$/) do |content, l|
+  expect(page).not_to have_content I18n.t("#{content}", locale: l.to_sym)
+end
+
 And(/^I should not see button "([^"]*)"$/) do |button|
   expect(page).not_to have_button button
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -2,6 +2,10 @@ And(/^I click on "([^"]*)"$/) do |element|
   click_link_or_button element
 end
 
+And(/^I click on t\("([^"]*)"\)$/) do |element|
+  click_link_or_button I18n.t("#{element}")
+end
+
 And(/^I fill in "([^"]*)" with "([^"]*)"$/) do |field, value|
   fill_in field, with: value
 end

--- a/features/view-site-in-lang-i18n-l10n.feature
+++ b/features/view-site-in-lang-i18n-l10n.feature
@@ -1,0 +1,45 @@
+Feature: As a visitor
+  In order to view the site in my language
+  I need to be able choose either Swedish or English for the site
+
+  PT: https://www.pivotaltracker.com/story/show/133316647
+
+  Background:
+    Given I am Logged out
+
+
+  Scenario: Default language is Swedish
+    Given I am on the "all companies" page
+    Then I should see "Hitta H-märkt företag"
+    And I should see "Kategori"
+    And I should see "Namn"
+    And I should see "Län"
+    And I should not see "Swedish flag"
+    And I should see "English flag"
+    And I should see t("theme_copyright", locale: :sv)
+
+
+  Scenario: Visitor switches the site language from English to Swedish
+    Given I am on the "all companies" page
+    When I click on "change-lang-to-english"
+    When I click on "change-lang-to-svenska"
+    Then I should see "Hitta H-märkt företag"
+    And I should see "Kategori"
+    And I should see "Namn"
+    And I should see "Län"
+    And I should not see "Swedish flag"
+    And I should see "English flag"
+    And I should see t("theme_copyright", locale: :sv)
+
+
+  Scenario: Visitor switches the site language from Swedish to English
+    Given I am on the "all companies" page
+    When I click on "change-lang-to-english"
+    Then I should see "Find H-labeled companies"
+    And I should see "Category"
+    And I should see "Name"
+    And I should see "County"
+    And I should see "Swedish flag"
+    And I should not see "English flag"
+    And I should see t("theme_copyright", locale: :en)
+

--- a/features/view-site-in-lang-i18n-l10n.feature
+++ b/features/view-site-in-lang-i18n-l10n.feature
@@ -11,9 +11,6 @@ Feature: As a visitor
   Scenario: Default language is Swedish
     Given I am on the "all companies" page
     Then I should see "Hitta H-märkt företag"
-    And I should see "Kategori"
-    And I should see "Namn"
-    And I should see "Län"
     And I should not see "Swedish flag"
     And I should see "English flag"
     And I should see t("theme_copyright", locale: :sv)
@@ -24,9 +21,6 @@ Feature: As a visitor
     When I click on "change-lang-to-english"
     When I click on "change-lang-to-svenska"
     Then I should see "Hitta H-märkt företag"
-    And I should see "Kategori"
-    And I should see "Namn"
-    And I should see "Län"
     And I should not see "Swedish flag"
     And I should see "English flag"
     And I should see t("theme_copyright", locale: :sv)
@@ -35,11 +29,7 @@ Feature: As a visitor
   Scenario: Visitor switches the site language from Swedish to English
     Given I am on the "all companies" page
     When I click on "change-lang-to-english"
-    Then I should see "Find H-labeled companies"
-    And I should see "Category"
-    And I should see "Name"
-    And I should see "County"
-    And I should see "Swedish flag"
+    Then I should see "Swedish flag"
     And I should not see "English flag"
     And I should see t("theme_copyright", locale: :en)
 


### PR DESCRIPTION
PT Story: 
https://www.pivotaltracker.com/story/show/133316647

This is the first step in doing i18n/l10n.  It implements what's needed to do translations.
It shows a simple link to switch the language (which should be styled and changed to a button later).
ONLY the copyright is translated (to keep this PR simple).

Changes proposed in this pull request:
1.  the default locale is sv
2. locales (language) is in the URL path.  Ex:
   - `..../sv/companies` will show the companies page in Swedish
   - `..../en/companies` will show the companies page in English
   - `..../companies` will show the companies page in the default language/locale
3. added a first version of locale files (sv.yml and en.yml)
4. use the `routing-filter` gem so all of the routing and adding `/sv` or `/en` to routes is handled for us
5. added a partial so the user can click on something to switch the language
6. translated the copyright in `_bottom.html.haml` so we have something to test
7. added feature steps that work with `I18n.t`
8. Updated features so errors would work with `I18n.t`

Ready for review:
@thesuss 
