### PR TITLE
i18n menus: locale entries

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -290,6 +290,78 @@ en:
         log_in_with: Log in with
 
 
+  #----------
+  # MENUS
+  #  This section will mostly parallel the structure of the actual menus.
+  #  For submenus:  create a key that represents the submenu, and then the
+  #   the first (sub-) entry under that key should be the text displayed for
+  #   that submenu. Use the key 'submenu_title:'  (This organization is a little different than the actual
+  #   menus; it has the extra key and the title for the submenu is under
+  #   the key for the section.)
+  menus:
+    skip_to_content: Skip to content
+    nav:
+      shf_main_site: &shf_main_site SHF main site
+      home: &home Home
+
+      visitor:
+        home: *home
+        brochure: Brochure
+        dog_owners:
+          submenu_title: For Dog Owners
+          about_us: &about_us About us
+          h_label: H Label
+          knowledge_bank: &knowledge_bank Knowledge bank
+          are_you_unsatisfied: 'Are you unsatisfied?'
+          become_supporter: Become a Supporter
+          being_dog_owners: Being Dog Owners
+        entrepreneurs:
+          submenu_title: Dog Company Entrepreneurs
+          about_us: *about_us
+          sign_up: Become a Member
+          be_h_labeled: Become H-labeled
+          member_criteria: Member Criteria
+          member_benefits: Member Benefits
+          quality_standards: Member Standards
+          knowledge_bank: *knowledge_bank
+        knowledge_bank:
+          submenu_title: *knowledge_bank
+          blogs: Blogs
+          books: Books
+          research: Research
+          pod: Podcasts
+          popular_science: Popular Science
+          video: Video
+        contact: Contact
+        find_dog_businesses: Find Dog Businesses
+
+      users:
+        my_application: &my_application My Application
+        apply_for_membership: Apply for Membership
+
+      members:
+        member_pages: Member pages
+        manage_company:
+          submenu_title: Manage my company
+          view_company: View Company
+          edit_company: Edit My Company
+        my_application: *my_application
+
+      admin:
+        shf_main_site: *shf_main_site
+        manage_applications: Manage Applications
+        categories:
+          submenu_title: Categories
+          list_categories: List Categories
+          new_category: New Category
+        companies:
+          submenu_title: Companies
+          list_companies: List Companies
+          new_company: New Company
+
+
+  #----------
+  # ERRORS
   errors:
     not_permitted: You do not have permission to do this.
     format: "%{attribute} %{message}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -391,7 +391,7 @@ en:
           become_supporter: Become a Supporter
           being_dog_owners: Being Dog Owners
         entrepreneurs:
-          submenu_title: Dog Company Entrepreneurs
+          submenu_title: Dog Company owners
           about_us: *about_us
           sign_up: Become a Member
           be_h_labeled: Become H-labeled
@@ -408,7 +408,7 @@ en:
           popular_science: Popular Science
           video: Video
         contact: Contact
-        find_dog_businesses: Find Dog Businesses
+        find_dog_businesses: Find Dog Company
 
       users:
         my_application: &my_application My Application

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -289,6 +289,78 @@ sv:
         log_in_with: Logga in med
 
 
+  #----------
+  # MENUS
+  #  This section will mostly parallel the structure of the actual menus.
+  #  For submenus:  create a key that represents the submenu, and then the
+  #   the first (sub-) entry under that key should be the text displayed for
+  #   that submenu. Use the key 'submenu_title:'  (This organization is a little different than the actual
+  #   menus; it has the extra key and the title for the submenu is under
+  #   the key for the section.)
+  menus:
+    skip_to_content: Gå direkt till innehållet
+    nav:
+      shf_main_site: &shf_main_site SHF-sajten
+      home: &home Hem
+
+      visitor:
+        home: *home
+        brochure: Broschyr
+        dog_owners:
+          submenu_title: Hundägare
+          about_us: &about_us Om oss
+          h_label: H-märket
+          knowledge_bank: &knowledge_bank Kunskapsbank
+          are_you_unsatisfied: 'Är du inte nöjd?'
+          become_supporter: Bli stödmedlem
+          being_dog_owners: Att vara hundägare
+        entrepreneurs:
+          submenu_title: Hundföretagare
+          about_us: *about_us
+          sign_up: Bli medlem
+          be_h_labeled: Bli H-märkt
+          member_criteria: Medlemskriterier
+          member_benefits: Medlemsförmåner
+          quality_standards: Kvalitetskontroll
+          knowledge_bank: *knowledge_bank
+        knowledge_bank:
+          submenu_title: *knowledge_bank
+          blogs: Bloggar
+          books: Böcker
+          research: Forskning
+          pod: Pod
+          popular_science: Populärvetenskap
+          video: Video
+        contact: Kontakt
+        find_dog_businesses: Hitta hundföretagare
+
+      users:
+        my_application: &my_application Min ansökan
+        apply_for_membership: Ansök om medlemsskap
+
+      members:
+        member_pages: Medlemssidor
+        manage_company:
+          submenu_title: Hantera företag
+          view_company: Visa företagssida
+          edit_company: Redigera företag
+        my_application: *my_application
+
+      admin:
+        shf_main_site: *shf_main_site
+        manage_applications: Hantera ansökningar
+        categories:
+          submenu_title: Kategorier
+          list_categories: Lista kategorier
+          new_category: Ny kategori
+        companies:
+          submenu_title: Företag
+          list_companies: Lista företag
+          new_company: Nytt företag
+
+
+  #----------
+  # ERRORS
   errors:
     not_permitted: Du har inte behörighet att göra detta.
     format: "%{attribute} %{message}"


### PR DESCRIPTION
PT Story: **Site is multi-lingual: Swedish=primary, then English**
https://www.pivotaltracker.com/story/show/133316647

These are entries for menus.  
I used Google Translate for the English entries, so they may need correction.

Now we can use them in the `views/application/` menu files and in the `features`

Changes proposed in this pull request:
1.  added a section in the locale files  for **menus**, added entries


Ready for review:
@thesuss 
