### PR TITLE
moved seeding from migrations to rake task

### DIFF
--- a/db/migrate/20161228160857_create_regions.rb
+++ b/db/migrate/20161228160857_create_regions.rb
@@ -6,17 +6,6 @@ class CreateRegions < ActiveRecord::Migration[5.0]
 
       t.timestamps
     end
-    
-    # This populates the 'regions' table for Swedish regions (aka counties),
-    # as well as 'Sweden' and 'Online'.  This is used to specify the primary
-    # region in which a company operates.
-    #
-    # This uses the 'city-state' gem for a list of regions (name and ISO code).
-    # (That gem will also return a list of cities within region)
-
-    CS.states(:se).each_pair { |k,v| Region.create(name: v, code: k.to_s) }
-    Region.create(name: 'Sweden', code: nil)
-    Region.create(name: 'Online', code: nil)
   end
 
   def self.down

--- a/db/migrate/20161228161607_add_region_id_to_company.rb
+++ b/db/migrate/20161228161607_add_region_id_to_company.rb
@@ -1,16 +1,6 @@
 class AddRegionIdToCompany < ActiveRecord::Migration[5.0]
   def self.up
     add_reference :companies, :region, foreign_key: true
-
-    Company.all.each do |cmpy|
-      region = Region.where(name: cmpy.old_region)[0]
-      if region
-        cmpy.region = region
-        cmpy.save
-      else
-        puts "No region match for company : #{cmpy.name}"
-      end
-    end
   end
 
   def self.down


### PR DESCRIPTION
PT Story: 
https://www.pivotaltracker.com/story/show/137640179


Changes proposed in this pull request:
1. Remove seeding for regions from migration 
2. Remove setting reference ID from migration (company ```belongs_to``` region)
3. Adding both actions above to rake task

Screenshots (Optional):


Ready for review:
@weedySeaDragon @thesuss 