### PR TITLE
seed development server - update I18n for states; seed with STATES (vs. old STATUS)

### DIFF
--- a/app/views/membership_applications/show.html.haml
+++ b/app/views/membership_applications/show.html.haml
@@ -28,7 +28,7 @@
   #uploaded_files
     = render 'uploaded_files_list', membership_application: @membership_application
 
-  %p #{t('.app_status')}: #{t("membership_applications.#{@membership_application.state}")}  - #{@membership_application.updated_at.strftime('%F')}
+  %p #{t('.app_status')}: #{t("membership_applications.state.#{@membership_application.state}")}  - #{@membership_application.updated_at.strftime('%F')}
 
   - if current_user.admin?
     = render partial: 'application_status_form'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,18 +221,26 @@ en:
       success: Your application has been submitted for another review.
       error: There was an error when trying to submit your application for another review.
 
-    new_status: &status_new New
+    state:
+      new: &status_new New
+      under_review: &status_under_review Under Review
+      waiting_for_applicant: &status_waiting_for_applicant  Waiting for applicant
+      ready_for_review: &status_ready_for_review Ready For Review
+      accepted: &status_accepted Accepted
+      rejected: &status_rejected Rejected
+
+    new_status: *status_new
     accept: &event_accept Accept
-    accepted: &status_accepted Accepted
+    accepted: *status_accepted
     reject: &event_reject Reject
-    rejected: &status_rejected Rejected
-    under_review: &status_under_review Under Review
+    rejected: *status_rejected
+    under_review: *status_under_review
     pending_completion: &pending_completion Pending completion
     ask_applicant_for_info: &event_ask_applicant_for_info Ask Applicant for Info
     cancel_waiting_for_applicant: &event_cancel_waiting_for_applicant Cancel Waiting for Applicant Info
-    waiting_for_applicant: &status_waiting_for_applicant  Waiting for applicant
+    waiting_for_applicant: *status_waiting_for_applicant
     applicant_updated_info: &event_applicant_updated_info Applicant Updated Info
-    ready_for_review: &status_ready_for_review Ready For Review
+    ready_for_review: *status_ready_for_review
     start_review: &start_review Start Review
 
     awaiting_payment: Awaiting payment

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -219,18 +219,26 @@ sv:
       success: Din ansökan har lämnats in för en annan granskning.
       error: Det uppstod ett fel när du försöker att skicka in din ansökan för en annan granskning.
 
-    new_status: &status_new Nytt
+    state:
+      new: &status_new Ny
+      under_review: &status_under_review Behandlas
+      waiting_for_applicant: &status_waiting_for_applicant  Väntar på sökande
+      ready_for_review: &status_ready_for_review Redo för granskning
+      accepted: &status_accepted Godkänd
+      rejected: &status_rejected Avböjd
+
+    new_status: *status_new
     accept: &event_accept Godkänn
-    accepted: &status_accepted Godkänd
+    accepted: *status_accepted
     reject: &event_reject Avböj
-    rejected: &status_rejected Avböjd
-    under_review: &status_under_review Behandlas
+    rejected: *status_rejected
+    under_review: *status_under_review
     pending_completion: &status_pending_completion Väntar på sökande
     ask_applicant_for_info: &event_ask_applicant_for_info Behöver kompletteras
     cancel_waiting_for_applicant: &event_cancel_waiting_for_applicant Ångra Behöver kompletteras
-    waiting_for_applicant: &status_waiting_for_applicant  Väntar på sökande
+    waiting_for_applicant: *status_waiting_for_applicant
     applicant_updated_info: &event_applicant_updated_info Sökanden har kompletterat sin ansökan
-    ready_for_review: &status_ready_for_review Redo för granskning
+    ready_for_review: *status_ready_for_review
     start_review: &start_review Starta omdöme
 
     awaiting_payment: Inväntar betalning

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,7 +71,7 @@ business_categories.each { |b_category| BusinessCategory.find_or_create_by(name:
 BusinessCategory.find_or_create_by(name: 'Sociala tjänstehundar', description: 'Terapi-, vård- & skolhund dvs hundar som jobbar tillsammans med sin förare/ägare inom vård, skola och omsorg.')
 BusinessCategory.find_or_create_by(name: 'Civila tjänstehundar', description: 'Assistanshundar dvs hundar som jobbar åt sin ägare som service-, signal, diabetes, PH-hund mm')
 
-if Rails.env.development? || Rails.env.staging?
+if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_STAGING']
 
   regions = Region.all.to_a
   

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,7 @@ SEED_ERROR_MSG = 'Seed ERROR: Could not load either admin email or password. NO 
 
 DEFAULT_PASSWORD = 'whatever'
 
-MA_ACCEPTED_STATUS = 'Godkänd'
+MA_ACCEPTED_STATE = :accepted
 
 private def env_invalid_blank(env_key)
   raise SeedAdminENVError, SEED_ERROR_MSG if (env_val = ENV.fetch(env_key)).blank?
@@ -110,7 +110,6 @@ if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_STAGING']
                                        last_name: FFaker::NameSE.last_name,
                                        contact_email: FFaker::InternetSE.free_email,
                                        company_number: company_number,
-                                       status: 'Pending',
                                        user: users[r.rand(0..NUM_USERS-1)])
         idx1 = r.rand(0..num_cats-1)
         ma.business_categories << business_categories[idx1]
@@ -132,7 +131,7 @@ if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_STAGING']
 
       next if ma.is_accepted?
 
-      ma.status = MA_ACCEPTED_STATUS
+      ma.state = MA_ACCEPTED_STATE
       ma.user.is_member = true
       ma.user.save
 
@@ -151,6 +150,6 @@ if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_STAGING']
     end
 
     puts "Applications accepted: #{MembershipApplication
-      .where(status: MA_ACCEPTED_STATUS).count}"
+      .where(state: MA_ACCEPTED_STATE).count}"
   end
 end


### PR DESCRIPTION
Be able to seed data with `seeds.rb` on the development server so that we have enough data to do a demo to the client.

PT Story:  https://www.pivotaltracker.com/story/show/139052283

_Although it's different from our usual accepted process, if this passes the CI checks, I'm going to merge it so that I can test it on Heroku quickly.  I need to be able to do that because we have the client demo tomorrow._

Changes proposed in this pull request:
SEE PR #141 (had to merge it to test it, which closed it).  Changes in that PR:
1.  in `seeds.rb` check for existance of ENV variable, do seeding if it exists.  Thus we don't need to change `Rails.env` on the development server
2.  I added the ENV variable on the development server (Heroku)

This PR:
3. update the I18n for a membership application state:  have to put them in a separate section, otherwise for a _new_ membership appliacation, it looks up the test for `membership_applications.new` -- which will show all of the text for the _new view_
4. change seed.db to set the membership_application.**state** (vs. old 'status')

Ready for review:
@patmbolger 
