### PR TITLE
i18n: file uploads needed to t() the message for invalid file type

### DIFF
--- a/app/models/uploaded_file.rb
+++ b/app/models/uploaded_file.rb
@@ -13,5 +13,5 @@ class UploadedFile < ApplicationRecord
                                                                    'application/msword',
                                                                    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
                                                                    'application/vnd.ms-word.document.macroEnabled.12'],
-                                                    message: 'Sorry, this is not a file type you can upload.'}
+                                                    message: I18n.t('membership_applications.uploads.invalid_upload_type')}
 end

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -75,7 +75,7 @@ Feature: As an applicant
     And I am on the "edit my application" page
     When I choose a file named "tred.exe" to upload
     And I click on t("membership_applications.edit.submit_button_label")
-    Then I should see "Sorry, this is not a file type you can upload."
+    Then I should see t("membership_applications.uploads.invalid_upload_type")
     And I should not see "not-accepted.exe" uploaded for this membership application
 
 


### PR DESCRIPTION
PT Story: **Site is multi-lingual: Swedish=primary, then English**
https://www.pivotaltracker.com/story/show/133316647

Changes proposed in this pull request:
1.  use I18n.t for the invalid file type message in the model and feature
Ready for review:
@AgileVentures/shf-project-team 
