### PR TITLE
Sprint3 cleanup model associations

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -10,7 +10,7 @@ class CompaniesController < ApplicationController
 
 
   def show
-    @categories = @company.categories
+    @categories = @company.business_categories
   end
 
 

--- a/app/helpers/companies_helper.rb
+++ b/app/helpers/companies_helper.rb
@@ -4,9 +4,18 @@ module CompaniesHelper
     !company.nil? && !company.name.nil? && !company.name.empty? &&
       !company.region.nil? && !company.region.empty?
   end
-  def list_categories company
-    if company.categories.any?
-      company.categories.last.name
+
+  def last_category_name company
+    if company.business_categories.any?
+      company.business_categories.last.name
     end
+
+  end
+
+  def list_categories company
+    if company.business_categories.any?
+      company.business_categories.order(:name).map(&:name).join(" ")
+    end
+
   end
 end

--- a/app/helpers/companies_helper.rb
+++ b/app/helpers/companies_helper.rb
@@ -2,20 +2,18 @@ module CompaniesHelper
 
   def company_complete? company
     !company.nil? && !company.name.nil? && !company.name.empty? &&
-      !company.region.nil? && !company.region.empty?
+        !company.region.nil? && !company.region.empty?
   end
+
 
   def last_category_name company
-    if company.business_categories.any?
-      company.business_categories.last.name
-    end
-
+    company.business_categories.any? ? company.business_categories.last.name : ''
   end
+
 
   def list_categories company
     if company.business_categories.any?
       company.business_categories.order(:name).map(&:name).join(" ")
     end
-
   end
 end

--- a/app/models/business_category.rb
+++ b/app/models/business_category.rb
@@ -1,3 +1,6 @@
 class BusinessCategory < ApplicationRecord
   validates_presence_of :name
+
+  has_and_belongs_to_many :membership_applications
+  has_many :companies, through: :membership_applications
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -8,7 +8,9 @@ class Company < ApplicationRecord
   validates_format_of :email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: [:create, :update]
   validate :swedish_organisationsnummer
 
-  has_and_belongs_to_many :business_categories
+  has_many :business_categories, through: :membership_applications
+
+  has_many :membership_applications
 
 
   def categories

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -12,15 +12,4 @@ class Company < ApplicationRecord
 
   has_many :membership_applications
 
-
-  def categories
-    cats = []
-
-    MembershipApplication.where(company_number: company_number).find_each do | employee |
-      cats << employee.business_categories.to_ary
-    end
-
-    cats.flatten.uniq{ |c1| c1.id }
-  end
-
 end

--- a/app/views/business_categories/_as_list.html.haml
+++ b/app/views/business_categories/_as_list.html.haml
@@ -1,4 +1,4 @@
 .post-category
   %ul.post-categories
-    - @company.categories.each do | business_category |
+    - @company.business_categories.each do | business_category |
       %li= business_category.name

--- a/app/views/business_categories/_as_list.html.haml
+++ b/app/views/business_categories/_as_list.html.haml
@@ -1,4 +1,4 @@
 .post-category
   %ul.post-categories
-    - @company.business_categories.each do | business_category |
+    - @company.business_categories.distinct.each do | business_category |
       %li= business_category.name

--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -29,7 +29,7 @@
       - @companies.each do |company|
         - if company_complete? company
           %tr.company
-            %td= list_categories company
+            %td= last_category_name company
             %td= link_to company.name, company
             %td= company.region
             - if current_user.try(:admin)

--- a/db/migrate/20161218040617_drop_table_business_categories_companies.rb
+++ b/db/migrate/20161218040617_drop_table_business_categories_companies.rb
@@ -1,0 +1,5 @@
+class DropTableBusinessCategoriesCompanies < ActiveRecord::Migration[5.0]
+  def change
+    drop_join_table :business_categories, :companies
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161206020021) do
+ActiveRecord::Schema.define(version: 20161218040617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,13 +20,6 @@ ActiveRecord::Schema.define(version: 20161206020021) do
     t.string   "description"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
-  end
-
-  create_table "business_categories_companies", force: :cascade do |t|
-    t.integer "company_id"
-    t.integer "business_category_id"
-    t.index ["business_category_id"], name: "index_on_co_categories", using: :btree
-    t.index ["company_id"], name: "index_on_companies", using: :btree
   end
 
   create_table "business_categories_membership_applications", force: :cascade do |t|

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -16,8 +16,8 @@ Feature: As a visitor,
 
     And the following applications exist:
       | first_name | user_email          | company_number | status   | category_name |
-      | Emma       | emma@happymutts.com | 5560360793     | Accepted | Groomer       |
-      | Anna       | a@happymutts.com    | 2120000142     | Accepted | Groomer       |
+      | Emma       | emma@happymutts.com | 5560360793     | Godkänd | Groomer       |
+      | Anna       | a@happymutts.com    | 2120000142     | Godkänd | Groomer       |
 
     And the following business categories exist
       | name         |

--- a/spec/helpers/companies_helper_spec.rb
+++ b/spec/helpers/companies_helper_spec.rb
@@ -7,41 +7,65 @@ RSpec.describe CompaniesHelper, type: :helper do
       company = nil
       expect(helper.company_complete?(company)).to eq false
     end
+
     it 'returns false if company name is nil' do
       company = FactoryGirl.create(:company, name: nil)
       expect(helper.company_complete?(company)).to eq false
     end
+
     it 'returns false if company region is nil' do
       company = FactoryGirl.create(:company, region: nil)
       expect(helper.company_complete?(company)).to eq false
     end
+
     it 'returns false is company name or region is empty string' do
       company = FactoryGirl.create(:company, name: '')
       expect(helper.company_complete?(company)).to eq false
-
     end
+
     it 'returns true if company name and region are non-empty string' do
       company = FactoryGirl.create(:company)
       expect(helper.company_complete?(company)).to eq true
     end
+
   end
 
-  describe '#list_companies' do
-    it 'returns a companys categories' do
-       FactoryGirl.create(:membership_application,
-                          company_number: 5562252998,
-                          category_name: 'Träning')
-      company = FactoryGirl.create(:company,
-                                    company_number: 5562252998)
-      expect(helper.list_categories(company)).to eq 'Träning'
+  describe 'companies' do
+
+    it '#last_category_name' do
+      Company.delete_all
+      MembershipApplication.delete_all
+      User.delete_all
+      company = FactoryGirl.create(:company, company_number: 5562252998)
+
+      employee1 = create(:user, email: 'emp1@happymutts.com')
+      employee2 = create(:user, email: 'emp2@happymutts.com')
+      employee3 = create(:user, email: 'emp3@happymutts.com')
+
+      create(:membership_application, user: employee1, status: 'Godkänd', num_categories: 1, category_name: 'cat1', company_number: '5562252998')
+      create(:membership_application, user: employee2, status: 'Godkänd', num_categories: 1, category_name: 'cat2', company_number: '5562252998')
+      create(:membership_application, user: employee3, status: 'Godkänd', num_categories: 1, category_name: 'cat3', company_number: '5562252998')
+
+      expect(helper.last_category_name(company)).to eq 'cat3'
+
     end
-    it 'returns correct categories' do
-      FactoryGirl.create(:membership_application,
-                         company_number: 5562252998,
-                         category_name: 'Whatever')
-      company = FactoryGirl.create(:company,
-                                   company_number: 5562252998)
-      expect(helper.list_categories(company)).not_to eq 'Träning'
+
+    it '#list_categories' do
+      Company.delete_all
+      MembershipApplication.delete_all
+      User.delete_all
+      company = FactoryGirl.create(:company, company_number: 5562252998)
+
+      employee1 = create(:user, email: 'emp1@happymutts.com')
+      employee2 = create(:user, email: 'emp2@happymutts.com')
+      employee3 = create(:user, email: 'emp3@happymutts.com')
+
+      create(:membership_application, user: employee1, status: 'Godkänd', num_categories: 1, category_name: 'cat1', company_number: '5562252998')
+      create(:membership_application, user: employee2, status: 'Godkänd', num_categories: 1, category_name: 'cat2', company_number: '5562252998')
+      create(:membership_application, user: employee3, status: 'Godkänd', num_categories: 1, category_name: 'cat3', company_number: '5562252998')
+
+      expect(helper.list_categories(company)).to eq 'cat1 cat2 cat3'
+      expect(helper.list_categories(company)).not_to include 'Träning'
     end
   end
 end

--- a/spec/helpers/companies_helper_spec.rb
+++ b/spec/helpers/companies_helper_spec.rb
@@ -1,59 +1,63 @@
 require 'rails_helper'
 
 RSpec.describe CompaniesHelper, type: :helper do
+  let(:company) { create(:company) }
 
   describe '#company_complete?' do
     it 'returns false if company is nil' do
-      company = nil
-      expect(helper.company_complete?(company)).to eq false
+      expect(helper.company_complete?(nil)).to eq false
     end
 
     it 'returns false if company name is nil' do
-      company = FactoryGirl.create(:company, name: nil)
+      company.name = nil
       expect(helper.company_complete?(company)).to eq false
     end
 
     it 'returns false if company region is nil' do
-      company = FactoryGirl.create(:company, region: nil)
+      company.region = nil
       expect(helper.company_complete?(company)).to eq false
     end
 
     it 'returns false is company name or region is empty string' do
-      company = FactoryGirl.create(:company, name: '')
+      company.name = ''
       expect(helper.company_complete?(company)).to eq false
     end
 
     it 'returns true if company name and region are non-empty string' do
-      company = FactoryGirl.create(:company)
       expect(helper.company_complete?(company)).to eq true
     end
 
   end
 
   describe 'companies' do
+    let(:employee1) { create(:user) }
+    let(:employee2) { create(:user) }
+    let(:employee3) { create(:user) }
+
+    let!(:ma1) { create(:membership_application, user: employee1,
+                        status: 'Godkänd', category_name: 'cat1',
+                        company_number: company.company_number) }
+    let!(:ma2) { create(:membership_application, user: employee2,
+                        status: 'Godkänd', category_name: 'cat2',
+                        company_number: company.company_number) }
+    let!(:ma3) { create(:membership_application, user: employee3,
+                        status: 'Godkänd', category_name: 'cat3',
+                        company_number: company.company_number) }
+
 
     before(:all) do
       Company.delete_all
       MembershipApplication.delete_all
       User.delete_all
-      company = FactoryGirl.create(:company, company_number: '5562252998')
-
-      employee1 = create(:user, email: 'emp1@happymutts.com')
-      employee2 = create(:user, email: 'emp2@happymutts.com')
-      employee3 = create(:user, email: 'emp3@happymutts.com')
-
-      create(:membership_application, user: employee1, status: 'Godkänd', num_categories: 1, category_name: 'cat1', company_number: '5562252998')
-      create(:membership_application, user: employee2, status: 'Godkänd', num_categories: 1, category_name: 'cat2', company_number: '5562252998')
-      create(:membership_application, user: employee3, status: 'Godkänd', num_categories: 1, category_name: 'cat3', company_number: '5562252998')
     end
 
     it '#last_category_name' do
-      expect(helper.last_category_name(Company.find_by_company_number('5562252998'))).to eq 'cat3'
+      expect(helper.last_category_name(company)).to eq 'cat3'
     end
 
     it '#list_categories' do
-      expect(helper.list_categories(Company.find_by_company_number('5562252998'))).to eq 'cat1 cat2 cat3'
-      expect(helper.list_categories(Company.find_by_company_number('5562252998'))).not_to include 'Träning'
+      expect(helper.list_categories(company)).to eq 'cat1 cat2 cat3'
+      expect(helper.list_categories(company)).not_to include 'Träning'
     end
   end
 end

--- a/spec/helpers/companies_helper_spec.rb
+++ b/spec/helpers/companies_helper_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe CompaniesHelper, type: :helper do
 
   describe 'companies' do
 
-    it '#last_category_name' do
+    before(:all) do
       Company.delete_all
       MembershipApplication.delete_all
       User.delete_all
-      company = FactoryGirl.create(:company, company_number: 5562252998)
+      company = FactoryGirl.create(:company, company_number: '5562252998')
 
       employee1 = create(:user, email: 'emp1@happymutts.com')
       employee2 = create(:user, email: 'emp2@happymutts.com')
@@ -45,27 +45,15 @@ RSpec.describe CompaniesHelper, type: :helper do
       create(:membership_application, user: employee1, status: 'Godkänd', num_categories: 1, category_name: 'cat1', company_number: '5562252998')
       create(:membership_application, user: employee2, status: 'Godkänd', num_categories: 1, category_name: 'cat2', company_number: '5562252998')
       create(:membership_application, user: employee3, status: 'Godkänd', num_categories: 1, category_name: 'cat3', company_number: '5562252998')
+    end
 
-      expect(helper.last_category_name(company)).to eq 'cat3'
-
+    it '#last_category_name' do
+      expect(helper.last_category_name(Company.find_by_company_number('5562252998'))).to eq 'cat3'
     end
 
     it '#list_categories' do
-      Company.delete_all
-      MembershipApplication.delete_all
-      User.delete_all
-      company = FactoryGirl.create(:company, company_number: 5562252998)
-
-      employee1 = create(:user, email: 'emp1@happymutts.com')
-      employee2 = create(:user, email: 'emp2@happymutts.com')
-      employee3 = create(:user, email: 'emp3@happymutts.com')
-
-      create(:membership_application, user: employee1, status: 'Godkänd', num_categories: 1, category_name: 'cat1', company_number: '5562252998')
-      create(:membership_application, user: employee2, status: 'Godkänd', num_categories: 1, category_name: 'cat2', company_number: '5562252998')
-      create(:membership_application, user: employee3, status: 'Godkänd', num_categories: 1, category_name: 'cat3', company_number: '5562252998')
-
-      expect(helper.list_categories(company)).to eq 'cat1 cat2 cat3'
-      expect(helper.list_categories(company)).not_to include 'Träning'
+      expect(helper.list_categories(Company.find_by_company_number('5562252998'))).to eq 'cat1 cat2 cat3'
+      expect(helper.list_categories(Company.find_by_company_number('5562252998'))).not_to include 'Träning'
     end
   end
 end

--- a/spec/models/business_category_spec.rb
+++ b/spec/models/business_category_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe BusinessCategory, type: :model do
     it { is_expected.to have_db_column :description }
   end
 
+  describe 'Associations' do
+    it { is_expected.to have_many(:companies).through(:membership_applications) }
+    it { is_expected.to have_and_belong_to_many(:membership_applications) }
+  end
+
   describe 'Validations' do
     it { is_expected.to validate_presence_of :name }
   end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -36,55 +36,47 @@ RSpec.describe Company, type: :model do
     it { is_expected.to have_many(:membership_applications) }
   end
 
+
   describe 'categories = all employee categories' do
 
-    it '3 employees, each with 1 unique category' do
+    before(:all) do
+      Company.delete_all
+      MembershipApplication.delete_all
+      User.delete_all
+
+      company = create(:company, company_number: '5562252998')
 
       employee1 = create(:user, email: 'emp1@happymutts.com')
       employee2 = create(:user, email: 'emp2@happymutts.com')
       employee3 = create(:user, email: 'emp3@happymutts.com')
 
-      create(:membership_application, user: employee1, num_categories: 1, category_name: 'cat1', company_number: '5562252998')
-      create(:membership_application, user: employee2, num_categories: 1, category_name: 'cat2', company_number: '5562252998')
-      create(:membership_application, user: employee3, num_categories: 1, category_name: 'cat3', company_number: '5562252998')
-
-      company = create(:company, company_number: '5562252998')
-
-      expect(company.categories.count).to eq 3
-      expect(company.categories.map { |c| c[:name] }).to contain_exactly('cat1', 'cat2', 'cat3')
-
     end
 
+    it '3 employees, each with 1 unique category' do
+      create(:membership_application, user: User.find_by_email('emp1@happymutts.com'), status: 'Godkänd', num_categories: 1, category_name: 'cat1', company_number: '5562252998')
+      create(:membership_application, user: User.find_by_email('emp2@happymutts.com'), status: 'Godkänd', num_categories: 1, category_name: 'cat2', company_number: '5562252998')
+      create(:membership_application, user: User.find_by_email('emp3@happymutts.com'), status: 'Godkänd', num_categories: 1, category_name: 'cat3', company_number: '5562252998')
 
-    def has_single_category(category_holder, category)
-      category_holder.business_categories.delete_all
-      category_holder.business_categories << category
-      category_holder
+      expect(Company.find_by_company_number('5562252998').business_categories.count).to eq 3
+      expect(Company.find_by_company_number('5562252998').business_categories.map { |c| c[:name] }).to contain_exactly('cat1', 'cat2', 'cat3')
     end
-
 
     it '3 employees, each with the same category' do
 
-      company = create(:company, company_number: '5562252998')
+      category = create(:business_category, name: 'cat1')
 
-      employee1 = create(:user, email: 'emp1@happymutts.com')
-      employee2 = create(:user, email: 'emp2@happymutts.com')
-      employee3 = create(:user, email: 'emp3@happymutts.com')
+      m1 =create(:membership_application, user: User.find_by_email('emp1@happymutts.com'), num_categories: 0, status: 'Godkänd', company_number: '5562252998')
+      m1.business_categories << category
 
-      category = create(:business_category)
-      app1 = create(:membership_application, user: employee1, company_number: '5562252998')
-      app2 = create(:membership_application, user: employee2, company_number: '5562252998')
-      app3 = create(:membership_application, user: employee3, company_number: '5562252998')
+      m2 = create(:membership_application, user: User.find_by_email('emp2@happymutts.com'), num_categories: 0, status: 'Godkänd', company_number: '5562252998')
+      m2.business_categories << category
 
-      has_single_category(app1, category)
-      has_single_category(app2, category)
-      has_single_category(app3, category)
+      m3 = create(:membership_application, user: User.find_by_email('emp3@happymutts.com'), num_categories: 0, status: 'Godkänd', company_number: '5562252998')
+      m3.business_categories << category
 
-      expect(company.categories.count).to eq 1
-      expect(company.categories.map { |c| c[:name] }).to contain_exactly('BusinessCategoryName')
-
+      expect(Company.find_by_company_number('5562252998').business_categories.distinct.count).to eq 1
+      expect(Company.find_by_company_number('5562252998').business_categories.distinct.map { |c| c[:name] }).to contain_exactly('cat1')
     end
-
 
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -39,44 +39,58 @@ RSpec.describe Company, type: :model do
 
   describe 'categories = all employee categories' do
 
+    let(:company) { create(:company, company_number: '5562252998') }
+
+    let(:employee1) { create(:user) }
+    let(:employee2) { create(:user) }
+    let(:employee3) { create(:user) }
+
+    let(:cat1) { create(:business_category, name: 'cat1') }
+    let(:cat2) { create(:business_category, name: 'cat2') }
+    let(:cat3) { create(:business_category, name: 'cat3') }
+
+    let(:m1) do
+      create(:membership_application, user: employee1,
+             num_categories: 0, status: 'Godkänd',
+             company_number: company.company_number)
+    end
+    let(:m2) do
+      create(:membership_application, user: employee2,
+             num_categories: 0, status: 'Godkänd',
+             company_number: company.company_number)
+    end
+    let(:m3) do
+      create(:membership_application, user: employee3,
+             num_categories: 0, status: 'Godkänd',
+             company_number: company.company_number)
+    end
+
     before(:all) do
       Company.delete_all
       MembershipApplication.delete_all
       User.delete_all
-
-      company = create(:company, company_number: '5562252998')
-
-      employee1 = create(:user, email: 'emp1@happymutts.com')
-      employee2 = create(:user, email: 'emp2@happymutts.com')
-      employee3 = create(:user, email: 'emp3@happymutts.com')
-
     end
 
     it '3 employees, each with 1 unique category' do
-      create(:membership_application, user: User.find_by_email('emp1@happymutts.com'), status: 'Godkänd', num_categories: 1, category_name: 'cat1', company_number: '5562252998')
-      create(:membership_application, user: User.find_by_email('emp2@happymutts.com'), status: 'Godkänd', num_categories: 1, category_name: 'cat2', company_number: '5562252998')
-      create(:membership_application, user: User.find_by_email('emp3@happymutts.com'), status: 'Godkänd', num_categories: 1, category_name: 'cat3', company_number: '5562252998')
+      m1.business_categories << cat1
+      m2.business_categories << cat2
+      m3.business_categories << cat3
 
-      expect(Company.find_by_company_number('5562252998').business_categories.count).to eq 3
-      expect(Company.find_by_company_number('5562252998').business_categories.map { |c| c[:name] }).to contain_exactly('cat1', 'cat2', 'cat3')
+      expect(company.business_categories.count).to eq 3
+      expect(company.business_categories.map(&:name))
+          .to contain_exactly('cat1', 'cat2', 'cat3')
     end
 
     it '3 employees, each with the same category' do
+      m1.business_categories << cat1
+      m2.business_categories << cat1
+      m3.business_categories << cat1
 
-      category = create(:business_category, name: 'cat1')
-
-      m1 =create(:membership_application, user: User.find_by_email('emp1@happymutts.com'), num_categories: 0, status: 'Godkänd', company_number: '5562252998')
-      m1.business_categories << category
-
-      m2 = create(:membership_application, user: User.find_by_email('emp2@happymutts.com'), num_categories: 0, status: 'Godkänd', company_number: '5562252998')
-      m2.business_categories << category
-
-      m3 = create(:membership_application, user: User.find_by_email('emp3@happymutts.com'), num_categories: 0, status: 'Godkänd', company_number: '5562252998')
-      m3.business_categories << category
-
-      expect(Company.find_by_company_number('5562252998').business_categories.distinct.count).to eq 1
-      expect(Company.find_by_company_number('5562252998').business_categories.distinct.map { |c| c[:name] }).to contain_exactly('cat1')
+      expect(company.business_categories.distinct.count).to eq 1
+      expect(company.business_categories.count).to eq 3
+      expect(company.business_categories.distinct.map(&:name))
+          .to contain_exactly('cat1')
     end
-
   end
+
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe Company, type: :model do
   end
 
   describe 'Associations' do
-    it { is_expected.to have_and_belong_to_many :business_categories }
+    it { is_expected.to have_many(:business_categories).through(:membership_applications) }
+    it { is_expected.to have_many(:membership_applications) }
   end
 
   describe 'categories = all employee categories' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+
+  before(:all) do
+    BusinessCategory.delete_all
+    Company.delete_all
+    MembershipApplication.delete_all
+    User.delete_all
+  end
+
   describe 'Factory' do
     it 'has a valid factory' do
       expect(create(:user)).to be_valid
@@ -365,10 +373,9 @@ RSpec.describe User, type: :model do
     describe 'admin will get all Companies' do
       subject { create(:user, admin: true) }
       it do
-        create(:company, company_number: '5562252998')
+        create(:company, company_number: '0000000000')
         create(:company, company_number: '5560360793')
         create(:company, company_number: '2120000142')
-
         num_companies = Company.all.size
         expect(subject.companies.size).to eq(num_companies)
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,10 +9,12 @@ require 'paperclip/matchers'
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-  config.use_transactional_fixtures = true
+
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
+
   config.include Shoulda::Matchers::ActiveRecord, type: :model
   config.include FactoryGirl::Syntax::Methods
   config.include Paperclip::Shoulda::Matchers
@@ -22,6 +24,54 @@ RSpec.configure do |config|
       with.test_framework :rspec
       with.library :rails
     end
+  end
+
+
+  config.use_transactional_fixtures = false
+
+  config.before(:suite) do
+    if config.use_transactional_fixtures
+      raise(<<-MSG)
+        Delete line `config.use_transactional_fixtures = true` from rails_helper.rb
+        (or set it to false) to prevent uncommitted transactions being used in
+        JavaScript-dependent specs.
+
+        During testing, the app-under-test that the browser driver connects to
+        uses a different database connection to the database connection used by
+        the spec. The app's database connection would not be able to access
+        uncommitted transaction data setup over the spec's database connection.
+      MSG
+    end
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, :js => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each, type: :feature) do
+    # :rack_test driver's Rack app under test shares database connection
+    # with the specs, so continue to use transaction strategy for speed.
+    driver_shares_db_connection_with_specs = Capybara.current_driver == :rack_test
+
+    if !driver_shares_db_connection_with_specs
+      # Driver is probably for an external browser with an app
+      # under test that does *not* share a database connection with the
+      # specs, so use truncation strategy.
+      DatabaseCleaner.strategy = :truncation
+    end
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.append_after(:each) do
+    DatabaseCleaner.clean
   end
 
 end


### PR DESCRIPTION
PT Story: **List member companies of a certain category**
https://www.pivotaltracker.com/story/show/135684057
This is a task needed so that  PR #88 can be accomplished.  See the comments in that PR for some of the reasoning behind this PR.

Now that we've learned more about the business, we need to ensure that the associations between the models can be traversed efficiently, and we need to delete old associations and/or tables not being used.

Changes proposed in this pull request:
1.  delete db table no longer used: 'business_categories_companies'
2.  Company:
   -  add these associations:
````
has_many :business_categories, through: :membership_applications	 
has_many :membership_applications
````
  - replace `.categories` with  `.business_categories`
  - update spec
3. CompanyHelper
    - rename the method from `list_categories` to `last_category_name` to reflect what it really does
    - add method that returns a string with all of the categories, separated by a space
    - update spec
4. BusinessCategory
    - added these associations:
````
  has_and_belongs_to_many :membership_applications
  has_many :companies, through: :membership_applications
````
5. use db_cleaner transaction settings for Rspec

Ready for review:
@patmbolger 
