### PR TITLE
Bug: MembershipApplication is_member? should not refer to the User status 

### DIFF
--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -89,7 +89,7 @@ class MembershipApplication < ApplicationRecord
 
 
   def is_member?
-    user && user.is_member?
+    is_accepted?
   end
 
 


### PR DESCRIPTION

PT Story: https://www.pivotaltracker.com/story/show/138126241

Changes proposed in this pull request:
1. change the `is_member?` method in MembershipApplication to just look at the state via the `is_accepted?` method.  This was the simple fix.  Later we can determine if the `is_member?` method is still needed at all.

I found this when working with seeded data.  The membership application state was `under_review` and it's `user.is_member` == true.  The membership application `.is_member?` checked the `user.is_member?` instead of the membership application state itself.  I don't think this situation exists in any of the test data created during features or specs, so it wasn't caught.  I'm not sure if this situation will ever exist in the real data.


I also added a chore in PivotalTracker to remove all old code relating to how MembershipApplication status _used to_ be determined.

Ready for review:
@patmbolger @thesuss 
