### PR TITLE
show open apps in users view #140598375

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -47,6 +47,9 @@ document.addEventListener('turbolinks:load', function() {
       $('#membership_applications_list').html(data);
     });
 
+    // Enable all Bootstrap tooltips
+    $('[data-toggle="tooltip"]').tooltip();
+
     // Slide mobile navigation from left
     jQuery('#site-navigation .menu-toggle').on('click', function () {
         jQuery(this).toggleClass('active');

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -32,6 +32,7 @@ class MembershipApplication < ApplicationRecord
 
   accepts_nested_attributes_for :uploaded_files, allow_destroy: true
 
+  scope :open, -> { where.not(state: [:accepted, :rejected]) }
 
   include AASM
 
@@ -115,7 +116,7 @@ class MembershipApplication < ApplicationRecord
       company = Company.find_or_create_by!(company_number: company_number) do |co|
         co.email = contact_email
       end
-      
+
       update(company: company)
 
     rescue => e

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -12,7 +12,8 @@
         %th= t('.logged_in_count')
         %th
           = t('.applications')
-          %span.glyphicon.glyphicon-info-sign{ title: "#{t('.applications_tooltip')}" }
+          %span.glyphicon.glyphicon-info-sign{ title: "#{t('.applications_tooltip')}",
+                                               data: {toggle: 'tooltip'} }
         %th= t('.member')
     %tbody
       - @users.each do |user|

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -10,7 +10,9 @@
         %th= t('.created')
         %th= t('.last_login')
         %th= t('.logged_in_count')
-        %th= t('.applications')
+        %th
+          = t('.applications')
+          %span.glyphicon.glyphicon-info-sign{ title: "#{t('.applications_tooltip')}" }
         %th= t('.member')
     %tbody
       - @users.each do |user|

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -22,7 +22,7 @@
             %small= user.last_sign_in_at ?                          |
               "#{time_ago_in_words(user.last_sign_in_at)} ago" : '' |
           %td= user.sign_in_count
-          %td= user.membership_applications.count
+          %td= user.membership_applications.open.count
           - if user.is_member?
             %td
               %span{ style: 'background-color: LightGreen;' }= t('.yes')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -390,7 +390,8 @@ en:
       last_login: Last login
       logged_in_count: Logins
       member: Member
-      applications: Open Applications
+      applications: Applications
+      applications_tooltip: Number of open applications
       'yes': *yes  # https://coderwall.com/p/ld65tq/rails-i18n-yes-no-translation
       'no': *no
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -390,7 +390,7 @@ en:
       last_login: Last login
       logged_in_count: Logins
       member: Member
-      applications: Applications
+      applications: Open Applications
       'yes': *yes  # https://coderwall.com/p/ld65tq/rails-i18n-yes-no-translation
       'no': *no
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -390,7 +390,7 @@ sv:
       last_login: Senast inloggad
       logged_in_count: Inloggningar
       member: Medlem
-      applications: Ansökningar
+      applications: Öppen Ansökningar
       'yes': *yes
       'no': *no
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -391,7 +391,7 @@ sv:
       logged_in_count: Inloggningar
       member: Medlem
       applications: Ansökningar
-      applications_tooltip: Antal öppna program
+      applications_tooltip: Antal öppna ansökningar
       'yes': *yes
       'no': *no
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -390,7 +390,8 @@ sv:
       last_login: Senast inloggad
       logged_in_count: Inloggningar
       member: Medlem
-      applications: Öppen Ansökningar
+      applications: Ansökningar
+      applications_tooltip: Antal öppna program
       'yes': *yes
       'no': *no
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/140598375


Changes proposed in this pull request:
1. Show only "open" (not accepted, not rejected) applications count in users index view  (requested by client after review of User index view)

Screenshots (Optional): 
<hr>
Added tooltip to clarify what the applications column means:
<img width="861" alt="screen shot 2017-03-02 at 6 08 57 am" src="https://cloud.githubusercontent.com/assets/9968213/23504799/fe1fa230-ff0e-11e6-9811-3da006d677a0.png">
<hr>
<img width="852" alt="screen shot 2017-03-02 at 6 10 42 am" src="https://cloud.githubusercontent.com/assets/9968213/23504809/02894e2a-ff0f-11e6-8f04-1847722c5c75.png">



Ready for review:
@weedySeaDragon 
@thesuss 