### PR TITLE
Category: company region is showing region object instead of the region name

### DIFF
--- a/app/views/business_categories/show.html.haml
+++ b/app/views/business_categories/show.html.haml
@@ -25,7 +25,7 @@
           - if company_complete? company
             %tr.company
               %td= link_to company.name, company
-              %td= company.region
+              %td= company.region.name
               - if current_user.try(:admin)
                 %td= company.company_number
                 %td= link_to t('edit'), edit_company_path(company)

--- a/features/list_companies_of_category.feature
+++ b/features/list_companies_of_category.feature
@@ -40,7 +40,9 @@ Feature: As any type of visitor
     Given I am Logged out
     And I am on the business category "Awesome"
     Then I should see "No More Snarky Barky"
+    And I should see "Stockholm"
     And I should see "WOOF"
+    And I should see "Västerbotten"
     And I should not see "Sad Sad Snarky Barky"
 
   Scenario: Categories list businesses
@@ -48,10 +50,12 @@ Feature: As any type of visitor
     And I am on the business category "Sadness"
     Then I should not see "No More Snarky Barky"
     And I should see "Sad Sad Snarky Barky"
+    And I should see "Norrbotten"
     When I am logged in as "anna@sadmutts.com "
     And I am on the business category "Sadness"
     Then I should not see "No More Snarky Barky"
     And I should see "Sad Sad Snarky Barky"
+    And I should see "Norrbotten"
 
   Scenario: Categories list no businesses
     Given I am Logged out
@@ -67,3 +71,4 @@ Feature: As any type of visitor
     And I click on t("membership_applications.edit.submit_button_label")
     When I am on the business category "Extra"
     Then I should see "WOOF"
+    And I should see "Västerbotten"


### PR DESCRIPTION
PT Story: **PRODUCTION: region on listing by category**
https://www.pivotaltracker.com/story/show/138311129

Changes proposed in this pull request:
1.  feature now checks to ensure the region names are displayed
2.    ` %td= company.region.name` instead of just `company.region`


Ready for review:
@patmbolger @thesuss 
