### PR TITLE
Seed development server;  I18n locale .state section under apps (last one)

### DIFF
--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -15,5 +15,5 @@
         %tr.applicant
           %td.name= link_to "#{membership_application.first_name + ' ' + membership_application.last_name}", membership_application_path(membership_application.id)
           %td.company_number= membership_application.company_number
-          %td.state= t("membership_applications.#{membership_application.state}")
+          %td.state= t("membership_applications.state.#{membership_application.state}")
           %td.action= link_to t('.manage'), membership_application_path(membership_application.id)

--- a/app/views/membership_applications/index.html.haml
+++ b/app/views/membership_applications/index.html.haml
@@ -15,5 +15,5 @@
         %tr.applicant
           %td.name= link_to "#{membership_application.first_name + ' ' + membership_application.last_name}", membership_application_path(membership_application.id)
           %td.company_number= membership_application.company_number
-          %td.state= t("membership_applications.#{membership_application.state}")
+          %td.state= t("membership_applications.state.#{membership_application.state}")
           %td.action= link_to "#{t('.manage')}", membership_application_path(membership_application.id)


### PR DESCRIPTION
Be able to seed data with `seeds.rb` on the development server so that we have enough data to do a demo to the client.
Also use the `.state` subsection in the I18n locale files to display a membership application state

PT Story:  https://www.pivotaltracker.com/story/show/139052283

_Although it's different from our usual accepted process, if this passes the CI checks, I'm going to merge it so that I can test it on Heroku quickly.  I need to be able to do that because we have the client demo tomorrow._

Changes proposed in this pull request:
SEE PR #141 (had to merge it to test it, which closed it).  Changes in that PR:
1.  in `seeds.rb` check for existance of ENV variable, do seeding if it exists.  Thus we don't need to change `Rails.env` on the development server
2.  I added the ENV variable on the development server (Heroku)

SEE PR #142 (had to merge it to test it, which closed it).  Changes in that PR:
3. update the I18n for a membership application state:  have to put them in a separate section, otherwise for a _new_ membership appliacation, it looks up the test for `membership_applications.new` -- which will show all of the text for the _new view_
4. change seed.db to set the membership_application.**state** (vs. old 'status')

Changes in *this* PR:
5. updated the views for the admin index ( = list of membership applications) to use the `.state` sub-section for membership_appliations in the locale files
6. update the list of membership applications view (index) to also use the `.state` local sub-section

Ready for review:
@patmbolger 
