### PR TITLE
I18n for devise and log in, add steps, add to locales

### DIFF
--- a/app/views/application/_login_items.html.haml
+++ b/app/views/application/_login_items.html.haml
@@ -1,5 +1,5 @@
 - if user_signed_in?
-  = link_to(t('log_out'), destroy_user_session_path, method: :delete)
+  = link_to(t('devise.sessions.destroy.log_out'), destroy_user_session_path, method: :delete)
 - else
-  = link_to(t('log_in'), new_user_session_path)
+  = link_to(t('devise.sessions.new.log_in'), new_user_session_path)
 = render 'select_language'

--- a/app/views/application/_login_items.html.haml
+++ b/app/views/application/_login_items.html.haml
@@ -1,5 +1,5 @@
 - if user_signed_in?
-  = link_to('Logga ut', destroy_user_session_path, method: :delete)
+  = link_to(t('log_out'), destroy_user_session_path, method: :delete)
 - else
-  = link_to('Logga in', new_user_session_path)
+  = link_to(t('log_in'), new_user_session_path)
 = render 'select_language'

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title #{t('.title')}
+  %h1.entry-title= t('.title')
 .post-title-divider
   %span
 .entry-content.wpcf7

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title Byt lösenord
+  %h1.entry-title #{t('.title')}
 .post-title-divider
   %span
 .entry-content.wpcf7
@@ -7,18 +7,16 @@
     = devise_error_messages!
     = f.hidden_field :reset_password_token
     .field
-      = f.label :password, 'Nytt lösenord', class: 'required'
+      = f.label :password, "#{t('.new_password')}", class: 'required'
       %br/
-      - if @minimum_password_length
-        %em
-          (minst #{@minimum_password_length} tecken)
-        %br/
+      = render 'devise/shared/min_password_length_info'
+      %br/
       = f.password_field :password, autofocus: true, autocomplete: 'off', class: 'wpcf7-form-control'
     .field
-      = f.label :password_confirmation, 'Bekräfta lösenord', class: 'required'
+      = f.label :password_confirmation, "#{t('.confirm_password')}", class: 'required'
       %br/
       = f.password_field :password_confirmation, autocomplete: 'off', class: 'wpcf7-form-control'
     .actions
-      = f.submit 'Byt lösenord'
+      = f.submit "#{t('.submit_button_label')}"
   = render 'devise/shared/links'
-  = render 'required_fields'
+  = render 'application/required_fields'

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title #{t('.title')}
+  %h1.entry-title= t('.title')
 .post-title-divider
   %span
 .entry-content.wpcf7

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title Glömt lösenordet
+  %h1.entry-title #{t('.title')}
 .post-title-divider
   %span
 .entry-content.wpcf7
@@ -10,6 +10,6 @@
       %br/
       = f.email_field :email, autofocus: true, class: 'wpcf7-form-control'
     .actions
-      = f.submit 'Skicka återställningsinstruktioner'
-  = render 'required_fields'
+      = f.submit "#{t('.submit_button_label')}"
+  = render 'application/required_fields'
   = render 'devise/shared/links'

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title #{t('edit')} #{t('user')}
+  %h1.entry-title #{t('.title')}
 .post-title-divider
   %span
 .entry-content.wpcf7
@@ -11,29 +11,29 @@
       = f.email_field :email, autofocus: true, class: 'wpcf7-form-control'
     - if devise_mapping.confirmable? && resource.pending_reconfirmation?
       %div
-        "#{t('unconfirmed_email_for')}: #{resource.unconfirmed_email}"
+        "#{t('.unconfirmed_email_for', unconfirmed_email: resource.unconfirmed_email )}"
     .field
       = f.label :password
-      %i #{t('leave_blank_if_no_change')}
+      %i #{t('.leave_blank_if_no_change')}
       %br/
       = f.password_field :password, autocomplete: 'off', class: 'wpcf7-form-control'
       = render 'devise/shared/min_password_length_info'
     .field
-      = f.label :password_confirmation, "#{t('confirm_password')}"
+      = f.label :password_confirmation, "#{t('.confirm_password')}"
       %br/
       = f.password_field :password_confirmation, autocomplete: 'off', class: 'wpcf7-form-control'
     .field
-      = f.label :current_password, "#{t('current_password')}", class: 'required'
-      %i #{t('required_to_save_changes')}
+      = f.label :current_password, "#{t('.current_password')}", class: 'required'
+      %i #{t('.required_to_save_changes')}
       %br/
       = f.password_field :current_password, autocomplete: 'off', class: 'wpcf7-form-control'
     .actions
-      = f.submit "#{t('update')}"
+      = f.submit "#{t('.submit_button_label')}"
   = render 'application/required_fields'
 
-  %h1.entry-title #{t('unregister')}
+  %h2.entry-title #{t('.unregister')}
   .post-title-divider
     %span
   %p
-    #{button_to t('delete_my_account'), registration_path(resource_name), data: { confirm: t('confirm_are_you_sure') }, method: :delete}
-  = link_to "#{t('back')}", :back
+    #{button_to t('.delete_my_account'), registration_path(resource_name), data: { confirm: t('.confirm_are_you_sure') }, method: :delete}
+  = link_to "#{t('.back')}", :back

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title Redigera användare
+  %h1.entry-title #{t('edit')} #{t('user')}
 .post-title-divider
   %span
 .entry-content.wpcf7
@@ -11,31 +11,29 @@
       = f.email_field :email, autofocus: true, class: 'wpcf7-form-control'
     - if devise_mapping.confirmable? && resource.pending_reconfirmation?
       %div
-        Obekräftad mailadress för: #{resource.unconfirmed_email}
+        "#{t('unconfirmed_email_for')}: #{resource.unconfirmed_email}"
     .field
-      = f.label :password, 'Lösenord'
-      %i (lämna tomt om du inte vill byta)
+      = f.label :password
+      %i #{t('leave_blank_if_no_change')}
       %br/
       = f.password_field :password, autocomplete: 'off', class: 'wpcf7-form-control'
-      - if @minimum_password_length
-        %em
-          (minst #{@minimum_password_length} tecken)
+      = render 'devise/shared/min_password_length_info'
     .field
-      = f.label :password_confirmation, 'Bekräfta lösenord'
+      = f.label :password_confirmation, "#{t('confirm_password')}"
       %br/
       = f.password_field :password_confirmation, autocomplete: 'off', class: 'wpcf7-form-control'
     .field
-      = f.label :current_password, 'Nuvarande lösenord', class: 'required'
-      %i (behövs för att spara ändringar)
+      = f.label :current_password, "#{t('current_password')}", class: 'required'
+      %i #{t('required_to_save_changes')}
       %br/
       = f.password_field :current_password, autocomplete: 'off', class: 'wpcf7-form-control'
     .actions
-      = f.submit 'Uppdatera'
-  = render 'required_fields'
+      = f.submit "#{t('update')}"
+  = render 'application/required_fields'
 
-  %h1.entry-title Avregistrera dig
+  %h1.entry-title #{t('unregister')}
   .post-title-divider
     %span
   %p
-    #{button_to 'Ta bort mitt konto', registration_path(resource_name), data: { confirm: 'Är du säker' }, method: :delete}
-  = link_to 'Tillbaks', :back
+    #{button_to t('delete_my_account'), registration_path(resource_name), data: { confirm: t('confirm_are_you_sure') }, method: :delete}
+  = link_to "#{t('back')}", :back

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title #{t('.title')}
+  %h1.entry-title= t('.title')
 .post-title-divider
   %span
 .entry-content.wpcf7
@@ -14,7 +14,7 @@
         "#{t('.unconfirmed_email_for', unconfirmed_email: resource.unconfirmed_email )}"
     .field
       = f.label :password
-      %i #{t('.leave_blank_if_no_change')}
+      %i= t('.leave_blank_if_no_change')
       %br/
       = f.password_field :password, autocomplete: 'off', class: 'wpcf7-form-control'
       = render 'devise/shared/min_password_length_info'
@@ -24,7 +24,7 @@
       = f.password_field :password_confirmation, autocomplete: 'off', class: 'wpcf7-form-control'
     .field
       = f.label :current_password, "#{t('.current_password')}", class: 'required'
-      %i #{t('.required_to_save_changes')}
+      %i= t('.required_to_save_changes')
       %br/
       = f.password_field :current_password, autocomplete: 'off', class: 'wpcf7-form-control'
     .actions

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -31,7 +31,7 @@
       = f.submit "#{t('.submit_button_label')}"
   = render 'application/required_fields'
 
-  %h2.entry-title #{t('.unregister')}
+  %h2.entry-title= t('.unregister')
   .post-title-divider
     %span
   %p

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title #{t('.title')}
+  %h1.entry-title= t('.title')
 .post-title-divider
   %span
 .entry-content.wpcf7

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title #{t('edit')} #{resource_name.to_s.humanize}
+  %h1.entry-title #{t('.title')}
 .post-title-divider
   %span
 .entry-content.wpcf7
@@ -15,10 +15,10 @@
       %br/
       = f.password_field :password, autocomplete: 'off', class: 'wpcf7-form-control'
     .field
-      = f.label :password_confirmation, "#{t('confirm_password')}", class: 'required'
+      = f.label :password_confirmation, "#{t('.confirm_password')}", class: 'required'
       %br/
       = f.password_field :password_confirmation, autocomplete: 'off', class: 'wpcf7-form-control'
     .actions
-      = f.submit "#{t('sign_up')}"
+      = f.submit "#{t('.submit_button_label')}"
   = render 'application/required_fields'
   = render 'devise/shared/links'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title Redigera #{resource_name.to_s.humanize}
+  %h1.entry-title #{t('edit')} #{resource_name.to_s.humanize}
 .post-title-divider
   %span
 .entry-content.wpcf7
@@ -10,17 +10,15 @@
       %br/
       = f.email_field :email, autofocus: true, class: 'wpcf7-form-control'
     .field
-      = f.label :password, 'Lösenord', class: 'required'
-      - if @minimum_password_length
-        %em
-          (minst #{@minimum_password_length} tecken)
+      = f.label :password, class: 'required'
+      = render 'devise/shared/min_password_length_info'
       %br/
       = f.password_field :password, autocomplete: 'off', class: 'wpcf7-form-control'
     .field
-      = f.label :password_confirmation, 'Bekräfta lösenord', class: 'required'
+      = f.label :password_confirmation, "#{t('confirm_password')}", class: 'required'
       %br/
       = f.password_field :password_confirmation, autocomplete: 'off', class: 'wpcf7-form-control'
     .actions
-      = f.submit 'Sign up'
-  = render 'required_fields'
+      = f.submit "#{t('sign_up')}"
+  = render 'application/required_fields'
   = render 'devise/shared/links'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title #{t('.title')}
+  %h1.entry-title= t('.title')
 .post-title-divider
   %span
 .entry-content.wpcf7

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title Logga in
+  %h1.entry-title #{t('log_in')}
 .post-title-divider
   %span
 .entry-content.wpcf7
@@ -15,8 +15,8 @@
     - if devise_mapping.rememberable?
       .checkbox
         = f.check_box(:remember_me, class: 'text-nicelabel', position_class: 'text_checkbox')
-        = f.label :remember_me, 'Kom ihåg mig'
+        = f.label :remember_me, "#{t('remember_me')}"
     .actions
-      = f.submit 'Logga in'
-  = render 'required_fields'
+      = f.submit "#{t('log_in')}"
+  = render 'application/required_fields'
   = render 'devise/shared/links'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title #{t('log_in')}
+  %h1.entry-title #{t('.title')}
 .post-title-divider
   %span
 .entry-content.wpcf7
@@ -15,8 +15,8 @@
     - if devise_mapping.rememberable?
       .checkbox
         = f.check_box(:remember_me, class: 'text-nicelabel', position_class: 'text_checkbox')
-        = f.label :remember_me, "#{t('remember_me')}"
+        = f.label :remember_me, "#{t('.remember_me')}"
     .actions
-      = f.submit "#{t('log_in')}"
+      = f.submit "#{t('.submit_button_label')}"
   = render 'application/required_fields'
   = render 'devise/shared/links'

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,19 +1,19 @@
 - if controller_name != 'sessions'
-  = link_to 'Logga in', new_session_path(resource_name)
+  = link_to "#{t('log_in')}", new_session_path(resource_name)
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to 'Skapa konto', new_registration_path(resource_name)
+  = link_to "#{t('create_account')}", new_registration_path(resource_name)
   %br/
 - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to 'Glömt lösenord?', new_password_path(resource_name)
+  = link_to "#{t('forgot_password')}?", new_password_path(resource_name)
   %br/
 - if devise_mapping.confirmable? && controller_name != 'confirmations'
-  = link_to 'Fick du inga instruktioner?', new_confirmation_path(resource_name)
+  = link_to "#{t('do_you_need_instructions')}", new_confirmation_path(resource_name)
   %br/
 - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-  = link_to 'Fick du inga instruktioner?', new_unlock_path(resource_name)
+  = link_to "#{t('do_you_need_instructions')}", new_unlock_path(resource_name)
   %br/
 - if devise_mapping.omniauthable?
   - resource_class.omniauth_providers.each do |provider|
-    = link_to "Logga in med #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
+    = link_to "#{t('log_in_with')} #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
     %br/

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,19 +1,19 @@
 - if controller_name != 'sessions'
-  = link_to "#{t('log_in')}", new_session_path(resource_name)
+  = link_to "#{t('devise.sessions.new.title')}", new_session_path(resource_name)
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "#{t('create_account')}", new_registration_path(resource_name)
+  = link_to "#{t('devise.registrations.new.create_account')}", new_registration_path(resource_name)
   %br/
 - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to "#{t('forgot_password')}?", new_password_path(resource_name)
+  = link_to "#{t('devise.registrations.new.forgot_password')}?", new_password_path(resource_name)
   %br/
 - if devise_mapping.confirmable? && controller_name != 'confirmations'
-  = link_to "#{t('do_you_need_instructions')}", new_confirmation_path(resource_name)
+  = link_to "#{t('devise.confirmations.new.do_you_need_instructions')}", new_confirmation_path(resource_name)
   %br/
 - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-  = link_to "#{t('do_you_need_instructions')}", new_unlock_path(resource_name)
+  = link_to "#{t('devise.unlocks.new.do_you_need_instructions')}", new_unlock_path(resource_name)
   %br/
 - if devise_mapping.omniauthable?
   - resource_class.omniauth_providers.each do |provider|
-    = link_to "#{t('log_in_with')} #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
+    = link_to "#{t('devise.omniauths.new.log_in_with')} #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
     %br/

--- a/app/views/devise/shared/_min_password_length_info.html.haml
+++ b/app/views/devise/shared/_min_password_length_info.html.haml
@@ -1,3 +1,3 @@
 - if @minimum_password_length
   %em
-    #{t('at_least_chars', minimum_length: @minimum_password_length)}
+    #{t('devise.min_length', minimum_length: @minimum_password_length)}

--- a/app/views/devise/shared/_min_password_length_info.html.haml
+++ b/app/views/devise/shared/_min_password_length_info.html.haml
@@ -1,0 +1,3 @@
+- if @minimum_password_length
+  %em
+    #{t('at_least_chars', minimum_length: @minimum_password_length)}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,54 +7,91 @@ en:
   about: 'About'
   more: 'More'
 
-  show_in_english: "In English"
-  show_in_swedish: "På Svenska"
+  show_in_english: Show the site in English
+  show_in_swedish: Visar webbplatsen på svenska
+
+  sign_up: Sign up
+  log_in: Log in
+  log_out: Log out
+  log_in_with: Log in with
+  create_account: Create account
+  forgot_password: Forgot your password
+  do_you_need_instructions: Do you need instructions?
+  remember_me: Remember me
+  password: Password
+  current_password: Current password
+  confirm_password: Confirm the password
+  send_reset_instructions: Send reset instructions
+  unconfirmed_email_for: Unconfirmed email address for
+  leave_blank_if_no_change: leave blank if you don't want to change it
+  delete_my_account: Delete my account
+  unregister: Remove your account (unregister)
+
+
+  at_least_chars: '(at least %{minimum_length} characters)'
+  is_required_explanation: Indicates a required field
+
+  user: user
+
+  edit: Edit
+  manage: Manage
+  update: Update
+  submit: Submit
+  delete: Delete
+  send: Send
+  new: New
+  change: Change
+  save: Save
+
+  back: Back
+
+  confirm_are_you_sure: Are you sure
+  required_to_save_changes: required to save changes
+
+  info:
+    logged_in_as_admin: You are logged in as an admin.
+    under_construction: This page is under construction.  More information and features are coming.
 
   apply_for_membership: 'Apply for membership'
 
   theme_copyright: "© 2017 Theme by Theme Feeder. All Rights Reserved."
 
-  memberships:
-    new:
-      title: 'Apply for a Membership'
-      company_name: 'Company Name'
-      company_number: 'Company Number'
-      contact_person: 'Contact Person'
-      company_email: 'Company Email'
-      phone_number: 'Phone Number'
-      submit: 'Submit'
-    create:
-      submit_acknowledgement: 'Thank You. Your membership application has been submitted.'
+  name: Name
+  org_nr: Org no.
 
+
+ # Automatic and manual lookup for ActiveRecords:
   activerecord:
     models:
-      membership:
+      membership_application:
         one: Membership
         other: Memberships
 
-      attributes:
-        membership_application:
-          company_number: Company number
-          first_name: First name
-          last_name: Last name
-          contact_email: Email
-          status: Status
-          phone_number: Phone Number
+    attributes:
+      membership_application:
+        company_number: Company number
+        first_name: First name
+        last_name: Last name
+        contact_email: Email
+        status: Status
+        phone_number: Phone number
+        membership_number: Membership number
 
-        company:
-          company_number: Company number
-          name: Name
-          phone_number: Phone Number
-          email: Email
-          street: Street
-          post_code: Post code
-          city: City
-          region: Region
-          website: Website
+      company:
+        company_number: Company number
+        name: Name
+        phone_number: Phone Number
+        email: Email
+        street: Street
+        post_code: Post code
+        city: City
+        region: Region
+        website: Website
+        org_nr: Org no.
 
-        business_category:
-          name: Name
-          description: Description
+      business_category:
+        name: Name
+        description: Description
 
     errors:
        messages:
@@ -62,6 +99,95 @@ en:
          restrict_dependent_destroy:
            has_one: "Cannot delete record because a dependent %{record} exists"
            has_many: "Cannot delete record because dependent %{record} exist"
+
+ # Automatic and manual lookup for views:
+  membership_applications:
+    new:
+      title: Apply for a Membership
+      submit: Submit
+      first_name: First name
+      last_name: Last name
+      phone_number: Phone number
+      company_number: Company number
+      contact_email: Email
+    create:
+      success: Thank You. Your membership application has been submitted.
+      error: The was a problem creating and submitting your application.
+    show:
+      title: Application from %{member_full_name}
+      first_name: First name
+      last_name: Last name
+      phone_number: Phone number
+      company_number: Company number
+      contact_email: Email
+      status: Status
+      membership_number: Membership number
+      with_categories: Categories
+    update:
+      success: The application was updated.
+      error: One or more problems prevented your application from being updated.
+      enter_member_number: Please enter the member number and save.
+
+    all_membership_applications: All applications
+    edit_membership_application: Edit application
+    view_membership_application: View application
+    list_all_membership_applications: List all applications
+
+    uploads:
+      no_files: No files uploaded for this application.
+      files_uploaded: 'Files uploaded for this application:'
+      filename: Filename
+      file_was_uploaded: 'This file was uploaded: %{filename}'
+      confirm_delete: 'Are you sure you want to delete %{filename}'
+      invalid_upload_type: Sorry, this is not a file type you can upload.
+
+    update_the_status: Update the status
+
+  companies:
+    new:
+      title: New company
+    create:
+      error: One or more problems prevented the company from being created.
+      success: The company was created successfully.
+    update:
+      error: There was a problem updating the company.
+      success: The company was updated.
+    show:
+      company_number: Company number
+      name: Name
+      phone_number: Phone Number
+      email: Company email
+      address: Address
+      street: Street
+      post_code: Post code
+      city: City
+      region: Region
+      website: Company website
+      org_nr: Org no.
+    index:
+      title: Find H-labeled companies
+      admin_title: Edit member companies
+      category: Category
+      region_land: Region
+      h_companies_listed_below: H-labeled companies are listed below.
+      how_to_search: To search the list, use Ctrl + F (PC) or Command + F (Mac)
+    company_name: Company name
+    telephone_number: Phone number
+    operations_region: County of operations
+    op_region_multiple_use_sweden: Enter Sweden if the company operates in several regions
+    website_include_http: Company website (please include http://)
+    org_nr_no_hyphens: Numbers only (no hyphens)
+
+    all_companies: All companies
+    edit_company: Edit company
+    view_company: View company
+    list_all_companies: List all companies
+
+  admin:
+    index:
+      title: 'Admin: All incoming applications'
+    all_applications_received: All applications received
+
   date:
     abbr_day_names:
     - Sun
@@ -159,7 +285,9 @@ en:
       month: Month
       second: Seconds
       year: Year
+
   errors:
+    not_permitted: You do not have permission to do this.
     format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
@@ -197,6 +325,7 @@ en:
       header:
         one: 1 error kept this %{model} from being saved
         other: "%{count} errors prohibited this %{model} from being saved"
+
   helpers:
     select:
       prompt: Please select

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,6 +68,11 @@ en:
         other: Memberships
 
     attributes:
+
+      user:
+        email: Email
+        password: Password
+
       membership_application:
         company_number: Company number
         first_name: First name
@@ -188,6 +193,109 @@ en:
       title: 'Admin: All incoming applications'
     all_applications_received: All applications received
 
+  errors:
+    not_permitted: You do not have permission to do this.
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: must be accepted
+      blank: can't be blank
+      present: must be blank
+      confirmation: doesn't match %{attribute}
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: "Validation failed: %{errors}"
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      required: must exist
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is 1 character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is 1 character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be 1 character)
+        other: is the wrong length (should be %{count} characters)
+      other_than: must be other than %{count}
+    template:
+      body: 'There were problems with the following fields:'
+      header:
+        one: 1 error kept this %{model} from being saved
+        other: "%{count} errors prohibited this %{model} from being saved"
+
+  helpers:
+    select:
+      prompt: Please select
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
+
+  support:
+    array:
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
+
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+
   date:
     abbr_day_names:
     - Sun
@@ -239,6 +347,7 @@ en:
     - :year
     - :month
     - :day
+
   datetime:
     distance_in_words:
       about_x_hours:
@@ -286,106 +395,6 @@ en:
       second: Seconds
       year: Year
 
-  errors:
-    not_permitted: You do not have permission to do this.
-    format: "%{attribute} %{message}"
-    messages:
-      accepted: must be accepted
-      blank: can't be blank
-      present: must be blank
-      confirmation: doesn't match %{attribute}
-      empty: can't be empty
-      equal_to: must be equal to %{count}
-      even: must be even
-      exclusion: is reserved
-      greater_than: must be greater than %{count}
-      greater_than_or_equal_to: must be greater than or equal to %{count}
-      inclusion: is not included in the list
-      invalid: is invalid
-      less_than: must be less than %{count}
-      less_than_or_equal_to: must be less than or equal to %{count}
-      model_invalid: "Validation failed: %{errors}"
-      not_a_number: is not a number
-      not_an_integer: must be an integer
-      odd: must be odd
-      required: must exist
-      taken: has already been taken
-      too_long:
-        one: is too long (maximum is 1 character)
-        other: is too long (maximum is %{count} characters)
-      too_short:
-        one: is too short (minimum is 1 character)
-        other: is too short (minimum is %{count} characters)
-      wrong_length:
-        one: is the wrong length (should be 1 character)
-        other: is the wrong length (should be %{count} characters)
-      other_than: must be other than %{count}
-    template:
-      body: 'There were problems with the following fields:'
-      header:
-        one: 1 error kept this %{model} from being saved
-        other: "%{count} errors prohibited this %{model} from being saved"
-
-  helpers:
-    select:
-      prompt: Please select
-    submit:
-      create: Create %{model}
-      submit: Save %{model}
-      update: Update %{model}
-  number:
-    currency:
-      format:
-        delimiter: ","
-        format: "%u%n"
-        precision: 2
-        separator: "."
-        significant: false
-        strip_insignificant_zeros: false
-        unit: "$"
-    format:
-      delimiter: ","
-      precision: 3
-      separator: "."
-      significant: false
-      strip_insignificant_zeros: false
-    human:
-      decimal_units:
-        format: "%n %u"
-        units:
-          billion: Billion
-          million: Million
-          quadrillion: Quadrillion
-          thousand: Thousand
-          trillion: Trillion
-          unit: ''
-      format:
-        delimiter: ''
-        precision: 3
-        significant: true
-        strip_insignificant_zeros: true
-      storage_units:
-        format: "%n %u"
-        units:
-          byte:
-            one: Byte
-            other: Bytes
-          gb: GB
-          kb: KB
-          mb: MB
-          tb: TB
-    percentage:
-      format:
-        delimiter: ''
-        format: "%n%"
-    precision:
-      format:
-        delimiter: ''
-  support:
-    array:
-      last_word_connector: ", and "
-      two_words_connector: " and "
-      words_connector: ", "
   time:
     am: am
     formats:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,33 +3,16 @@ en:
 
   title: "SWEDEN'S ETHICAL DOG COMPANIES"
 
-  home: 'Home'
-  about: 'About'
-  more: 'More'
+  home: Home
+  about: About
+  more: More
 
   show_in_english: Show the site in English
   show_in_swedish: Visar webbplatsen på svenska
 
-  sign_up: Sign up
-  log_in: Log in
-  log_out: Log out
-  log_in_with: Log in with
-  create_account: Create account
-  forgot_password: Forgot your password
-  do_you_need_instructions: Do you need instructions?
-  remember_me: Remember me
   password: Password
-  current_password: Current password
-  confirm_password: Confirm the password
-  send_reset_instructions: Send reset instructions
-  unconfirmed_email_for: Unconfirmed email address for
-  leave_blank_if_no_change: leave blank if you don't want to change it
-  delete_my_account: Delete my account
-  unregister: Remove your account (unregister)
 
-
-  at_least_chars: '(at least %{minimum_length} characters)'
-  is_required_explanation: Indicates a required field
+  is_required_field: Indicates a required field
 
   user: user
 
@@ -43,10 +26,9 @@ en:
   change: Change
   save: Save
 
-  back: Back
+  back: &back Back
 
-  confirm_are_you_sure: Are you sure
-  required_to_save_changes: required to save changes
+  confirm_are_you_sure: &are_you_sure_confirm Are you sure
 
   info:
     logged_in_as_admin: You are logged in as an admin.
@@ -56,8 +38,8 @@ en:
 
   theme_copyright: "© 2017 Theme by Theme Feeder. All Rights Reserved."
 
-  name: Name
-  org_nr: Org no.
+  name: &name Name
+  org_nr: &org_nr Org no.
 
 
  # Automatic and manual lookup for ActiveRecords:
@@ -70,13 +52,13 @@ en:
     attributes:
 
       user:
-        email: Email
+        email: &email Email
         password: Password
 
       membership_application:
         company_number: Company number
-        first_name: First name
-        last_name: Last name
+        first_name: &first_name First name
+        last_name: &last_name Last name
         contact_email: Email
         status: Status
         phone_number: Phone number
@@ -84,18 +66,18 @@ en:
 
       company:
         company_number: Company number
-        name: Name
+        name: *name
         phone_number: Phone Number
-        email: Email
+        email: *email
         street: Street
         post_code: Post code
         city: City
         region: Region
         website: Website
-        org_nr: Org no.
+        org_nr: *org_nr
 
       business_category:
-        name: Name
+        name: *name
         description: Description
 
     errors:
@@ -110,21 +92,21 @@ en:
     new:
       title: Apply for a Membership
       submit: Submit
-      first_name: First name
-      last_name: Last name
+      first_name: *first_name
+      last_name: *last_name
       phone_number: Phone number
       company_number: Company number
-      contact_email: Email
+      contact_email: *email
     create:
       success: Thank You. Your membership application has been submitted.
       error: The was a problem creating and submitting your application.
     show:
       title: Application from %{member_full_name}
-      first_name: First name
-      last_name: Last name
+      first_name: *first_name
+      last_name: *last_name
       phone_number: Phone number
       company_number: Company number
-      contact_email: Email
+      contact_email: *email
       status: Status
       membership_number: Membership number
       with_categories: Categories
@@ -159,7 +141,7 @@ en:
       success: The company was updated.
     show:
       company_number: Company number
-      name: Name
+      name: *name
       phone_number: Phone Number
       email: Company email
       address: Address
@@ -168,7 +150,7 @@ en:
       city: City
       region: Region
       website: Company website
-      org_nr: Org no.
+      org_nr: *org_nr
     index:
       title: Find H-labeled companies
       admin_title: Edit member companies
@@ -194,9 +176,54 @@ en:
     all_applications_received: All applications received
 
   devise:
+    min_length: '(at least %{minimum_length} characters)'
+
+    registrations:
+      new:
+        title: Create your login information
+        create_account: Create account
+        confirm_password: &confirm_password Confirm password
+        forgot_password: Forgot password
+        submit_button_label: Sign up
+      edit:
+        title: Edit your login information
+        unconfirmed_email_for: 'Unconfirmed email address for: %{unconfirmed_email}'
+        confirm_password: *confirm_password
+        current_password: Current password
+        required_to_save_changes: (required to save changes)
+        leave_blank_if_no_change: "leave blank if there's no change"
+        submit_button_label: Update
+        delete_my_account: Delete my account
+        unregister: Unregister
+        confirm_are_you_sure: *are_you_sure_confirm
+        back: *back
+    sessions:
+      new:
+        log_in: &log_in Log In
+        title: *log_in
+        remember_me: Remember me
+        submit_button_label: *log_in
+      destroy:
+        log_out: Log out
     passwords:
+      new:
+        title: Forgot your password
+        submit_button_label: Send the reset instructions
       edit:
         title: Change your password
+        new_password: New password
+        confirm_password: Confirm your password
+        submit_button_label: Change Your Password
+    confirmations:
+      new:
+        do_you_need_instructions: &need_instructions Do you need instructions?
+    unlocks:
+      new:
+        do_you_need_instructions: *need_instructions
+    omniauths:
+      new:
+        log_in_with: Log in with
+
 
   errors:
     not_permitted: You do not have permission to do this.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,11 @@ en:
       title: 'Admin: All incoming applications'
     all_applications_received: All applications received
 
+  devise:
+    passwords:
+      edit:
+        title: Change your password
+
   errors:
     not_permitted: You do not have permission to do this.
     format: "%{attribute} %{message}"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -7,54 +7,93 @@ sv:
   about: 'Om'
   more: 'Mer'
 
-  show_in_english: "In English"
-  show_in_swedish: "På Svenska"
+  show_in_english: Show the site in English
+  show_in_swedish: Visar webbplatsen på svenska
 
-  apply_for_membership: 'Ansök om medlemskap'
+  sign_up: Sign up
+  log_in: Logga in
+  log_out: Logga ut
+  log_in_with: Logga in med
+  create_account: Skapa konto
+  forgot_password: Glömt lösenord
+  do_you_need_instructions: Fick du inga instruktioner?
+  remember_me: Kom ihåg mig
+  password: Lösenord
+  current_password: Nuvarande lösenord
+  confirm_password: Bekräfta lösenord
+  send_reset_instructions: Skicka återställningsinstruktioner
+  unconfirmed_email_for: Obekräftad mailadress för
+  leave_blank_if_no_change: lämna tomt om du inte vill byta
+  delete_my_account: Ta bort mitt konto
+  unregister: Avregistrera dig
+
+
+  at_least_chars: '(minst %{minimum_length} tecken)'
+  is_required_explanation: Indikerar ett obligatoriskt fält
+
+  user: användare
+
+  edit: Redigera
+  manage: Hantera
+  update: Uppdatera
+  submit: Skicka
+  delete: Radera
+  send: Skicka
+  new: Nytt
+  change: Byt
+  save: Save
+
+  back: Tillbaks
+
+  confirm_are_you_sure: Är du säker
+
+  required_to_save_changes: behövs för att spara ändringar
+
+  info:
+    logged_in_as_admin: Du är inloggad som admin
+    under_construction: Sidan är under uppbyggnad, mer information och funktioner kommer att komma efterhand.
+
+
+
+  apply_for_membership: Ansök om medlemskap
 
   theme_copyright: "© 2017 Tema av Theme Feeder. Alla rättigheter förbehållna."
 
-  memberships:
-    new:
-      title: 'Ansök om medlemskap'
-      company_name: 'Företagsnamn'
-      company_number: 'Organisationsnummer'
-      contact_person: 'Kontaktperson'
-      company_email: 'Företagets e-postadress'
-      phone_number: 'Telefonnummer'
-      submit: 'Skicka'
-    create:
-      submit_acknowledgement: 'Tack, Din ansökan har skickats.'
+  name: Namn
+  org_nr: Org no.
 
+  # Automatisk och manuell sökning för Active Records
   activerecord:
     models:
-      membership:
+      membership_application:
         one: Medlemskap
         other: Medlemskap
 
-      attributes:
-        membership_application:
-          company_number: Company number
-          first_name: First name
-          last_name: Last name
-          contact_email: Contact email
-          status: Status
-          phone_number: Phone Number
+    attributes:
+      membership_application:
+        company_number: Organisationsnummer
+        first_name: Förnamn
+        last_name: Efternamn
+        contact_email: Kontakt e-post
+        status: Status
+        phone_number: Telefonnummer
+        membership_number: Medlemsnummer
 
-        company:
-          company_number: Company number
-          name: Name
-          phone_number: Phone Number
-          email: Email
-          street: Street
-          post_code: Post code
-          city: City
-          region: Region
-          website: Website
+      company:
+        company_number: Org nr
+        name: Namn
+        phone_number: Telefon
+        email: Email
+        street: Gata
+        post_code: Post nr
+        city: Ort
+        region: Verksamhetslän
+        website: Webbplats
+        org_nr: Org nr
 
-        business_category:
-          name: Name
-          description: Description
+      business_category:
+        name: Namn
+        description: Beskrivning
 
     errors:
       messages:
@@ -62,6 +101,99 @@ sv:
         restrict_dependent_destroy:
           has_one: Kan inte ta bort post då beroende %{record} finns
           has_many: Kan inte ta bort poster då beroende %{record} finns
+
+
+  # Automatisk och manuell sökning för views:
+  membership_applications:
+    new:
+      title: Ansök om medlemskap
+      submit: Skicka
+      company_number: Organisationsnummer
+      phone_number: Telefonnummer
+      first_name: Förnamn
+      last_name: Efternamn
+      contact_email: Kontakt e-post
+    create:
+      success: Tack, din ansökan har skickats.
+      error: Ett eller flera problem hindrade din ansökan från att skickas.
+    show:
+      title: Ansökan från %{member_full_name}
+      first_name: Förnamn
+      last_name: Efternamn
+      phone_number: Telefonnummer
+      company_number: Organisationsnummer
+      contact_email: Kontakt e-post
+      status: Status
+      membership_number: Medlemsnummer
+      with_categories: Ansöker inom
+    update:
+      success: Ansökan har uppdaterats.
+      error: Ett eller flera problem hindrade din ansökan från att sparas.
+      enter_member_number: Var god ange medlemsnummer och spara.
+
+
+    all_membership_applications: Alla ansökningar
+    edit_membership_application: Redigera ansökan
+    view_membership_application: Visa ansökan
+    list_all_membership_applications: Lista alla ansökningar
+
+    uploads:
+      no_files: Inga filer är uppladdade för denna ansökan.
+      files_uploaded: 'Uppladdade filer för denna ansökan:'
+      filename: Filnamn
+      file_was_uploaded: 'Filen laddades upp: %{filename}'
+      confirm_delete: 'Är du säker på att du vill radera %{filename}'
+      invalid_upload_type: Tyvärr kan du inte ladda upp denna filtypen.
+
+    update_the_status: Uppdatera status
+
+
+  companies:
+    new:
+      title: Nytt företag
+    create:
+      error: Ett eller flera problem hindrade företaget från att skapas.
+      success: Företaget har skapats.
+    update:
+      error: Ett problem förhindrade uppdatering av företaget.
+      success: Företaget har uppdaterats.
+    show:
+      company_number: Org nr
+      name: Namn
+      phone_number: Telefon
+      email: Företagets e-postadress
+      address: Adress
+      street: Gata
+      post_code: Post nr
+      city: Ort
+      region: Verksamhetslän
+      website: Företagets webbplats
+      org_nr: Org nr
+    index:
+      title:  Hitta H-märkt företag
+      admin_title: Redigera medlemsföretag
+      category: Kategori
+      region_land: Län
+      h_companies_listed_below: Nedan listas anslutna H-märkta företag
+      how_to_search: Du kan söka i listan på datorn med ctrl+F(PC) eller cmd+F(mac)
+    company_name: Företagsnamn
+    telephone_number: Telefonnummer
+    operations_region: Verksamhetslän
+    op_region_multiple_use_sweden: Skriv Sverige om företaget är verksamt i flera delar av landet
+    website_include_http: Företagets webbplats (glöm inte http://)
+    org_nr_no_hyphens: Endast siffror (ej bindestreck)
+
+    all_companies: Alla företag
+    edit_company: Redigera detta företag
+    view_company: Visa företagssida
+    list_all_companies: Lista alla företag
+
+  admin:
+    index:
+      title: 'Admin: Alla inkomna ansökningar'
+    all_applications_received: Alla inkomna ansökningar
+
+
   date:
     abbr_day_names:
     - sön
@@ -160,6 +292,7 @@ sv:
       second: sekund
       year: år
   errors:
+    not_permitted: Du har inte behörighet att göra detta.
     format: "%{attribute} %{message}"
     messages:
       accepted: måste accepteras

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -3,33 +3,16 @@ sv:
 
   title: 'Medlemmar i Sveriges Hundföretagare'
 
-  home: 'Hem'
-  about: 'Om'
-  more: 'Mer'
+  home: Hem
+  about: Om
+  more: Mer
 
   show_in_english: Show the site in English
   show_in_swedish: Visar webbplatsen på svenska
 
-  sign_up: Sign up
-  log_in: Logga in
-  log_out: Logga ut
-  log_in_with: Logga in med
-  create_account: Skapa konto
-  forgot_password: Glömt lösenord
-  do_you_need_instructions: Fick du inga instruktioner?
-  remember_me: Kom ihåg mig
   password: Lösenord
-  current_password: Nuvarande lösenord
-  confirm_password: Bekräfta lösenord
-  send_reset_instructions: Skicka återställningsinstruktioner
-  unconfirmed_email_for: Obekräftad mailadress för
-  leave_blank_if_no_change: lämna tomt om du inte vill byta
-  delete_my_account: Ta bort mitt konto
-  unregister: Avregistrera dig
 
-
-  at_least_chars: '(minst %{minimum_length} tecken)'
-  is_required_explanation: Indikerar ett obligatoriskt fält
+  is_required_field: Indikerar ett obligatoriskt fält
 
   user: användare
 
@@ -43,24 +26,21 @@ sv:
   change: Byt
   save: Save
 
-  back: Tillbaks
+  back: &back Tillbaks
 
-  confirm_are_you_sure: Är du säker
-
-  required_to_save_changes: behövs för att spara ändringar
+  confirm_are_you_sure: &are_you_sure_confirm Är du säker
 
   info:
     logged_in_as_admin: Du är inloggad som admin
     under_construction: Sidan är under uppbyggnad, mer information och funktioner kommer att komma efterhand.
 
 
-
   apply_for_membership: Ansök om medlemskap
 
   theme_copyright: "© 2017 Tema av Theme Feeder. Alla rättigheter förbehållna."
 
-  name: Namn
-  org_nr: Org no.
+  name: &name Namn
+  org_nr: &org_nr Org no.
 
   # Automatisk och manuell sökning för Active Records
   activerecord:
@@ -72,32 +52,32 @@ sv:
     attributes:
 
       user:
-        email: E-post
+        email: &email E-post
         password: Lösenord
 
       membership_application:
         company_number: Organisationsnummer
-        first_name: Förnamn
-        last_name: Efternamn
+        first_name: &first_name Förnamn
+        last_name: &last_name Efternamn
         contact_email: Kontakt e-post
-        status: Status
+        status: &status Status
         phone_number: Telefonnummer
-        membership_number: Medlemsnummer
+        membership_number: &membership_number Medlemsnummer
 
       company:
-        company_number: Org nr
-        name: Namn
+        company_number: *org_nr
+        name: *name
         phone_number: Telefon
-        email: Email
+        email: *email
         street: Gata
         post_code: Post nr
         city: Ort
         region: Verksamhetslän
         website: Webbplats
-        org_nr: Org nr
+        org_nr: *org_nr
 
       business_category:
-        name: Namn
+        name: *name
         description: Beskrivning
 
     errors:
@@ -113,23 +93,23 @@ sv:
     new:
       title: Ansök om medlemskap
       submit: Skicka
-      company_number: Organisationsnummer
-      phone_number: Telefonnummer
-      first_name: Förnamn
-      last_name: Efternamn
-      contact_email: Kontakt e-post
+      company_number: &company_number Organisationsnummer
+      phone_number: &phone_number Telefonnummer
+      first_name: *first_name
+      last_name: *last_name
+      contact_email: &contact_email Kontakt e-post
     create:
       success: Tack, din ansökan har skickats.
       error: Ett eller flera problem hindrade din ansökan från att skickas.
     show:
       title: Ansökan från %{member_full_name}
-      first_name: Förnamn
-      last_name: Efternamn
-      phone_number: Telefonnummer
-      company_number: Organisationsnummer
-      contact_email: Kontakt e-post
-      status: Status
-      membership_number: Medlemsnummer
+      first_name: *first_name
+      last_name: *last_name
+      phone_number: *phone_number
+      company_number: *company_number
+      contact_email: *contact_email
+      status: *status
+      membership_number: *membership_number
       with_categories: Ansöker inom
     update:
       success: Ansökan har uppdaterats.
@@ -152,7 +132,6 @@ sv:
 
     update_the_status: Uppdatera status
 
-
   companies:
     new:
       title: Nytt företag
@@ -163,8 +142,8 @@ sv:
       error: Ett problem förhindrade uppdatering av företaget.
       success: Företaget har uppdaterats.
     show:
-      company_number: Org nr
-      name: Namn
+      company_number: *org_nr
+      name: *name
       phone_number: Telefon
       email: Företagets e-postadress
       address: Adress
@@ -173,7 +152,7 @@ sv:
       city: Ort
       region: Verksamhetslän
       website: Företagets webbplats
-      org_nr: Org nr
+      org_nr: *org_nr
     index:
       title:  Hitta H-märkt företag
       admin_title: Redigera medlemsföretag
@@ -199,9 +178,54 @@ sv:
     all_applications_received: Alla inkomna ansökningar
 
   devise:
-    passwords:
+    min_length: '(minst %{minimum_length} tecken)'
+
+    registrations:
+      new:
+        title: Skapa dina inloggningsuppgifter
+        create_account: Skapa konto
+        forgot_password: Glömt lösenord
+        confirm_password: &confirm_password Bekräfta lösenord
+        submit_button_label: Sign up
       edit:
-        title: Ändra ditt lösenord
+        title: Redigera användare
+        unconfirmed_email_for: 'Obekräftad mailadress för: %{unconfirmed_email}'
+        leave_blank_if_no_change: lämna tomt om du inte vill byta
+        confirm_password: *confirm_password
+        current_password: Nuvarande lösenord
+        required_to_save_changes: (behövs för att spara ändringar)
+        submit_button_label: Uppdatera
+        delete_my_account: Ta bort mitt konto
+        unregister: Avregistrera dig
+        confirm_are_you_sure: *are_you_sure_confirm
+        back: *back
+    sessions:
+      new:
+        log_in: &log_in Logga In
+        title: *log_in
+        remember_me: Kom ihåg mig
+        submit_button_label: *log_in
+      destroy:
+        log_out: Logga ut
+    passwords:
+      new:
+        title: Glömt lösenordet
+        submit_button_label: Skicka återställningsinstruktioner
+      edit:
+        title: &change_password Byt lösenord
+        new_password: Nytt lösenord
+        confirm_password: *confirm_password
+        submit_button_label: *change_password
+    confirmations:
+      new:
+        do_you_need_instructions: &need_instructions Fick du inga instruktioner?
+    unlocks:
+      new:
+        do_you_need_instructions: *need_instructions
+    omniauths:
+      new:
+        log_in_with: Logga in med
+
 
   errors:
     not_permitted: Du har inte behörighet att göra detta.

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -182,11 +182,11 @@ sv:
 
     registrations:
       new:
-        title: Skapa dina inloggningsuppgifter
-        create_account: Skapa konto
+        title: Skapa användare
+        create_account: Skicka
         forgot_password: Glömt lösenord
         confirm_password: &confirm_password Bekräfta lösenord
-        submit_button_label: Sign up
+        submit_button_label: Skapa användare
       edit:
         title: Redigera användare
         unconfirmed_email_for: 'Obekräftad mailadress för: %{unconfirmed_email}'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -70,6 +70,11 @@ sv:
         other: Medlemskap
 
     attributes:
+
+      user:
+        email: E-post
+        password: Lösenord
+
       membership_application:
         company_number: Organisationsnummer
         first_name: Förnamn
@@ -330,6 +335,7 @@ sv:
       header:
         one: Ett fel förhindrade %{model} från att sparas
         other: "%{count} fel förhindrade %{model} från att sparas"
+
   helpers:
     select:
       prompt: Välj

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -198,6 +198,114 @@ sv:
       title: 'Admin: Alla inkomna ansökningar'
     all_applications_received: Alla inkomna ansökningar
 
+  devise:
+    passwords:
+      edit:
+        title: Ändra ditt lösenord
+
+  errors:
+    not_permitted: Du har inte behörighet att göra detta.
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: måste accepteras
+      blank: måste anges
+      present: får inte anges
+      confirmation: stämmer inte överens
+      empty: får ej vara tom
+      equal_to: måste vara samma som
+      even: måste vara jämnt
+      exclusion: är reserverat
+      greater_than: måste vara större än %{count}
+      greater_than_or_equal_to: måste vara större än eller lika med %{count}
+      inclusion: finns inte i listan
+      invalid: har fel format
+      less_than: måste vara mindre än %{count}
+      less_than_or_equal_to: måste vara mindre än eller lika med %{count}
+      model_invalid: "Validering lyckades inte: %{errors}"
+      not_a_number: är inte ett nummer
+      not_an_integer: måste vara ett heltal
+      odd: måste vara udda
+      required: must exist
+      taken: används redan
+      too_long:
+        one: är för lång (max är ett tecken)
+        other: är för lång (maximum är %{count} tecken)
+      too_short:
+        one: är för kort (minimum är ett tecken)
+        other: är för kort (minimum är %{count} tecken)
+      wrong_length:
+        one: är fel längd (ska vara ett tecken)
+        other: har fel längd (ska vara %{count} tecken)
+      other_than: måste vara annat än %{count}
+    template:
+      body: 'Det var problem med följande fält:'
+      header:
+        one: Ett fel förhindrade %{model} från att sparas
+        other: "%{count} fel förhindrade %{model} från att sparas"
+
+  helpers:
+    select:
+      prompt: Välj
+    submit:
+      create: Skapa %{model}
+      submit: Spara %{model}
+      update: Ändra %{model}
+
+
+  support:
+    array:
+      last_word_connector: " och "
+      two_words_connector: " och "
+      words_connector: ", "
+
+  number:
+    currency:
+      format:
+        delimiter: ''
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: kr
+    format:
+      delimiter: ''
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Miljard
+          million: Miljon
+          quadrillion: Biljard
+          thousand: Tusen
+          trillion: Biljon
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
 
   date:
     abbr_day_names:
@@ -250,6 +358,7 @@ sv:
     - :day
     - :month
     - :year
+
   datetime:
     distance_in_words:
       about_x_hours:
@@ -296,106 +405,7 @@ sv:
       month: månad
       second: sekund
       year: år
-  errors:
-    not_permitted: Du har inte behörighet att göra detta.
-    format: "%{attribute} %{message}"
-    messages:
-      accepted: måste accepteras
-      blank: måste anges
-      present: får inte anges
-      confirmation: stämmer inte överens
-      empty: får ej vara tom
-      equal_to: måste vara samma som
-      even: måste vara jämnt
-      exclusion: är reserverat
-      greater_than: måste vara större än %{count}
-      greater_than_or_equal_to: måste vara större än eller lika med %{count}
-      inclusion: finns inte i listan
-      invalid: har fel format
-      less_than: måste vara mindre än %{count}
-      less_than_or_equal_to: måste vara mindre än eller lika med %{count}
-      model_invalid: "Validering lyckades inte: %{errors}"
-      not_a_number: är inte ett nummer
-      not_an_integer: måste vara ett heltal
-      odd: måste vara udda
-      required: must exist
-      taken: används redan
-      too_long:
-        one: är för lång (max är ett tecken)
-        other: är för lång (maximum är %{count} tecken)
-      too_short:
-        one: är för kort (minimum är ett tecken)
-        other: är för kort (minimum är %{count} tecken)
-      wrong_length:
-        one: är fel längd (ska vara ett tecken)
-        other: har fel längd (ska vara %{count} tecken)
-      other_than: måste vara annat än %{count}
-    template:
-      body: 'Det var problem med följande fält:'
-      header:
-        one: Ett fel förhindrade %{model} från att sparas
-        other: "%{count} fel förhindrade %{model} från att sparas"
 
-  helpers:
-    select:
-      prompt: Välj
-    submit:
-      create: Skapa %{model}
-      submit: Spara %{model}
-      update: Ändra %{model}
-  number:
-    currency:
-      format:
-        delimiter: ''
-        format: "%n %u"
-        precision: 2
-        separator: ","
-        significant: false
-        strip_insignificant_zeros: false
-        unit: kr
-    format:
-      delimiter: ''
-      precision: 2
-      separator: ","
-      significant: false
-      strip_insignificant_zeros: false
-    human:
-      decimal_units:
-        format: "%n %u"
-        units:
-          billion: Miljard
-          million: Miljon
-          quadrillion: Biljard
-          thousand: Tusen
-          trillion: Biljon
-          unit: ''
-      format:
-        delimiter: ''
-        precision: 1
-        significant: true
-        strip_insignificant_zeros: true
-      storage_units:
-        format: "%n %u"
-        units:
-          byte:
-            one: Byte
-            other: Bytes
-          gb: GB
-          kb: KB
-          mb: MB
-          tb: TB
-    percentage:
-      format:
-        delimiter: ''
-        format: "%n%"
-    precision:
-      format:
-        delimiter: ''
-  support:
-    array:
-      last_word_connector: " och "
-      two_words_connector: " och "
-      words_connector: ", "
   time:
     am: ''
     formats:

--- a/features/admin_creates_company.feature
+++ b/features/admin_creates_company.feature
@@ -107,8 +107,8 @@ Feature: As an admin
 
     Scenarios:
       | name        | org_number | phone | street         | post_code | city   | region    | email        | website                   | model_attribute                              | error                   |
-      | Happy Mutts | 5560360793 |       | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kickiimmi.nu | http://www.gladajyckar.se | activerecord.models.attributes.company.email | errors.messages.invalid |
-      | Happy Mutts | 5560360793 |       | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@imminu | http://www.gladajyckar.se | activerecord.models.attributes.company.email | errors.messages.invalid |
+      | Happy Mutts | 5560360793 |       | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kickiimmi.nu | http://www.gladajyckar.se | activerecord.attributes.company.email | errors.messages.invalid |
+      | Happy Mutts | 5560360793 |       | Ålstensgatan 4 | 123 45    | Bromma | Stockholm | kicki@imminu | http://www.gladajyckar.se | activerecord.attributes.company.email | errors.messages.invalid |
 
 
   Scenario Outline: Admin edits a company: company number is wrong length

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -88,13 +88,13 @@ Feature: As a user
     Then I should see translated error <model_attribute> <error>
 
     Scenarios:
-      | f_name | c_number   | l_name    | c_email       | phone      | model_attribute                                                      | error                   |
-      | Kicki  |            | Andersson | kicki@immi.nu | 0706898525 | activerecord.models.attributes.membership_application.company_number | errors.messages.blank   |
-      | Kicki  | 5562252998 |           | kicki@immi.nu | 0706898525 | activerecord.models.attributes.membership_application.last_name      | errors.messages.blank   |
-      | Kicki  | 5562252998 | Andersson |               | 0706898525 | activerecord.models.attributes.membership_application.contact_email  | errors.messages.blank   |
-      |        | 5562252998 | Andersson | kicki@immi.nu | 0706898525 | activerecord.models.attributes.membership_application.first_name     | errors.messages.blank   |
-      | Kicki  | 5562252998 | Andersson | kicki@imminu  | 0706898525 | activerecord.models.attributes.membership_application.contact_email  | errors.messages.invalid |
-      | Kicki  | 5562252998 | Andersson | kickiimmi.nu  | 0706898525 | activerecord.models.attributes.membership_application.contact_email  | errors.messages.invalid |
+      | f_name | c_number   | l_name    | c_email       | phone      | model_attribute                                               | error                   |
+      | Kicki  |            | Andersson | kicki@immi.nu | 0706898525 | activerecord.attributes.membership_application.company_number | errors.messages.blank   |
+      | Kicki  | 5562252998 |           | kicki@immi.nu | 0706898525 | activerecord.attributes.membership_application.last_name      | errors.messages.blank   |
+      | Kicki  | 5562252998 | Andersson |               | 0706898525 | activerecord.attributes.membership_application.contact_email  | errors.messages.blank   |
+      |        | 5562252998 | Andersson | kicki@immi.nu | 0706898525 | activerecord.attributes.membership_application.first_name     | errors.messages.blank   |
+      | Kicki  | 5562252998 | Andersson | kicki@imminu  | 0706898525 | activerecord.attributes.membership_application.contact_email  | errors.messages.invalid |
+      | Kicki  | 5562252998 | Andersson | kickiimmi.nu  | 0706898525 | activerecord.attributes.membership_application.contact_email  | errors.messages.invalid |
 
 
   Scenario Outline: Apply for membership: company number wrong length

--- a/features/devise-views-i18n.feature
+++ b/features/devise-views-i18n.feature
@@ -14,31 +14,38 @@ Feature: As a non-swedish speaking potential member
       | emma@random.com      | password | false | false     |
 
 
-  Scenario: Devise New password view is translated
+  Scenario: Devise new session view is translated
+    Given I am on the "login" page
+    Then I should see t("devise.sessions.new.title")
+    And I should see t("activerecord.attributes.user.email")
+    And I should see t("activerecord.attributes.user.password")
+    And I should see t("devise.sessions.new.remember_me")
+    And I should see button t("devise.sessions.new.submit_button_label")
+
+  Scenario: Devise new password view is translated
     Given I am on the "new password" page
-    Then I should see t("activerecord.attributes.user.email")
-    And I should see t("forgot_password")
-    And I should see button t("send_reset_instructions")
+    Then I should see t("devise.passwords.new.title")
+    And I should see t("activerecord.attributes.user.email")
+    And I should see button t("devise.passwords.new.submit_button_label")
 
-  Scenario: Devise New registration view is translated
-    Given I am on the "register a new user" page
-    Then I should see t("activerecord.attributes.user.password")
+  Scenario: Devise new registration view is translated
+    Given I am on the "register as a new user" page
+    Then I should see t("devise.registrations.new.title")
+    And I should see t("activerecord.attributes.user.email")
     And I should see t("activerecord.attributes.user.password")
-    And I should see t("activerecord.attributes.user.password")
-    And I should see t("confirm_password")
+    And I should see t("devise.registrations.new.confirm_password")
+    And I should see button t("devise.registrations.new.submit_button_label")
 
-  Scenario: Devise Edit registration view is translated
+  Scenario: Devise edit registration view is translated
     Given I am logged in as "emma@random.com"
     And I am on the "edit registration for a user" page
-    Then I should see t("activerecord.attributes.user.password")
+    Then I should see t("devise.registrations.edit.title")
     And I should see t("activerecord.attributes.user.password")
-    And I should see t("confirm_password")
-    And I should see t("current_password")
-    And I should see t("leave_blank_if_no_change")
-    And I should see t("required_to_save_changes")
-    And I should see t("unregister")
-    And I should see button t("delete_my_account")
-
-
-
-
+    And I should see t("activerecord.attributes.user.password")
+    And I should see t("devise.registrations.edit.confirm_password")
+    And I should see t("devise.registrations.edit.current_password")
+    And I should see t("devise.registrations.edit.leave_blank_if_no_change")
+    And I should see t("devise.registrations.edit.required_to_save_changes")
+    And I should see t("devise.registrations.edit.unregister")
+    And I should see button t("devise.registrations.edit.delete_my_account")
+    And I should see button t("devise.registrations.edit.submit_button_label")

--- a/features/devise-views-i18n.feature
+++ b/features/devise-views-i18n.feature
@@ -1,0 +1,44 @@
+Feature: As a non-swedish speaking potential member
+  In order to understand the information
+  the site must also offer at least English.
+
+  This also makes tests less brittle because the wording will be able to
+  change without affecting any code. (It will just change in the
+  locale .yml files.)
+
+  PT: https://www.pivotaltracker.com/story/show/133316647
+
+  Background:
+    Given the following users exists
+      | email                | password | admin | is_member |
+      | emma@random.com      | password | false | false     |
+
+
+  Scenario: Devise New password view is translated
+    Given I am on the "new password" page
+    Then I should see t("activerecord.attributes.user.email")
+    And I should see t("forgot_password")
+    And I should see button t("send_reset_instructions")
+
+  Scenario: Devise New registration view is translated
+    Given I am on the "register a new user" page
+    Then I should see t("activerecord.attributes.user.password")
+    And I should see t("activerecord.attributes.user.password")
+    And I should see t("activerecord.attributes.user.password")
+    And I should see t("confirm_password")
+
+  Scenario: Devise Edit registration view is translated
+    Given I am logged in as "emma@random.com"
+    And I am on the "edit registration for a user" page
+    Then I should see t("activerecord.attributes.user.password")
+    And I should see t("activerecord.attributes.user.password")
+    And I should see t("confirm_password")
+    And I should see t("current_password")
+    And I should see t("leave_blank_if_no_change")
+    And I should see t("required_to_save_changes")
+    And I should see t("unregister")
+    And I should see button t("delete_my_account")
+
+
+
+

--- a/features/edit_business_category.feature
+++ b/features/edit_business_category.feature
@@ -37,7 +37,7 @@ Feature: As an admin
     Then I should see "Redigerar: dog crooning"
     And I fill in "Category Name" with ""
     And I click on "Save"
-    Then I should see translated error activerecord.models.attributes.business_category.name errors.messages.blank
+    Then I should see translated error activerecord.attributes.business_category.name errors.messages.blank
 
   Scenario: A non-admin user cannot edit business categories
     Given I am logged in as "applicant_1@random.com"

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -15,87 +15,84 @@ Feature: As a registered user
       | Emma       | emma@random.com      | 5562252998     | Godkänd |
       | Lars       | lars-user@random.com | 2120000142     | pending |
 
+
   Scenario: Logging in
     Given I am on the "landing" page
-    Then I should see "Logga in"
-    When I click on "Logga in" link
+    Then I should see t("log_in")
+    When I click on t("log_in") link
     Then I should be on "login" page
-    When I fill in "Email" with "emma@random.com"
-    And I fill in "Password" with "password"
-    And I click on "Logga in" button
+    When I fill in t("activerecord.attributes.user.email") with "emma@random.com"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I click on t("log_in") button
     Then I should see t("devise.sessions.signed_in")
 
   Scenario: Not proper e-mail
     Given I am on the "login" page
-    When I fill in "Email" with "emmarandom.com"
-    And I fill in "Password" with "password"
-    And I click on "Logga in" button
+    When I fill in t("activerecord.attributes.user.email") with "emma@random"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I click on t("log_in") button
     Then I should see t("devise.failure.invalid")
 
   Scenario: No input of email
     Given I am on the "login" page
-    When I leave the "Password" field empty
-    And I click on "Logga in" button
+    When I leave the t("activerecord.attributes.user.password") field empty
+    And I click on t("log_in") button
     Then I should see t("devise.failure.invalid")
 
   Scenario: No input of password
     Given I am on the "login" page
-    When I leave the "Password" field empty
-    And I click on "Logga in" button
+    When I leave the t("activerecord.attributes.user.password") field empty
+    And I click on t("log_in") button
     Then I should see t("devise.failure.invalid")
 
   Scenario: Not registered user
     Given I am on the "login" page
-    When I fill in "Email" with "anna@random.com"
-    And I fill in "Password" with "password"
-    And I click on "Logga in" button
+    When I fill in t("activerecord.attributes.user.email") with "anna@random.com"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I click on t("log_in") button
     Then I should see t("devise.failure.invalid")
 
   Scenario: Not accessing protected page
     Given I am on the "login" page
-    When I fill in "Email" with "anna@random.com"
-    And I fill in "Password" with "password"
-    And I click on "Logga in" button
+    When I fill in t("activerecord.attributes.user.email") with "anna@random.com"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I click on t("log_in") button
     Then I should see t("devise.failure.invalid")
     When I fail to visit the "applications index" page
-    Then I should see "Du har inte behörighet att göra detta."
+    Then I should see t("errors.not_permitted")
     And I should be on "landing" page
 
   Scenario: Logging in as admin
     Given I am on the "landing" page
-    Then I should see "Logga in"
-    When I click on "Logga in" link
+    Then I should see t("log_in")
+    When I click on t("log_in") link
     Then I should be on "login" page
-    When I fill in "Email" with "arne@random.com"
-    And I fill in "Password" with "password"
-    And I click on "Logga in" button
+    When I fill in t("activerecord.attributes.user.email") with "arne@random.com"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I click on t("log_in") button
     Then I should see t("devise.sessions.signed_in")
-    And I should see "Admin:"
-    And I should not see "Välkommen"
-    And I should not see "Hej, kul att du är intresserad"
+    And I should see t("info.logged_in_as_admin")
+
 
   Scenario: Logging in as a member
     Given I am on the "landing" page
-    Then I should see "Logga in"
-    When I click on "Logga in" link
+    Then I should see t("log_in")
+    When I click on t("log_in") link
     Then I should be on "login" page
-    When I fill in "Email" with "emma@random.com"
-    And I fill in "Password" with "password"
-    And I click on "Logga in" button
-    Then I should see "Välkommen"
+    When I fill in t("activerecord.attributes.user.email") with "emma@random.com"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I click on t("log_in") button
     And I should be on "member instructions" page
-    And I should not see "Admin:"
-    And I should not see "Hej, kul att du är intresserad"
+    And I should not see t("info.logged_in_as_admin")
+
 
   Scenario: Logging in as a user
     Given I am on the "landing" page
-    Then I should see "Logga in"
-    When I click on "Logga in" link
+    Then I should see t("log_in")
+    When I click on t("log_in") link
     Then I should be on "login" page
-    When I fill in "Email" with "lars-user@random.com"
-    And I fill in "Password" with "password"
-    And I click on "Logga in" button
-    Then I should not see "Välkommen"
+    When I fill in t("activerecord.attributes.user.email") with "lars-user@random.com"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I click on t("log_in") button
     And I should be on "user instructions" page
-    And I should not see "Admin:"
-    And I should see "Hej, kul att du är intresserad"
+    And I should not see t("info.logged_in_as_admin")

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -18,45 +18,45 @@ Feature: As a registered user
 
   Scenario: Logging in
     Given I am on the "landing" page
-    Then I should see t("log_in")
-    When I click on t("log_in") link
+    Then I should see t("devise.sessions.new.log_in")
+    When I click on t("devise.sessions.new.log_in") link
     Then I should be on "login" page
     When I fill in t("activerecord.attributes.user.email") with "emma@random.com"
     And I fill in t("activerecord.attributes.user.password") with "password"
-    And I click on t("log_in") button
+    And I click on t("devise.sessions.new.log_in") button
     Then I should see t("devise.sessions.signed_in")
 
   Scenario: Not proper e-mail
     Given I am on the "login" page
     When I fill in t("activerecord.attributes.user.email") with "emma@random"
     And I fill in t("activerecord.attributes.user.password") with "password"
-    And I click on t("log_in") button
+    And I click on t("devise.sessions.new.log_in") button
     Then I should see t("devise.failure.invalid")
 
   Scenario: No input of email
     Given I am on the "login" page
     When I leave the t("activerecord.attributes.user.password") field empty
-    And I click on t("log_in") button
+    And I click on t("devise.sessions.new.log_in") button
     Then I should see t("devise.failure.invalid")
 
   Scenario: No input of password
     Given I am on the "login" page
     When I leave the t("activerecord.attributes.user.password") field empty
-    And I click on t("log_in") button
+    And I click on t("devise.sessions.new.log_in") button
     Then I should see t("devise.failure.invalid")
 
   Scenario: Not registered user
     Given I am on the "login" page
     When I fill in t("activerecord.attributes.user.email") with "anna@random.com"
     And I fill in t("activerecord.attributes.user.password") with "password"
-    And I click on t("log_in") button
+    And I click on t("devise.sessions.new.log_in") button
     Then I should see t("devise.failure.invalid")
 
   Scenario: Not accessing protected page
     Given I am on the "login" page
     When I fill in t("activerecord.attributes.user.email") with "anna@random.com"
     And I fill in t("activerecord.attributes.user.password") with "password"
-    And I click on t("log_in") button
+    And I click on t("devise.sessions.new.log_in") button
     Then I should see t("devise.failure.invalid")
     When I fail to visit the "applications index" page
     Then I should see t("errors.not_permitted")
@@ -64,35 +64,35 @@ Feature: As a registered user
 
   Scenario: Logging in as admin
     Given I am on the "landing" page
-    Then I should see t("log_in")
-    When I click on t("log_in") link
+    Then I should see t("devise.sessions.new.log_in")
+    When I click on t("devise.sessions.new.log_in") link
     Then I should be on "login" page
     When I fill in t("activerecord.attributes.user.email") with "arne@random.com"
     And I fill in t("activerecord.attributes.user.password") with "password"
-    And I click on t("log_in") button
+    And I click on t("devise.sessions.new.log_in") button
     Then I should see t("devise.sessions.signed_in")
     And I should see t("info.logged_in_as_admin")
 
 
   Scenario: Logging in as a member
     Given I am on the "landing" page
-    Then I should see t("log_in")
-    When I click on t("log_in") link
+    Then I should see t("devise.sessions.new.log_in")
+    When I click on t("devise.sessions.new.log_in") link
     Then I should be on "login" page
     When I fill in t("activerecord.attributes.user.email") with "emma@random.com"
     And I fill in t("activerecord.attributes.user.password") with "password"
-    And I click on t("log_in") button
+    And I click on t("devise.sessions.new.log_in") button
     And I should be on "member instructions" page
     And I should not see t("info.logged_in_as_admin")
 
 
   Scenario: Logging in as a user
     Given I am on the "landing" page
-    Then I should see t("log_in")
-    When I click on t("log_in") link
+    Then I should see t("devise.sessions.new.log_in")
+    When I click on t("devise.sessions.new.log_in") link
     Then I should be on "login" page
     When I fill in t("activerecord.attributes.user.email") with "lars-user@random.com"
     And I fill in t("activerecord.attributes.user.password") with "password"
-    And I click on t("log_in") button
+    And I click on t("devise.sessions.new.log_in") button
     And I should be on "user instructions" page
     And I should not see t("info.logged_in_as_admin")

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -1,8 +1,7 @@
-
-
 Then(/^I should be on the landing page$/) do
   expect(current_path).to eq root_path
 end
+
 
 And(/^I should see "([^"]*)"$/) do |content|
   expect(page).to have_content content
@@ -24,6 +23,10 @@ And(/^I should see t\("([^"]*)"\)$/) do |content|
   expect(page).to have_content i18n_content(content)
 end
 
+And(/^I should not see t\("([^"]*)"\)$/) do |content|
+  expect(page).not_to have_content i18n_content(content)
+end
+
 And(/^I should see t\("([^"]*)", locale: :(.*)\)$/) do |content, l|
   expect(page).to have_content i18n_content(content, l)
 end
@@ -36,18 +39,58 @@ And(/^I should see t\("([^"]*)"\), locale: :sv$/) do |content|
   expect(page).to have_content i18n_content(content)
 end
 
+And(/^I should not see t\("([^"]*)"\), locale: :sv$/) do |content|
+  expect(page).not_to have_content i18n_content(content)
+end
+
 And(/^I should see t\("([^"]*)", ([^:]*): ([^)]*)\), locale: :(.*)\)$/) do |content, key, value, l|
   expect(page).to have_content I18n.t("#{content}", key.to_sym => value, locale: l.to_sym)
+end
+
+And(/^I should not see t\("([^"]*)", ([^:]*): ([^)]*)\), locale: :(.*)\)$/) do |content, key, value, l|
+  expect(page).not_to have_content I18n.t("#{content}", key.to_sym => value, locale: l.to_sym)
 end
 
 And(/^I should see t\("([^"]*)", ([^:]*): (\d+)\), locale: :(.*)$/) do |content, key, value, locale|
   expect(page).to have_content I18n.t("#{content}", key.to_sym => value, locale: locale.to_sym)
 end
 
+And(/^I should not see t\("([^"]*)", ([^:]*): (\d+)\), locale: :(.*)$/) do |content, key, value, locale|
+  expect(page).not_to have_content I18n.t("#{content}", key.to_sym => value, locale: locale.to_sym)
+end
+
+And(/^I should see button "([^"]*)"$/) do |button|
+  expect(page).to have_button button
+end
+
 And(/^I should not see button "([^"]*)"$/) do |button|
   expect(page).not_to have_button button
 end
 
+And(/^I should see button t\("([^"]*)"\)$/) do |button|
+  expect(page).to have_button i18n_content(button)
+end
+
+And(/^I should not see button t\("([^"]*)"\)$/) do |button|
+  expect(page).not_to have_button i18n_content(button)
+end
+
+
+And(/^I should see "([^"]*)" link$/) do |link_label|
+  expect(page).to have_link link_label
+end
+
+And(/^I should see t\("([^"]*)"\) link$/) do |link_label|
+  expect(page).to have_link i18n_content(link_label)
+end
+
+And(/^I should not see "([^"]*)" link$/) do |link_label|
+  expect(page).not_to have_link link_label
+end
+
+And(/^I should not see t\("([^"]*)"\) link$/) do |link_label|
+  expect(page).not_to have_link i18n_content(link_label)
+end
 
 
 Then(/^I should be on "([^"]*)" page$/) do |page|
@@ -104,6 +147,14 @@ And(/^the field "([^"]*)" should not have a required field indicator$/) do |labe
   expect(page.find('label', text: label_text)[:class]).not_to have_css 'required'
 end
 
+Then(/^the field t\("([^"]*)"\) should have a required field indicator$/) do |label_text|
+  expect(page.find('label', text: i18n_content(label_text))[:class].include?('required')).to be true
+end
+
+And(/^the field t\("([^"]*)"\) should not have a required field indicator$/) do |label_text|
+  expect(page.find('label', text: i18n_content(label_text))[:class]).not_to have_css 'required'
+end
+
 Then(/^I should see (\d+) (.*?) rows$/) do |n, css_class_name|
   n = n.to_i
   expect(page).to have_selector(".#{css_class_name}", count: n)
@@ -118,8 +169,10 @@ end
 Then(/^I should see translated error (.*) (.*)$/) do |model_attribute, error|
   expect(page).to have_content("#{i18n_content(model_attribute)} #{i18n_content(error)}")
 end
-
-def i18n_content(content, locale='sv')
-  I18n.t(content, locale: locale.to_sym)
+Then(/^I should see t\("([^"]*)", member_full_name: '([^']*)'\)$/) do |i18n_key, name_value|
+ expect(page).to have_content(I18n.t(i18n_key, member_full_name: name_value))
 end
 
+And(/^I should see t\("([^"]*)", filename: '([^']*)'\)$/) do |i18n_key, filename_value|
+  expect(page).to have_content(I18n.t(i18n_key, filename: filename_value))
+end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -47,6 +47,10 @@ When(/^I leave the "([^"]*)" field empty$/) do |field|
   fill_in field, with: nil
 end
 
+When(/^I leave the t\("([^"]*)"\) field empty$/) do |field|
+  fill_in i18n_content(field), with: nil
+end
+
 And(/^I click the "([^"]*)" action for the row with "([^"]*)"$/) do |action, row_content|
   find(:xpath, "//tr[contains(.,'#{row_content}')]/td/a", :text => "#{action}").click
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -3,11 +3,15 @@ And(/^I click on "([^"]*)"$/) do |element|
 end
 
 And(/^I click on t\("([^"]*)"\)$/) do |element|
-  click_link_or_button I18n.t("#{element}")
+  click_link_or_button i18n_content("#{element}")
 end
 
 And(/^I fill in "([^"]*)" with "([^"]*)"$/) do |field, value|
   fill_in field, with: value
+end
+
+And(/^I fill in t\("([^"]*)"\) with "([^"]*)"$/) do |field, value|
+  fill_in i18n_content(field), with: value
 end
 
 When(/^I fill in the form with data :$/) do |table|
@@ -15,6 +19,18 @@ When(/^I fill in the form with data :$/) do |table|
   data.each do |label, value|
     unless value.empty?
       fill_in label, with: value
+    end
+  end
+end
+
+When(/^I fill in the translated form with data:$/) do |table|
+  data = table.hashes.first
+  data.each do |label, value|
+    data = table.hashes.first
+    data.each do |label, value|
+      unless value.empty?
+        fill_in i18n_content("#{label}"), with: value
+      end
     end
   end
 end
@@ -31,15 +47,26 @@ When(/^I leave the "([^"]*)" field empty$/) do |field|
   fill_in field, with: nil
 end
 
-And(/^I click the "([^"]*)" action for the row with "([^"]*)"$/) do |action, row_content |
+And(/^I click the "([^"]*)" action for the row with "([^"]*)"$/) do |action, row_content|
   find(:xpath, "//tr[contains(.,'#{row_content}')]/td/a", :text => "#{action}").click
 end
 
+And(/^I click the t\("([^"]*)"\) action for the row with "([^"]*)"$/) do |action, row_content|
+  find(:xpath, "//tr[contains(.,'#{row_content}')]/td/a", :text => "#{i18n_content(action)}").click
+end
 
 When(/^I click on "([^"]*)" link$/) do |element|
   click_link element
 end
 
+And(/^I click on t\("([^"]*)"\) link$/) do |element|
+  click_link i18n_content("#{element}")
+end
+
 And(/^I click on "([^"]*)" button$/) do |element|
   click_button element
+end
+
+And(/^I click on t\("([^"]*)"\) button$/) do |element|
+  click_button i18n_content("#{element}")
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -26,14 +26,12 @@ end
 When(/^I fill in the translated form with data:$/) do |table|
   data = table.hashes.first
   data.each do |label, value|
-    data = table.hashes.first
-    data.each do |label, value|
-      unless value.empty?
-        fill_in i18n_content("#{label}"), with: value
-      end
+    unless value.empty?
+      fill_in i18n_content("#{label}"), with: value
     end
   end
 end
+
 
 When(/^I set "([^"]*)" to "([^"]*)"$/) do |list, option|
   select option, from: list

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -29,6 +29,12 @@ Given(/^I am on the "([^"]*)" page$/) do |page|
       path = information_path
     when 'member instructions'
       path = information_path
+    when 'new password'
+      path = new_user_password_path
+    when 'register a new user'
+      path = new_user_registration_path
+    when 'edit registration for a user'
+      path = edit_user_registration_path
     else
       path = 'no path set'
   end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -31,7 +31,7 @@ Given(/^I am on the "([^"]*)" page$/) do |page|
       path = information_path
     when 'new password'
       path = new_user_password_path
-    when 'register a new user'
+    when 'register as a new user'
       path = new_user_registration_path
     when 'edit registration for a user'
       path = edit_user_registration_path

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -16,3 +16,7 @@ Cucumber::Rails::Database.javascript_strategy = :truncation
 Warden.test_mode!
 World Warden::Test::Helpers
 After { Warden.test_reset! }
+
+def i18n_content(content, locale='sv')
+  I18n.t(content, locale: locale.to_sym)
+end

--- a/features/view-site-in-lang-i18n-l10n.feature
+++ b/features/view-site-in-lang-i18n-l10n.feature
@@ -10,7 +10,7 @@ Feature: As a visitor
 
   Scenario: Default language is Swedish
     Given I am on the "all companies" page
-    Then I should see "Hitta H-märkt företag"
+    Then I should see t("companies.index.title")
     And I should not see "Swedish flag" image
     And I should see "English flag" image
     And I should see t("theme_copyright", locale: :sv)
@@ -20,7 +20,7 @@ Feature: As a visitor
     Given I am on the "all companies" page
     When I click on "change-lang-to-english"
     When I click on "change-lang-to-svenska"
-    Then I should see "Hitta H-märkt företag"
+    Then I should see t("companies.index.title")
     And I should not see "Swedish flag" image
     And I should see "English flag" image
     And I should see t("theme_copyright", locale: :sv)


### PR DESCRIPTION
PT Story:  **Site is multi-lingual: Swedish=primary, then English**
https://www.pivotaltracker.com/story/show/133316647

Now that the I18n infrastructure is in place, I'm  going to try to do the remaining I18n work in chunks so that I don't end up with one giant PR. :-)   This is the first one.

Changes proposed in this pull request:
1.  added to the locale files (they are still WIP, but should be checked for grammar, etc.)
2. I18n for devise views and login  (cannot test the `edit password` view because that requires setting up email and tokens -- that page is only reached after a user clicks on a link in an email sent to them)
3. added to steps files to support I18n

Ready for review:
@thesuss @Irex777 
