### PR TITLE
Only show org nr to admin

### DIFF
--- a/app/views/companies/show.html.haml
+++ b/app/views/companies/show.html.haml
@@ -8,9 +8,10 @@
   %p
     %b #{t('.name')}:
     = @company.name
-  %p
-    %b #{t('.org_nr')}:
-    = @company.company_number
+  - if current_user && current_user.admin?
+    %p
+      %b #{t('.org_nr')}:
+      = @company.company_number
   %p
     %b #{t('.phone_number')}:
     = @company.phone_number

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,16 +49,17 @@ ActiveRecord::Schema.define(version: 20170207191717) do
   create_table "membership_applications", force: :cascade do |t|
     t.string   "company_number"
     t.string   "phone_number"
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
     t.integer  "user_id"
     t.string   "first_name"
     t.string   "last_name"
     t.string   "contact_email"
     t.integer  "company_id"
     t.string   "membership_number"
-    t.string   "state",             default: "new"
+    t.string   "state",             default: "under_review"
     t.index ["company_id"], name: "index_membership_applications_on_company_id", using: :btree
+    t.index ["state"], name: "index_membership_applications_on_state", using: :btree
     t.index ["user_id"], name: "index_membership_applications_on_user_id", using: :btree
   end
 

--- a/features/show-company.feature
+++ b/features/show-company.feature
@@ -1,0 +1,143 @@
+Feature: As a visitor,
+  So that I can see if a company can provide the services I need,
+  Show me the details about a company
+
+  Because some Org Nr.s are actually for individuals and we don't have a reliable
+  way to tell if they are or not, and because we do not want to
+  (and legally cannot) show the org nr. for an individual,
+  only show the Org Nr to admins.
+
+  PivotalTracker: https://www.pivotaltracker.com/story/show/135474603
+
+
+  Background:
+    Given the following regions exist:
+      | name         |
+      | Stockholm    |
+      | Västerbotten |
+
+    Given the following companies exist:
+      | name                 | company_number | email                  | region       |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.com | Stockholm    |
+      | Bowsers              | 2120000142     | bowwow@bowsersy.com    | Västerbotten |
+      | Company3             | 6613265393     | cmpy3@mail.com         | Stockholm    |
+      | Company4             | 6222279082     | cmpy4@mail.com         | Stockholm    |
+      | Company5             | 8025085252     | cmpy5@mail.com         | Stockholm    |
+      | Company6             | 6914762726     | cmpy6@mail.com         | Stockholm    |
+      | Company7             | 7661057765     | cmpy7@mail.com         | Stockholm    |
+      | Company8             | 7736362901     | cmpy8@mail.com         | Stockholm    |
+      | Company9             | 6112107039     | cmpy9@mail.com         | Stockholm    |
+      | Company10            | 3609340140     | cmpy10@mail.com        | Stockholm    |
+      | Company11            | 2965790286     | cmpy11@mail.com        | Stockholm    |
+      | Company12            | 4268582063     | cmpy12@mail.com        | Stockholm    |
+      | Company13            | 8028973322     | cmpy13@mail.com        | Stockholm    |
+
+    And the following users exists
+      | email               | admin |
+      | emma@happymutts.com |       |
+      | a@happymutts.com    |       |
+      | admin@shf.se        | true  |
+
+    And the following business categories exist
+      | name         |
+      | Groomer      |
+      | Psychologist |
+      | Trainer      |
+      | Rehab        |
+      | Walker       |
+      | JustForFun   |
+
+    And the following applications exist:
+      | first_name | user_email          | company_number | category_name | state    |
+      | Emma       | emma@happymutts.com | 5560360793     | Groomer       | accepted |
+      | Emma       | emma@happymutts.com | 5560360793     | JustForFun    | accepted |
+      | Anna       | a@happymutts.com    | 2120000142     | Groomer       | accepted |
+      | Anna       | a@happymutts.com    | 2120000142     | Trainer       | accepted |
+      | Anna       | a@happymutts.com    | 2120000142     | Rehab         | accepted |
+      | Emma       | emma@happymutts.com | 2120000142     | Psychologist  | accepted |
+      | Emma       | emma@happymutts.com | 2120000142     | Groomer       | accepted |
+      | Anna       | a@happymutts.com    | 6613265393     | Groomer       | accepted |
+      | Anna       | a@happymutts.com    | 6222279082     | Groomer       | accepted |
+      | Anna       | a@happymutts.com    | 8025085252     | Groomer       | accepted |
+      | Anna       | a@happymutts.com    | 6914762726     | Groomer       | accepted |
+      | Anna       | a@happymutts.com    | 7661057765     | Groomer       | accepted |
+      | Anna       | a@happymutts.com    | 7736362901     | Groomer       | accepted |
+      | Anna       | a@happymutts.com    | 6112107039     | Groomer       | accepted |
+      | Anna       | a@happymutts.com    | 3609340140     | Groomer       | accepted |
+      | Anna       | a@happymutts.com    | 2965790286     | Groomer       | accepted |
+      | Anna       | a@happymutts.com    | 4268582063     | Groomer       | accepted |
+      | Anna       | a@happymutts.com    | 8028973322     | Groomer       | accepted |
+
+
+  Scenario: Show company details to a visitor, but don't show the org nr.
+    Given I am Logged out
+    And I am the page for company number "5560360793"
+    Then I should not see "5560360793"
+    And I should see "No More Snarky Barky"
+    And I should see "Groomer"
+    And I should see "JustForFun"
+    And I should see "snarky@snarkybarky.com"
+    And I should see "Stockholm"
+    And I should see "123123123"
+    And I should see "123 1st Street"
+    And I should see "00000"
+    And I should see "Hundborg"
+    And I should see "http://www.example.com"
+    When I am the page for company number "2120000142"
+    Then I should not see "2120000142"
+    And I should see "Bowsers"
+    And I should see "Groomer"
+    And I should see "Trainer"
+    And I should see "Rehab"
+    And I should see "Psychologist"
+    And I should see "bowwow@bowsersy.com"
+    And I should see "Västerbotten"
+    And I should see "123123123"
+    And I should see "123 1st Street"
+    And I should see "00000"
+    And I should see "Hundborg"
+    And I should see "http://www.example.com"
+
+  Scenario: Show company details to member of the company, but don't show the org nr.
+    Given I am logged in as "emma@happymutts.com"
+    And I am the page for company number "5560360793"
+    Then I should not see "5560360793"
+    And I should see "No More Snarky Barky"
+    And I should see "Groomer"
+    And I should see "JustForFun"
+    And I should see "snarky@snarkybarky.com"
+    And I should see "Stockholm"
+    And I should see "123123123"
+    And I should see "123 1st Street"
+    And I should see "00000"
+    And I should see "Hundborg"
+    And I should see "http://www.example.com"
+
+  Scenario: Show company details to admin and do show the org nr.
+    Given I am logged in as "admin@shf.se"
+    And I am the page for company number "5560360793"
+    Then I should see "5560360793"
+    And I should see "No More Snarky Barky"
+    And I should see "Groomer"
+    And I should see "JustForFun"
+    And I should see "snarky@snarkybarky.com"
+    And I should see "Stockholm"
+    And I should see "123123123"
+    And I should see "123 1st Street"
+    And I should see "00000"
+    And I should see "Hundborg"
+    And I should see "http://www.example.com"
+    When I am the page for company number "2120000142"
+    Then I should see "2120000142"
+    And I should see "Bowsers"
+    And I should see "Groomer"
+    And I should see "Trainer"
+    And I should see "Rehab"
+    And I should see "Psychologist"
+    And I should see "bowwow@bowsersy.com"
+    And I should see "Västerbotten"
+    And I should see "123123123"
+    And I should see "123 1st Street"
+    And I should see "00000"
+    And I should see "Hundborg"
+    And I should see "http://www.example.com"

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -66,18 +66,25 @@ Feature: As a visitor,
     And I am on the "landing" page
     Then I should see t("companies.index.h_companies_listed_below")
     And I should see "Bowsers"
+    And I should not see "2120000142"
     And I should see "No More Snarky Barky"
+    And I should not see "5560360793"
     And I should see "Groomer"
     And I should not see "Walker"
     And I should not see t("companies.new_company")
+
 
   Scenario: User sees all the companies
     Given I am logged in as "emma@happymutts.com"
     And I am on the "landing" page
     Then I should see t("companies.index.title")
     And I should see "Bowsers"
+    And I should not see "2120000142"
     And I should see "No More Snarky Barky"
+    And I should not see "5560360793"
     And I should not see t("companies.new_company")
+
+
 
   @javascript
   Scenario: Pagination
@@ -85,8 +92,11 @@ Feature: As a visitor,
     And I am on the "landing" page
     Then I should see t("companies.index.h_companies_listed_below")
     And I should see "Bowsers"
+    And I should not see "2120000142"
     And I should see "No More Snarky Barky"
+    And I should not see "5560360793"
     And I should see "Company10"
+    And I should not see "3609340140"
     And I should not see "Company11"
     Then I click on t("will_paginate.next_label") link
     And I should see "Company11"


### PR DESCRIPTION
PT Story:  **Don't show Org Nr to anyone but admin**
https://www.pivotaltracker.com/story/show/135474603

Changes proposed in this pull request:
1.  created feature for 'show company details'  (We didn't have one!)
2. added check to ensure we're only showing org. nr to admin on list all companies (index)
3.  added conditional so that the Org Nr. is only shown to the admin

**Screenshots (Optional):**

<img width="713" alt="screen shot 2017-02-12 at 12 13 18 pm" src="https://cloud.githubusercontent.com/assets/673794/22865620/cff2c2a2-f11c-11e6-9429-1815d6b8ff75.png">

**Admin:**
<img width="731" alt="screen shot 2017-02-12 at 12 12 59 pm" src="https://cloud.githubusercontent.com/assets/673794/22865618/c1baf8ee-f11c-11e6-8e3f-48c336671403.png">


**Ready for review:**
@thesuss 
