### PR TITLE
I18n admin related pages (= the 'landing' page)

### DIFF
--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -1,14 +1,14 @@
 %header.entry-header
-  %h1.entry-title Admin: Alla inkomna ansökningar
+  %h1.entry-title= t('.title')
 .post-title-divider
   %span
 .entry-content
   %table
     %thead
       %tr
-        %th Namn
-        %th Org nr
-        %th Status
+        %th= t('.name')
+        %th= t('.org_nr')
+        %th= t('.status')
         %th
     %tbody
       - @membership_applications.each do | membership_application |
@@ -16,4 +16,4 @@
           %td= link_to "#{membership_application.first_name + ' ' + membership_application.last_name}", membership_application_path(membership_application.id)
           %td= membership_application.company_number
           %td= membership_application.status
-          %td= link_to 'Manage', membership_application_path(membership_application.id)
+          %td= link_to t('.manage'), membership_application_path(membership_application.id)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,10 +235,17 @@ en:
     view_company: View company
     list_all_companies: List all companies
 
+
   admin:
     index:
       title: 'Admin: All incoming applications'
+      name: *name
+      org_nr: *org_nr
+      status: *status
+      manage: *manage
+
     all_applications_received: All applications received
+
 
   devise:
     min_length: '(at least %{minimum_length} characters)'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,7 +120,7 @@ en:
       success: The application was updated.
       error: One or more problems prevented your application from being updated.
       enter_member_number: Please enter the member number and save.
-      
+
     show:
       title: Application from %{member_full_name}
       first_name: *first_name
@@ -133,7 +133,7 @@ en:
       with_categories: Categories
       delete: *delete
       confirm_are_you_sure: *are_you_sure_confirm
-      
+
     index:
       title: All incoming applications
       name: Name

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -234,10 +234,17 @@ sv:
     view_company: Visa företagssida
     list_all_companies: Lista alla företag
 
+
   admin:
     index:
       title: 'Admin: Alla inkomna ansökningar'
+      name: *name
+      org_nr: *org_nr
+      status: *status
+      manage: *manage
+
     all_applications_received: Alla inkomna ansökningar
+
 
   devise:
     min_length: '(minst %{minimum_length} tecken)'

--- a/features/approve-member.feature
+++ b/features/approve-member.feature
@@ -80,7 +80,7 @@ Feature: As an admin
     When I set "membership_application_status" to t("membership_applications.accepted")
     And I click on t("update")
     And I should be on the edit application page for "Emma"
-    And I should see "Var god ange medlemsnummer och spara."
+    And I should see t("membership_applications.update.enter_member_number")
     And I fill in t("membership_applications.show.membership_number") with "901"
     And I click on t("membership_applications.edit.submit_button_label")
     Then I should see t("membership_applications.update.success")

--- a/features/landing_page_for_admin.feature
+++ b/features/landing_page_for_admin.feature
@@ -16,25 +16,25 @@ Feature: As an Admin
   Scenario: After login, Admin sees new memberships on their landing page
     Given I am logged in as "admin@shf.se"
     When I am on the "landing" page
-    Then I should see "Alla inkomna ansökningar"
-    And I should see "Du är inloggad som admin"
+    Then I should see t("admin.index.title")
+    And I should see t("info.logged_in_as_admin")
 
   Scenario: After login, User sees instructions about applying for membership
     Given I am logged in as "hans@bowsers.com"
     When I am on the "landing" page
     Then I should not see "Alla inkomna ansökningar"
-    And I should not see "Du är inloggad som admin"
+    And I should not see t("info.logged_in_as_admin")
 
   Scenario: After login, Member sees instructions about using their badge, etc
     Given I am logged in as "emma@happymutts.se"
     When I am on the "landing" page
-    Then I should not see "Alla inkomna ansökningar"
-    And I should not see "Du är inloggad som admin"
+    Then I should not see t("admin.index.title")
+    And I should not see t("info.logged_in_as_admin")
 
 
   Scenario: Visitor does not see instructions
     Given I am Logged out
     When I am on the "landing" page
-    Then I should not see "Alla inkomna ansökningar"
-    And I should not see "Du är inloggad som admin"
+    Then I should not see t("admin.index.title")
+    And I should not see t("info.logged_in_as_admin")
 


### PR DESCRIPTION
PT Story: **Site is multi-lingual: Swedish=primary, then English**
https://www.pivotaltracker.com/story/show/133316647

Changes proposed in this pull request:
1.  added to locale files for the admin / index.html view
2. updated the feature files to t() the message that should be displayed 

Ready for review:
@thesuss @Irex777 
