### PR TITLE
Translation missing #139123527

### DIFF
--- a/app/views/membership_applications/_application_status_form.html.haml
+++ b/app/views/membership_applications/_application_status_form.html.haml
@@ -3,15 +3,15 @@
     = "#{t('membership_applications.show.change_status')}:"
 
 
-  = button_to t('membership_applications.start_review'), start_review_membership_application_path(@membership_application), {class: 'btn start-review', disabled: !(@membership_application.may_start_review?)}
+  = button_to t('membership_applications.start_review_btn'), start_review_membership_application_path(@membership_application), {class: 'btn start-review', disabled: !(@membership_application.may_start_review?)}
 
-  = button_to t('membership_applications.accept'), accept_membership_application_path(@membership_application), {class: 'btn accept', disabled: !(@membership_application.may_accept?)}
+  = button_to t('membership_applications.accept_btn'), accept_membership_application_path(@membership_application), {class: 'btn accept', disabled: !(@membership_application.may_accept?)}
 
-  = button_to t('membership_applications.reject'), reject_membership_application_path(@membership_application), {class: 'btn reject', disabled: !(@membership_application.may_reject?)}
+  = button_to t('membership_applications.reject_btn'), reject_membership_application_path(@membership_application), {class: 'btn reject', disabled: !(@membership_application.may_reject?)}
 
-  = button_to t('membership_applications.ask_applicant_for_info'), need_info_membership_application_path(@membership_application), {class: 'btn need-info', disabled: !(@membership_application.may_ask_applicant_for_info?)}
+  = button_to t('membership_applications.ask_applicant_for_info_btn'), need_info_membership_application_path(@membership_application), {class: 'btn need-info', disabled: !(@membership_application.may_ask_applicant_for_info?)}
 
-  = button_to t('membership_applications.cancel_waiting_for_applicant'), cancel_need_info_membership_application_path(@membership_application), {class: 'btn cancel-need-info', disabled: !(@membership_application.may_cancel_waiting_for_applicant?)}
+  = button_to t('membership_applications.cancel_waiting_for_applicant_btn'), cancel_need_info_membership_application_path(@membership_application), {class: 'btn cancel-need-info', disabled: !(@membership_application.may_cancel_waiting_for_applicant?)}
 
 %br
   - if !@membership_application.paid?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,10 +200,9 @@ en:
                         If your application is approved, we'll give you a link
                         so you can describe and list your business here."
 
-
     start_review:
       success: The review has been started.
-      error: There was a problemm starting the review for this application.
+      error: There was a problem starting the review for this application.
 
     accept:
       success: The membership has been approved.
@@ -234,18 +233,18 @@ en:
       rejected: &status_rejected Rejected
 
     new_status: *status_new
-    accept: &event_accept Accept
+    accept_btn: Accept
     accepted: *status_accepted
-    reject: &event_reject Reject
+    reject_btn: Reject
     rejected: *status_rejected
     under_review: *status_under_review
     pending_completion: &pending_completion Pending completion
-    ask_applicant_for_info: &event_ask_applicant_for_info Ask Applicant for Info
-    cancel_waiting_for_applicant: &event_cancel_waiting_for_applicant Cancel Waiting for Applicant Info
+    ask_applicant_for_info_btn: Ask Applicant for Info
+    cancel_waiting_for_applicant_btn: Cancel Waiting for Applicant Info
     waiting_for_applicant: *status_waiting_for_applicant
     applicant_updated_info: &event_applicant_updated_info Applicant Updated Info
     ready_for_review: *status_ready_for_review
-    start_review: &start_review Start Reviewing
+    start_review_btn: Start Reviewing
 
     awaiting_payment: Awaiting payment
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -204,7 +204,6 @@ sv:
       success: Granskningen har påbörjats.
       error: Det fanns ett problem med att påbörja granskning för denna applikation.
 
-
     accept:
       success: Medlemsansökan har godkänts.
       error: Det uppstod ett fel vid godkännande av medlemskap.
@@ -234,18 +233,18 @@ sv:
       rejected: &status_rejected Avböjd
 
     new_status: *status_new
-    accept: &event_accept Godkänn
+    accept_btn: Godkänn
     accepted: *status_accepted
-    reject: &event_reject Avböj
+    reject_btn: Avböj
     rejected: *status_rejected
     under_review: *status_under_review
     pending_completion: &status_pending_completion Väntar på sökande
-    ask_applicant_for_info: &event_ask_applicant_for_info Behöver kompletteras
-    cancel_waiting_for_applicant: &event_cancel_waiting_for_applicant Ångra Behöver kompletteras
+    ask_applicant_for_info_btn: Behöver kompletteras
+    cancel_waiting_for_applicant_btn: Ångra Behöver kompletteras
     waiting_for_applicant: *status_waiting_for_applicant
     applicant_updated_info: &event_applicant_updated_info Sökanden har kompletterat sin ansökan
     ready_for_review: *status_ready_for_review
-    start_review: &start_review Påbörja granskning
+    start_review_btn: Påbörja granskning
 
     awaiting_payment: Inväntar betalning
 

--- a/features/approve-member.feature
+++ b/features/approve-member.feature
@@ -40,7 +40,7 @@ Feature: As an admin
 
   Scenario: Admin approves, no company exists so one is created
     Given I am on "Emma" application page
-    When I click on t("membership_applications.accept")
+    When I click on t("membership_applications.accept_btn")
     And I should be on the edit application page for "Emma"
     And I should see t("membership_applications.accept.success")
     And I should see t("membership_applications.update.enter_member_number")
@@ -54,7 +54,7 @@ Feature: As an admin
 
   Scenario: Admin approves, member is added to existing company
     Given I am on "Anna" application page
-    When I click on t("membership_applications.accept")
+    When I click on t("membership_applications.accept_btn")
     And I should be on the edit application page for "Anna"
     And I should see t("membership_applications.update.enter_member_number")
     And I fill in t("membership_applications.show.membership_number") with "902"
@@ -79,7 +79,7 @@ Feature: As an admin
 
   Scenario: Admin approves, but then rejects it
     Given I am on "Emma" application page
-    When I click on t("membership_applications.accept")
+    When I click on t("membership_applications.accept_btn")
     And I should be on the edit application page for "Emma"
     And I should see t("membership_applications.update.enter_member_number")
     And I fill in t("membership_applications.show.membership_number") with "901"
@@ -88,7 +88,7 @@ Feature: As an admin
     And I should see t("membership_applications.accepted")
     And I should see "901"
     When I am on "Emma" application page
-    And I click on t("membership_applications.reject")
+    And I click on t("membership_applications.reject_btn")
     Then I should see status line with status t("membership_applications.rejected")
     And I am Logged out
     And I am on the "landing" page

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -44,18 +44,15 @@ Feature: As an Admin
     And I am logged in as "emma_under_review@happymutts.se"
     Given I am on "EmmaUnderReview" application page
     And I should see status line with status t("membership_applications.under_review")
-    And I should not see button t("membership_applications.accept")
-    And I should not see button t("membership_applications.reject")
-
-
-
-  Scenario: Things go wrong when trying to reject an application
+    And I should not see button t("membership_applications.accept_btn")
+    And I should not see button t("membership_applications.reject_btn")
 
 
   # From under_review to...
+
   Scenario: Admin requests more info from user (from under_review to 'waiting for applicant')
     Given I am on "EmmaUnderReview" application page
-    When I click on t("membership_applications.ask_applicant_for_info")
+    When I click on t("membership_applications.ask_applicant_for_info_btn")
     Then I should see t("membership_applications.need_info.success")
     And I should see status line with status t("membership_applications.waiting_for_applicant")
     And I should not see t("membership_applications.update.enter_member_number")
@@ -72,7 +69,7 @@ Feature: As an Admin
 
   Scenario: Admin changed from under_review to accepted
     Given I am on "EmmaUnderReview" application page
-    When I click on t("membership_applications.accept")
+    When I click on t("membership_applications.accept_btn")
     Then I should see t("membership_applications.accept.success")
     And I should see t("membership_applications.update.enter_member_number")
     When I am on the "landing" page
@@ -84,7 +81,7 @@ Feature: As an Admin
 
   Scenario: Admin changed from under_review to rejected
     Given I am on "EmmaUnderReview" application page
-    When I click on t("membership_applications.reject")
+    When I click on t("membership_applications.reject_btn")
     Then I should see t("membership_applications.reject.success")
     And I should see status line with status t("membership_applications.rejected")
     And I should not see t("membership_applications.update.enter_member_number")
@@ -97,12 +94,12 @@ Feature: As an Admin
 
   Scenario: Admin cannot change from under_review to 'cancel waiting for applicant'
     Given I am on "EmmaUnderReview" application page
-    Then I should not see button t("membership_applications.cancel_waiting_for_applicant")
+    Then I should not see button t("membership_applications.cancel_waiting_for_applicant_btn")
 
 
   Scenario: Admin rejects an application (under_review to rejected)
     Given I am on "EmmaUnderReview" application page
-    When I click on t("membership_applications.reject")
+    When I click on t("membership_applications.reject_btn")
     Then I should see t("membership_applications.reject.success")
     And I should see status line with status t("membership_applications.rejected")
     And I should not see t("membership_applications.update.enter_member_number")
@@ -121,7 +118,7 @@ Feature: As an Admin
     And I am Logged out
     And I am logged in as "admin@shf.se"
     And I am on "AnnaWaiting" application page
-    Then I click on t("membership_applications.ask_applicant_for_info")
+    Then I click on t("membership_applications.ask_applicant_for_info_btn")
     And  I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
     And I am on the "edit my application" page
     And I choose a file named "image.png" to upload
@@ -129,7 +126,7 @@ Feature: As an Admin
     And I am Logged out
     And I am logged in as "admin@shf.se"
     And I am on "AnnaWaiting" application page
-    When I click on t("membership_applications.reject")
+    When I click on t("membership_applications.reject_btn")
     Then I should see t("membership_applications.reject.success")
     And I should see status line with status t("membership_applications.rejected")
     And I should see 0 uploaded files listed
@@ -172,7 +169,7 @@ Feature: As an Admin
 
   Scenario: Admin changed from 'waiting for applicant' to 'under review'
     Given I am on "AnnaWaiting" application page
-    When I click on t("membership_applications.cancel_waiting_for_applicant")
+    When I click on t("membership_applications.cancel_waiting_for_applicant_btn")
     Then I should see t("membership_applications.cancel_need_info.success")
     And I should see status line with status t("membership_applications.under_review")
     And I should not see t("membership_applications.waiting_for_applicant")
@@ -186,17 +183,17 @@ Feature: As an Admin
 
   Scenario: Admin cannot change from 'waiting for applicant' to rejected
     Given I am on "AnnaWaiting" application page
-    Then I should not see button t("membership_applications.reject")
+    Then I should not see button t("membership_applications.reject_btn")
 
 
   Scenario: Admin cannot change from 'waiting for applicant' to accepted
     Given I am on "AnnaWaiting" application page
-    Then I should not see button t("membership_applications.waiting_for_applicant")
+    Then I should not see button t("membership_applications.accepted_btn")
 
 
   Scenario: Admin cannot change from 'waiting for applicant' to 'waiting for applicant'
     Given I am on "AnnaWaiting" application page
-    Then I should not see button t("membership_applications.waiting_for_applicant")
+    Then I should not see button t("membership_applications.waiting_for_applicant_btn")
 
 
   Scenario: 'Waiting for applicant' status is not changed if admin edits the application
@@ -212,7 +209,7 @@ Feature: As an Admin
   # From accepted to...
   Scenario: Admin changed from accepted to rejected
     Given I am on "NilsAccepted" application page
-    When I click on t("membership_applications.reject")
+    When I click on t("membership_applications.reject_btn")
     Then I should see t("membership_applications.reject.success")
     And I should see status line with status t("membership_applications.rejected")
     When I am on the "landing" page
@@ -224,21 +221,21 @@ Feature: As an Admin
 
   Scenario: Admin cannot change from accepted to accepted
     Given I am on "NilsAccepted" application page
-    Then I should not see button t("membership_applications.accept")
+    Then I should not see button t("membership_applications.accept_btn")
 
 
   Scenario: Admin cannot change from accepted to 'waiting for applicant'
     Given I am on "NilsAccepted" application page
-    Then I should not see button t("membership_applications.waiting_for_applicant")
-    Then I should not see button t("membership_applications.accept")
-    And I should not see button t("membership_applications.ask_applicant_for_info")
-    And I should not see button t("membership_applications.cancel_waiting_for_applicant")
+    Then I should not see button t("membership_applications.waiting_for_applicant_btn")
+    Then I should not see button t("membership_applications.accept_btn")
+    And I should not see button t("membership_applications.ask_applicant_for_info_btn")
+    And I should not see button t("membership_applications.cancel_waiting_for_applicant_btn")
 
 
 
   Scenario: Admin cannot change from accepted to cancel waiting for applicant
     Given I am on "NilsAccepted" application page
-    Then I should not see button t("membership_applications.cancel_waiting_for_applicant")
+    Then I should not see button t("membership_applications.cancel_waiting_for_applicant_btn")
 
 
   # From rejected to...
@@ -265,12 +262,12 @@ Feature: As an Admin
 
   Scenario: Admin cannot change from rejected to 'waiting for applicant'
     Given I am on "LarsRejected" application page
-    Then I should not see button t("membership_applications.waiting_for_applicant")
+    Then I should not see button t("membership_applications.waiting_for_applicant_btn")
 
 
   Scenario: Admin changed from rejected to accepted
     Given I am on "LarsRejected" application page
-    When I click on t("membership_applications.accept")
+    When I click on t("membership_applications.accept_btn")
     Then I should see t("membership_applications.accept.success")
     And I should see t("membership_applications.update.enter_member_number")
     When I am on the "landing" page
@@ -282,9 +279,9 @@ Feature: As an Admin
 
   Scenario: Admin cannot change from rejected to rejected
     Given I am on "LarsRejected" application page
-    Then I should not see button t("membership_applications.reject")
+    Then I should not see button t("membership_applications.reject_btn")
 
 
   Scenario: Admin cannot change from rejected to cancel needs info
     Given I am on "LarsRejected" application page
-    Then I should not see button t("membership_applications.cancel_waiting_for_applicant")
+    Then I should not see button t("membership_applications.cancel_waiting_for_applicant_btn")

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -51,7 +51,7 @@ Feature: As an applicant
     And I am Logged out
     And I am logged in as "admin@shf.com"
     And I am on "Emma" application page
-    Then I click on t("membership_applications.ask_applicant_for_info")
+    Then I click on t("membership_applications.ask_applicant_for_info_btn")
     And  I am logged in as "applicant_1@random.com"
     And I am on the "edit my application" page
     When I choose a file named "picture.jpg" to upload
@@ -91,7 +91,7 @@ Feature: As an applicant
     And I am Logged out
     And I am logged in as "admin@shf.com"
     And I am on "Emma" application page
-    Then I click on t("membership_applications.ask_applicant_for_info")
+    Then I click on t("membership_applications.ask_applicant_for_info_btn")
     And  I am logged in as "applicant_1@random.com"
     And I am on the "edit my application" page
     And I click on trash icon for "diploma.pdf"
@@ -134,4 +134,3 @@ Feature: As an applicant
     And I am on the list applications page
     And I click the t("manage") action for the row with "5562252998"
     And I click on "diploma.pdf"
-


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/139123527

There are errors showing up when an admin creates a state change event when reviewing a membership application.   The errors shows in the flash and indicates a missing translation.

This is because the translation lookups for the state changes are not missing, but rather ambiguous.

For example, translating "membership_application.accept" matches these two entries in the locale file:
```
membership_application
  accept: &event_accept Accept
```
and
```
membership_application
  accept:
      success: The membership has been approved.
      error: There was an error when trying to approve the membership.
```
The first is meant for the label of the "Accept" button, and the second for the #accept action in the controller.

So, ```translate()``` returns "missing translation" message.

Changes proposed in this pull request:
1. Fixed by adding suffix ```_btn``` to the button labels.

<hr>
Start Review:
<img width="272" alt="screen shot 2017-02-12 at 9 13 38 am" src="https://cloud.githubusercontent.com/assets/9968213/22862807/b695604e-f103-11e6-981f-f42290a61bbb.png">
<hr>
Accept Application:
<img width="239" alt="screen shot 2017-02-12 at 9 13 56 am" src="https://cloud.githubusercontent.com/assets/9968213/22862811/b9954dc2-f103-11e6-969b-beec5d4e2e0d.png">
<hr>
Reject Application:
<img width="259" alt="screen shot 2017-02-12 at 9 14 04 am" src="https://cloud.githubusercontent.com/assets/9968213/22862812/bc28aed0-f103-11e6-9495-8d9cb34bad7e.png">
<hr>
Need info:
<img width="556" alt="screen shot 2017-02-12 at 9 14 27 am" src="https://cloud.githubusercontent.com/assets/9968213/22862813/be8cd520-f103-11e6-95c9-0cc5e7c487f5.png">
<hr> 
No longer need info:
<img width="602" alt="screen shot 2017-02-12 at 9 14 35 am" src="https://cloud.githubusercontent.com/assets/9968213/22862814/c01eb7aa-f103-11e6-80e6-3c568e08c6f9.png">



Screenshots (Optional):


Ready for review:
@weedySeaDragon 
@thesuss 