### PR TITLE
Removed transient vars from cmpy factory - PT #136527071

### DIFF
--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -9,23 +9,5 @@ FactoryGirl.define do
     city 'Hundborg'
     region 'D'
     website 'http://www.example.com'
-
-    transient do
-      num_categories 0
-      category_name 'Business Category'
-    end
-
-    after(:create) do |company, evaluator|
-
-      if evaluator.num_categories == 1
-        company.business_categories << create(:business_category, name: evaluator.category_name)
-      else
-        evaluator.num_categories.times do |cat_num|
-          company.business_categories << create(:business_category, name: "#{evaluator.category_name} #{cat_num + 1}")
-        end
-      end
-    end
-
-
   end
 end


### PR DESCRIPTION
PT Story: 
https://www.pivotaltracker.com/story/show/136527071


Changes proposed in this pull request:
Removed use of transient vars in company factory - these were meant to support creation of business categories associated with the company - however, there is no long a direct association between Comanpy and BusinessCategory.

Screenshots (Optional):


Ready for review:
@thesuss @weedySeaDragon 