### PR TITLE
added old_region: Gamla Länet  to sv locale file

### DIFF
--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -83,6 +83,7 @@ sv:
         city: &city Ort
         region: &region Verksamhetslän
         region_short: &region_short Län
+        old_region: Gamla Länet
         website: Webbplats
         org_nr: *org_nr
 


### PR DESCRIPTION
PT Story: #137064201 missing translation in sv.yml: activerecord.attributes.company.old_region
https://www.pivotaltracker.com/story/show/137064201

Changes proposed in this pull request:
1. added `old_region:  Gamla Länet` to sv.yml locale file

Ready for review:
@thesuss 
