### PR TITLE
seed data on development server 

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,7 +71,7 @@ business_categories.each { |b_category| BusinessCategory.find_or_create_by(name:
 BusinessCategory.find_or_create_by(name: 'Sociala tjänstehundar', description: 'Terapi-, vård- & skolhund dvs hundar som jobbar tillsammans med sin förare/ägare inom vård, skola och omsorg.')
 BusinessCategory.find_or_create_by(name: 'Civila tjänstehundar', description: 'Assistanshundar dvs hundar som jobbar åt sin ägare som service-, signal, diabetes, PH-hund mm')
 
-if Rails.env.development? || Rails.env.staging?
+if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_STAGING']
 
   regions = Region.all.to_a
   


### PR DESCRIPTION
Be able to seed data with `seeds.rb` on the development server so that we have enough data to do a demo to the client.

PT Story:  https://www.pivotaltracker.com/story/show/139052283

_Although it's different from our usual accepted process, if this passes the CI checks, I'm going to merge it so that I can test it on Heroku quickly.  I need to be able to do that because we have the client demo tomorrow._

Changes proposed in this pull request:
1.  in `seeds.rb` check for existance of ENV variable, do seeding if it exists.  Thus we don't need to change `Rails.env` on the development server
2.  I added the ENV variable on the development server (Heroku)

Ready for review:
@patmbolger 
