### PR TITLE
Removed large image at top of company index view PT #137089257

### DIFF
--- a/app/views/application/_top.html.haml
+++ b/app/views/application/_top.html.haml
@@ -1,9 +1,5 @@
 = render 'navigation'
-- unless current_user.try(:admin)
-  #site-logo
-    %a{ href: 'http://sverigeshundforetagare.se/' }
-      %img{ alt: 'logo', src: 'http://media.sverigeshundforetagare.se/2016/10/SH_logo_RGB.png' }
-- else
+- if current_user.try(:admin)
   #site-logo
     %p.admin
       = t('info.logged_in_as_admin')

--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -3,8 +3,8 @@
     %h1.entry-title= t('.title')
   - if current_user.try(:admin)
     %h1.entry-title= t('.admin_title')
-.post-title-divider
-  %span
+-# .post-title-divider
+-#   %span
 .entry-content
   - unless current_user.try(:admin)
     %p

--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -3,8 +3,7 @@
     %h1.entry-title= t('.title')
   - if current_user.try(:admin)
     %h1.entry-title= t('.admin_title')
--# .post-title-divider
--#   %span
+
 .entry-content
   - unless current_user.try(:admin)
     %p


### PR DESCRIPTION
PT Story: 
https://www.pivotaltracker.com/story/show/137089257


Changes proposed in this pull request:
1. Changed partial `_top.html.haml` to not pull in image
2. Removed styling that introduced unneeded separator line

Screenshots (Optional):


Ready for review:
@thesuss @weedySeaDragon 