### PR TITLE
I18n run features with different locales

### DIFF
--- a/app/views/application/_required_fields.html.haml
+++ b/app/views/application/_required_fields.html.haml
@@ -1,3 +1,3 @@
 %p
   %span.required
-  Indikerar ett obligatoriskt fält
+  =t('is_required_field')

--- a/app/views/application/_required_fields.html.haml
+++ b/app/views/application/_required_fields.html.haml
@@ -1,3 +1,3 @@
 %p
   %span.required
-  =t('is_required_field')
+  = t('is_required_field')

--- a/app/views/application/_top.html.haml
+++ b/app/views/application/_top.html.haml
@@ -6,4 +6,4 @@
 - else
   #site-logo
     %p.admin
-      Du är inloggad som admin
+      =t('info.logged_in_as_admin')

--- a/app/views/application/_top.html.haml
+++ b/app/views/application/_top.html.haml
@@ -6,4 +6,4 @@
 - else
   #site-logo
     %p.admin
-      =t('info.logged_in_as_admin')
+      = t('info.logged_in_as_admin')

--- a/features/create_business_category.feature
+++ b/features/create_business_category.feature
@@ -15,7 +15,7 @@ Feature: As an admin
 
   Scenario Outline: Admin creates a new Business Category
     Given I am on the "business categories" page
-    And I click on "Skapa ny företagstyp (kategori)"
+    And I click on t("business_categories.new_business_category")
     When I fill in the translated form with data:
       | business_categories.form.category_name | business_categories.form.category_description |
       | <category_name>                        | <category_description>                        |
@@ -32,7 +32,7 @@ Feature: As an admin
 
   Scenario Outline: Create a new category - when things go wrong
     Given I am on the "business categories" page
-    And I click on "Skapa ny företagstyp (kategori)"
+    And I click on t("business_categories.new_business_category")
     When I fill in the translated form with data:
       | business_categories.form.category_name | business_categories.form.category_description |
       | <category_name>                        | <category_description>                        |
@@ -46,7 +46,7 @@ Feature: As an admin
 
   Scenario: Indicate required field
     Given I am on the "business categories" page
-    And I click on "Skapa ny företagstyp (kategori)"
+    And I click on t("business_categories.new_business_category")
     Then the field t("business_categories.form.category_name") should have a required field indicator
 
   Scenario: Listing Business Categories restricted for Non-admins

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -31,33 +31,33 @@ Feature: As a registered user
     When I fill in t("activerecord.attributes.user.email") with "emma@random"
     And I fill in t("activerecord.attributes.user.password") with "password"
     And I click on t("devise.sessions.new.log_in") button
-    Then I should see t("devise.failure.invalid")
+    Then I should see t("devise.failure.invalid", authentication_keys: 'Email')
 
   Scenario: No input of email
     Given I am on the "login" page
     When I leave the t("activerecord.attributes.user.password") field empty
     And I click on t("devise.sessions.new.log_in") button
-    Then I should see t("devise.failure.invalid")
+    Then I should see t("devise.failure.invalid", authentication_keys: 'Email')
 
   Scenario: No input of password
     Given I am on the "login" page
     When I leave the t("activerecord.attributes.user.password") field empty
     And I click on t("devise.sessions.new.log_in") button
-    Then I should see t("devise.failure.invalid")
+    Then I should see t("devise.failure.invalid", authentication_keys: 'Email')
 
   Scenario: Not registered user
     Given I am on the "login" page
     When I fill in t("activerecord.attributes.user.email") with "anna@random.com"
     And I fill in t("activerecord.attributes.user.password") with "password"
     And I click on t("devise.sessions.new.log_in") button
-    Then I should see t("devise.failure.invalid")
+    Then I should see t("devise.failure.invalid", authentication_keys: 'Email')
 
   Scenario: Not accessing protected page
     Given I am on the "login" page
     When I fill in t("activerecord.attributes.user.email") with "anna@random.com"
     And I fill in t("activerecord.attributes.user.password") with "password"
     And I click on t("devise.sessions.new.log_in") button
-    Then I should see t("devise.failure.invalid")
+    Then I should see t("devise.failure.invalid", authentication_keys: 'Email')
     When I fail to visit the "applications index" page
     Then I should see t("errors.not_permitted")
     And I should be on "landing" page

--- a/features/show_status_of_application.feature
+++ b/features/show_status_of_application.feature
@@ -5,15 +5,15 @@ Feature: As an Admin
 
   Background:
     Given the following users exists
-      | email                  | admin |
-      | din@mail.se            |       |
-      | min@mail.se            |       |
-      | admin@sgf.com          | true  |
+      | email         | admin |
+      | din@mail.se   |       |
+      | min@mail.se   |       |
+      | admin@sgf.com | true  |
 
     And the following applications exist:
       | company_number | user_email  | status   |
-      | 5562252998     | din@mail.se | Inlämnad  |
-      | 2120000142     | min@mail.se | Godkänd |
+      | 5562252998     | din@mail.se | Inlämnad |
+      | 2120000142     | min@mail.se | Godkänd  |
 
     And I am logged in as "admin@sgf.com"
 
@@ -22,5 +22,5 @@ Feature: As an Admin
     And I am on the list applications page
     Then I should see "2" applications
     And I should see t("membership_applications.index.status")
-    And I should see t("membership_applications.pending")
-    And I should see t("membership_applications.accepted")
+    And I should see "Inlämnad"
+    And I should see "Godkänd"

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -1,5 +1,12 @@
+
+# remove any leading locale path info
+def current_path_without_locale(path)
+  locale_pattern =  /^(\/)(en|sv)?(\/)?(.*)$/
+  path.gsub(locale_pattern, '\1\4')
+end
+
 Then(/^I should be on the landing page$/) do
-  expect(current_path).to eq root_path
+  expect(current_path_without_locale(current_path)).to eq root_path
 end
 
 And(/^I should see "([^"]*)"$/) do |content|
@@ -35,11 +42,11 @@ And(/^I should not see t\("([^"]*)", locale: :(.*)\)$/) do |content, l|
 end
 
 And(/^I should see t\("([^"]*)"\), locale: :sv$/) do |content|
-  expect(page).to have_content i18n_content(content)
+  expect(page).to have_content i18n_content(content, :sv)
 end
 
 And(/^I should not see t\("([^"]*)"\), locale: :sv$/) do |content|
-  expect(page).not_to have_content i18n_content(content)
+  expect(page).not_to have_content i18n_content(content, :sv)
 end
 
 And(/^I should see t\("([^"]*)", ([^:]*): ([^)]*)\), locale: :(.*)\)$/) do |content, key, value, l|
@@ -111,7 +118,7 @@ Then(/^I should be on "([^"]*)" page$/) do |page|
     when 'member instructions'
       path = information_path
   end
-  expect(current_path).to eq path
+  expect(current_path_without_locale(current_path)).to eq path
 end
 
 
@@ -136,12 +143,12 @@ end
 
 Then(/^I should be on the application page for "([^"]*)"$/) do |first_name|
   membership_application = MembershipApplication.find_by(first_name: first_name)
-  expect(current_path).to eq membership_application_path(membership_application)
+  expect(current_path_without_locale(current_path)).to eq membership_application_path(membership_application)
 end
 
 Then(/^I should be on the edit application page for "([^"]*)"$/) do |first_name|
   membership_application = MembershipApplication.find_by(first_name: first_name)
-  expect(current_path).to eq edit_membership_application_path(membership_application)
+  expect(current_path_without_locale(current_path)).to eq edit_membership_application_path(membership_application)
 end
 
 
@@ -173,7 +180,7 @@ end
 
 
 And(/^I should be on the applications page$/) do
-  expect(current_path).to eq membership_applications_path
+  expect(current_path_without_locale(current_path)).to eq membership_applications_path
 end
 
 Then(/^I should see translated error (.*) (.*)$/) do |model_attribute, error|
@@ -189,6 +196,24 @@ And(/^I should see t\("([^"]*)", filename: '([^']*)'\)$/) do |i18n_key, filename
 end
 
 
+And(/^I should see status line with status "([^"]*)" and date "([^"]*)"$/) do |status, date_string|
+  expect(page).to have_content("#{status} - #{date_string}")
+end
+
 And(/^I should see status line with status t\("([^"]*)"\) and date "([^"]*)"$/) do |status, date_string|
   expect(page).to have_content("#{i18n_content(status)} - #{date_string}")
+end
+
+And(/^I should see t\("([^"]*)", ([^:]*): (\d+)\)$/) do |content, key, number|
+  expect(page).to have_content I18n.t("#{content}", key.to_sym => number)
+end
+
+
+And(/^I should see t\("([^"]*)", ([^:]*): "([^"]*)"\)$/) do |content, key, value|
+  expect(page).to have_content I18n.t("#{content}", key.to_sym => value)
+end
+
+
+Then(/^I should see t\("([^"]*)", authentication_keys: '([^']*)'\)$/) do |error, auth_key|
+  expect(page).to have_content I18n.t("#{error}", authentication_keys: auth_key)
 end

--- a/features/step_definitions/business_category_steps.rb
+++ b/features/step_definitions/business_category_steps.rb
@@ -7,7 +7,7 @@ end
 
 And(/^I navigate to the business category edit page for "([^"]*)"$/) do |name|
   business_category = BusinessCategory.find_by(name: name)
-  visit edit_business_category_path(business_category)
+  visit path_with_locale(edit_business_category_path(business_category))
 end
 
 And(/^I select "([^"]*)" Category/) do |element|
@@ -16,5 +16,5 @@ end
 
 Given(/^I am on the business category "([^"]*)"$/) do |name|
   business_category = BusinessCategory.find_by(name: name)
-  visit business_category_path(business_category)
+  visit path_with_locale(business_category_path(business_category))
 end

--- a/features/step_definitions/company_steps.rb
+++ b/features/step_definitions/company_steps.rb
@@ -6,18 +6,17 @@ end
 
 And(/^I am the page for company number "([^"]*)"$/) do |company_number|
   company = Company.find_by_company_number(company_number)
-  visit company_path company
+  visit path_with_locale(company_path company)
 end
 
 When(/^I am on the edit company page for "([^"]*)"$/) do |company_number|
   company = Company.find_by_company_number(company_number)
-  visit edit_company_path company
+  visit path_with_locale(edit_company_path company)
 end
 
 Then(/^I can go to the company page for "([^"]*)"$/) do |company_number|
   company = Company.find_by_company_number(company_number)
-  visit edit_company_path company
-  expect(current_path).to eq edit_company_path(company)
+  visit path_with_locale(edit_company_path company)
 end
 
 And(/^the "([^"]*)" should go to "([^"]*)"$/) do |link, url|

--- a/features/step_definitions/i18n_steps.rb
+++ b/features/step_definitions/i18n_steps.rb
@@ -1,0 +1,3 @@
+And(/^I set the locale to "([^"]*)"$/) do | locale|
+  I18n.locale = locale
+end

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -21,14 +21,15 @@ end
 
 And(/^I navigate to the edit page for "([^"]*)"$/) do |first_name|
   membership_application = MembershipApplication.find_by(first_name: first_name)
-  visit edit_membership_application_path(membership_application)
+  visit path_with_locale(edit_membership_application_path(membership_application))
 end
 
 Given(/^I am on "([^"]*)" application page$/) do |first_name|
   membership = MembershipApplication.find_by(first_name: first_name)
-  visit membership_application_path(membership)
+  visit path_with_locale(membership_application_path(membership))
 end
 
 Given(/^I am on the list applications page$/) do
-  visit membership_applications_path
+  locale_path = path_with_locale(membership_applications_path)
+  visit locale_path
 end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -23,8 +23,6 @@ Given(/^I am on the "([^"]*)" page$/) do |page|
           path = edit_company_path(user.membership_applications.last.company)
         end
       end
-    when 'static workgroups'
-      path = page_path('arbetsgrupper')
     when 'user instructions'
       path = information_path
     when 'member instructions'
@@ -38,7 +36,7 @@ Given(/^I am on the "([^"]*)" page$/) do |page|
     else
       path = 'no path set'
   end
-  visit path
+  visit path_with_locale(path)
 end
 
 
@@ -78,7 +76,7 @@ And(/^I am on the "([^"]*)" page for "([^"]*)"$/) do |page, user_email|
     else
       path = 'no path set'
   end
-  visit path
+  visit path_with_locale(path)
 
 end
 
@@ -89,12 +87,17 @@ When(/^I fail to visit the "([^"]*)" page$/) do |page|
     else
       path = 'path not set'
   end
-  visit path
+  visit path_with_locale(path)
   expect(current_path).not_to be path
 end
 
 
 When(/^I am on the application page for "([^"]*)"$/) do |first_name|
     membership_application = MembershipApplication.find_by(first_name: first_name)
-    visit membership_application_path(membership_application)
+    visit path_with_locale(membership_application_path(membership_application))
+end
+
+
+And(/^I am on the static workgroups page$/) do
+  visit page_path('arbetsgrupper')
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,10 +13,20 @@ end
 
 Cucumber::Rails::Database.javascript_strategy = :truncation
 
+
+Before do
+ # I18n.locale = 'en'
+end
+
+
 Warden.test_mode!
 World Warden::Test::Helpers
 After { Warden.test_reset! }
 
-def i18n_content(content, locale='sv')
-  I18n.t(content, locale: locale.to_sym)
+def path_with_locale(visit_path)
+  "/#{I18n.locale}#{visit_path}"
+end
+
+def i18n_content(content, locale=I18n.locale)
+  I18n.t(content, locale)
 end

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -25,7 +25,7 @@ Feature: As an Admin
     And I click on t("update")
     Then I should see t("membership_applications.update.success")
     And t("membership_applications.rejected") should be set in "membership_application_status"
-    And I should see status line with status t("membership_applications.rejected") and date "2016-12-16"
+    And I should see status line with status "Avböjd" and date "2016-12-16"
 
 
   Scenario: Application submitter can see but not update the Application status

--- a/features/view-site-in-lang-i18n-l10n.feature
+++ b/features/view-site-in-lang-i18n-l10n.feature
@@ -4,12 +4,16 @@ Feature: As a visitor
 
   PT: https://www.pivotaltracker.com/story/show/133316647
 
+  Note that we always explicitly start with the locale set to sv. This is
+  necessary in case the feature are being run with a different locale.
+
   Background:
     Given I am Logged out
 
 
   Scenario: Default language is Swedish
-    Given I am on the "all companies" page
+    Given I set the locale to "sv"
+    And I am on the "all companies" page
     Then I should see t("companies.index.title")
     And I should not see "Swedish flag" image
     And I should see "English flag" image
@@ -17,7 +21,8 @@ Feature: As a visitor
 
 
   Scenario: Visitor switches the site language from English to Swedish
-    Given I am on the "all companies" page
+    Given I set the locale to "sv"
+    And I am on the "all companies" page
     When I click on "change-lang-to-english"
     When I click on "change-lang-to-svenska"
     Then I should see t("companies.index.title")
@@ -27,7 +32,8 @@ Feature: As a visitor
 
 
   Scenario: Visitor switches the site language from Swedish to English
-    Given I am on the "all companies" page
+    Given I set the locale to "sv"
+    And I am on the "all companies" page
     When I click on "change-lang-to-english"
     Then I should see "Swedish flag" image
     And I should not see "English flag" image

--- a/features/view_hidden_pages.feature
+++ b/features/view_hidden_pages.feature
@@ -19,7 +19,7 @@ Feature: Only members and admins can see members only (hidden) pages
 
   Scenario: Visitor cannot see members only pages
     Given I am Logged out
-    And I am on the "static workgroups" page
+    And I am on the static workgroups page
     Then I should see t("errors.not_permitted")
     And I should not see "Arbetsgrupper"
 
@@ -30,7 +30,7 @@ Feature: Only members and admins can see members only (hidden) pages
 
   Scenario: User cannot see members only pages
     Given I am logged in as "not_a_member@bowsers.com"
-    And I am on the "static workgroups" page
+    And I am on the static workgroups page
     Then I should see t("errors.not_permitted")
     And I should not see "Arbetsgrupper"
 
@@ -41,7 +41,7 @@ Feature: Only members and admins can see members only (hidden) pages
 
   Scenario: Member can see members only pages
     Given I am logged in as "emma@happymutts.com"
-    And  I am on the "static workgroups" page
+    And  I am on the static workgroups page
     Then I should see "Arbetsgrupper"
     Then I should not see t("errors.not_permitted")
 
@@ -52,7 +52,7 @@ Feature: Only members and admins can see members only (hidden) pages
 
   Scenario: Admin can see members only pages
     Given I am logged in as "admin@shf.se"
-    And  I am on the "static workgroups" page
+    And  I am on the static workgroups page
     Then I should see "Arbetsgrupper"
     Then I should not see t("errors.not_permitted")
 


### PR DESCRIPTION
PT Story:  **Site is multi-lingual: Swedish=primary, then English**
https://www.pivotaltracker.com/story/show/133316647

Changes proposed in this pull request:
1.  add Before block so we can run all scenarios with locale explicitly set
2. change steps so that they prepend the current locale to the path visited
3. fix places where Swedish is still hardcoded (discovered when running the features with locale='en')

Ready for review:
@AgileVentures/shf-project-team 
