### PR TITLE
Added steps, @poltergeist tag for testing deleting membership apps, companies

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,7 @@ en:
         company:
           company_number:
             taken: This company (organization number) already exists in the system.
+          company_has_active_memberships: "The company has active (accepted) membership applications."
 
       messages:
         record_invalid: "Validation failed: %{errors}"
@@ -125,7 +126,6 @@ en:
       upload_more_files: 'You can upload more files. After you submit your application, edit it and you can upload more there.'
 
       submit_button_label: *submit
-
 
     create:
       success: Thank You. Your membership application has been submitted.
@@ -271,6 +271,8 @@ en:
       region: Region
       website: Company website
       org_nr: *org_nr
+      delete: "Delete the company"
+      confirm_are_you_sure: '*are_you_sure_confirm you want to delete the company?'
     index:
       title: Find H-labeled companies
       admin_title: Edit member companies
@@ -282,9 +284,11 @@ en:
       how_to_search: Search by specifying one or more of the search parameters below.
       confirm_are_you_sure: *are_you_sure_confirm
       no_search_results: No records matched your search criteria.
+      delete: *delete
 
     destroy:
       success: Company deleted.
+      error: Could not delete the company.
 
     company_name: Company name
     telephone_number: Phone number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -282,6 +282,10 @@ en:
       how_to_search: Search by specifying one or more of the search parameters below.
       confirm_are_you_sure: *are_you_sure_confirm
       no_search_results: No records matched your search criteria.
+
+    destroy:
+      success: Company deleted.
+
     company_name: Company name
     telephone_number: Phone number
     operations_region: County of operations

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -279,6 +279,10 @@ sv:
       how_to_search: Sök genom att ange en eller flera av sökparametrarna nedan.
       confirm_are_you_sure: *are_you_sure_confirm
       no_search_results: Din sökning gav inget resultat, prova att ta bort något av dina val.
+
+    destroy:
+      success: Företag raderad.
+
     company_name: Företagsnamn
     telephone_number: Telefonnummer
     operations_region: *region

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -97,6 +97,7 @@ sv:
         company:
           company_number:
             taken: Detta företag (org nr) finns redan i systemet.
+          company_has_active_memberships: "NEEDS TRANSLATION The company has active (accepted) membership applications."
 
       messages:
         record_invalid: 'Ett fel uppstod: %{errors}'
@@ -268,6 +269,8 @@ sv:
       region: *region
       website: Företagets webbplats
       org_nr: *org_nr
+      delete: "Radera företaget NEEDS TRANSLATION REVIEW"
+      confirm_are_you_sure: *are_you_sure_confirm
     index:
       title:  Hitta H-märkt företag
       admin_title: Redigera medlemsföretag
@@ -279,9 +282,11 @@ sv:
       how_to_search: Sök genom att ange en eller flera av sökparametrarna nedan.
       confirm_are_you_sure: *are_you_sure_confirm
       no_search_results: Din sökning gav inget resultat, prova att ta bort något av dina val.
+      delete: *delete
 
     destroy:
       success: Företag raderad.
+      error: TRANSLATION NEEDED Ett problem hindrade företaget från att raderas.
 
     company_name: Företagsnamn
     telephone_number: Telefonnummer

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -171,6 +171,14 @@ Then(/^I should see "([^"]*)" applications$/) do |number|
   expect(page).to have_selector('.applicant', count: number)
 end
 
+Then(/^I should see "([^"]*)" companies/) do |number|
+  expect(page).to have_selector('.company', count: number)
+end
+
+Then(/^I should see "([^"]*)" business categories/) do |number|
+  expect(page).to have_selector('.business_category', count: number)
+end
+
 Then(/^the field "([^"]*)" should have a required field indicator$/) do |label_text|
   expect(page.find('label', text: label_text)[:class].include?('required')).to be true
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -6,6 +6,15 @@ And(/^I click on t\("([^"]*)"\)$/) do |element|
   click_link_or_button i18n_content("#{element}")
 end
 
+When /^I confirm popup$/ do
+  # requires poltergeist:
+  page.driver.accept_modal(:confirm)
+end
+
+When /^I dismiss popup$/ do
+  page.driver.dismiss_modal(:confirm)
+end
+
 And(/^I fill in "([^"]*)" with "([^"]*)"$/) do |field, value|
   fill_in field, with: value
 end

--- a/features/step_definitions/company_steps.rb
+++ b/features/step_definitions/company_steps.rb
@@ -15,7 +15,7 @@ And(/^the following regions exist:$/) do |table|
   end
 end
 
-And(/^I am the page for company number "([^"]*)"$/) do |company_number|
+And(/^I am (on )*the page for company number "([^"]*)"$/) do |grammar_fix_on, company_number|
   company = Company.find_by_company_number(company_number)
   visit path_with_locale(company_path company)
 end

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -2,7 +2,7 @@ And(/^the following applications exist:$/) do |table|
  table.hashes.each do |hash|
    attributes = hash.except('user_email')
    user = User.find_by(email: hash[:user_email])
-    if hash['state'] == 'accepted'
+    if hash['state'] == 'accepted' || hash['state'] == 'rejected'
      company = Company.find_by(company_number: hash['company_number'])
      unless company
        company = FactoryGirl.create(:company, company_number: hash['company_number'])

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,18 +1,8 @@
-Before('@javascript') do
+Before('@javascript, @poltergeist') do
   Capybara.current_driver = :poltergeist
 end
 
-After('@javascript') do
-  Capybara.reset_sessions!
-  Capybara.current_driver = :rack_test
-end
-
-
-Before('@poltergeist') do
-  Capybara.current_driver = :poltergeist
-end
-
-After('@poltergeist') do
+After('@javascript, @poltergeist') do
   Capybara.reset_sessions!
   Capybara.current_driver = :rack_test
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -6,3 +6,13 @@ After('@javascript') do
   Capybara.reset_sessions!
   Capybara.current_driver = :rack_test
 end
+
+
+Before('@poltergeist') do
+  Capybara.current_driver = :poltergeist
+end
+
+After('@poltergeist') do
+  Capybara.reset_sessions!
+  Capybara.current_driver = :rack_test
+end


### PR DESCRIPTION
part 1: Adds Cucumber steps so that PT #138063171 can be tested.   (and a little grammar fix to the steps)

(This is the first PR for the PT story below.)

PT Story: **Delete company associated with deleted membership application. (see details)**
#138063171 https://www.pivotaltracker.com/story/show/138063171

Changes proposed in this pull request:
1.  added steps to show how many companies or business categories are on a page:
   `I should see "n" companies`  (where `n` is a number) 
   `I should see "n" business categories`  (where `n` is a number) 
   both use specific css tags to identify what is a 'company' or 'business category' on a page
2. added steps to confirm or dismiss a popup like the one that asks a user to confirm that they want to delete something:
    `[When] I confirm popup`
    `[When] I dismiss popup`
    These **require** the poltergeist driver.  So any scenario using them must include either the `@javascript` tag or the new `@poltergeist` tag below.

3. added tag `@poltergeist` to signal that the poltergeist driver is required.  Since javascript isn't explicitly involved, I added this tag instead of using `@javascript`

4. Corrected the grammar in a step. It was `I am the page for company number "n"` it should be `I am on the page for company number "n"`
    The (correct) `on ` is optional so that the previous wrong-grammar steps are still just fine, but you can know write it correctly by including `on`.

@patmbolger @thesuss 
