### PR TITLE
Always show an application's categories to the admin

### DIFF
--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -16,11 +16,6 @@ class MembershipApplicationsController < ApplicationController
   end
 
 
-  def show
-    @categories = @membership_application.business_categories
-  end
-
-
   def edit
     @all_business_categories = BusinessCategory.all
   end
@@ -130,6 +125,7 @@ class MembershipApplicationsController < ApplicationController
 
   def get_membership_application
     @membership_application = MembershipApplication.find(params[:id])
+    @categories = @membership_application.business_categories
   end
 
 

--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -21,6 +21,11 @@ class MembershipApplicationsController < ApplicationController
   end
 
 
+  def show
+    @categories = @membership_application.business_categories
+  end
+
+
   def edit
     @all_business_categories = BusinessCategory.all
   end

--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -1,6 +1,6 @@
 class MembershipApplicationsController < ApplicationController
   before_action :get_membership_application, except: [:information, :index, :new, :create]
-  before_action :authorize_membership_application, only: [:update, :show, :edit, :destroy]
+  before_action :authorize_membership_application, only: [:update, :show, :edit]
 
 
   def new
@@ -15,7 +15,10 @@ class MembershipApplicationsController < ApplicationController
 
     @search_params = MembershipApplication.ransack(params[:q])
 
-    @membership_applications = @search_params.result.page(params[:page]).per_page(10)
+    @membership_applications = @search_params
+                                   .result
+                                   .includes(:business_categories)
+                                   .page(params[:page]).per_page(10)
 
     render partial: 'membership_applications_list' if request.xhr?
   end
@@ -87,6 +90,7 @@ class MembershipApplicationsController < ApplicationController
 
 
   def destroy
+    @membership_application = MembershipApplication.find(params[:id])  # we don't need to fetch the categories
     @membership_application.destroy
     redirect_to membership_applications_url, notice: t('membership_applications.application_deleted')
   end

--- a/features/show_membership_application.feature
+++ b/features/show_membership_application.feature
@@ -12,33 +12,47 @@ Feature: As an Admin
 
   Background:
     Given the following users exists
-      | email                       | admin |
-      | emma@random.com             |       |
-      | hans@random.com             |       |
-      | anna_needs_info@random.com  |       |
-      | lars_rejected@snarkybark.se |       |
-      | nils_member@bowwowwow.se    |       |
-      | admin@sgf.com               | true  |
+      | email                               | admin |
+      | emma@random.com                     |       |
+      | hans@random.com                     |       |
+      | anna_needs_info@random.com          |       |
+      | lars_rejected@snarkybark.se         |       |
+      | nils_member@bowwowwow.se            |       |
+      | admin@shf.com                       | true  |
+      | emma_under_review@happymutts.se     |       |
+      | hans_ready_for_review@happymutts.se |       |
 
-    And the following applications exist:
-      | first_name   | user_email                  | company_number | state                 |
-      | Emma         | emma@random.com             | 5562252998     | waiting_for_applicant |
-      | Hans         | hans@random.com             | 5560360793     | waiting_for_applicant |
-      | Anna         | anna_needs_info@random.com  | 2120000142     | waiting_for_applicant |
-      | LarsRejected | lars_rejected@snarkybark.se | 0000000000     | rejected              |
-      | NilsApproved | nils_member@bowwowwow.se    | 0000000000     | accepted              |
 
     And the following business categories exist
       | name         |
       | Groomer      |
       | Psychologist |
       | Trainer      |
+      | dog grooming |
+      | dog crooning |
+      | rehab        |
 
+    And the following companies exist:
+      | name                 | company_number | email                 |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.se |
+
+    And the following applications exist:
+      | first_name         | user_email                          | company_number | state                 | category_name |
+      | Emma               | emma@random.com                     | 5562252998     | waiting_for_applicant | Psychologist  |
+      | Hans               | hans@random.com                     | 5560360793     | waiting_for_applicant | Psychologist  |
+      | Anna               | anna_needs_info@random.com          | 2120000142     | waiting_for_applicant | Psychologist  |
+      | LarsRejected       | lars_rejected@snarkybark.se         | 0000000000     | rejected              | dog crooning  |
+      | NilsApproved       | nils_member@bowwowwow.se            | 0000000000     | accepted              | Groomer       |
+      | EmmaUnderReview    | emma_under_review@happymutts.se     | 5562252998     | under_review          | rehab         |
+      | HansReadyForReview | hans_ready_for_review@happymutts.se | 5562252998     | ready_for_review      | dog grooming  |
+
+
+  @admin
   Scenario: Listing incoming Applications open for Admin
-    Given I am logged in as "admin@sgf.com"
+    Given I am logged in as "admin@shf.com"
     And I am on the list applications page
-    Then I should see "5" applications
-    And I should see 0 t("membership_applications.under_review")
+    Then I should see "7" applications
+    And I should see 1 t("membership_applications.under_review")
     And I should see 1 t("membership_applications.accepted")
     And I should see 3 t("membership_applications.waiting_for_applicant")
     And I should see 1 t("membership_applications.rejected")
@@ -49,25 +63,27 @@ Feature: As an Admin
     And I should see status line with status t("membership_applications.waiting_for_applicant")
 
 
+  @admin
   Scenario: Admin can see an application with one business categories given
-    Given I am logged in as "hans@random.com"
-    And I am on the "landing" page
-    And I click on t("menus.nav.users.my_application")
-    And I select "Groomer" Category
-    And I click on t("membership_applications.edit.submit_button_label")
-    And I am Logged out
-    And I am logged in as "admin@sgf.com"
+  #  Given I am logged in as "hans@random.com"
+  #  And I am on the "landing" page
+  #  And I click on t("menus.nav.users.my_application")
+  #  And I select "Groomer" Category
+  #  And I click on t("membership_applications.edit.submit_button_label")
+  #  And I am Logged out
+    Given I am logged in as "admin@shf.com"
     And I am on the list applications page
-    Then I should see "5" applications
+    Then I should see "7" applications
     And I click on "Hans Lastname"
     Then I should be on the application page for "Hans"
     And I should see "Hans Lastname"
     And I should see "5560360793"
     And I should see t("membership_applications.new_status")
-    And I should see "Groomer"
+    And I should see "Psychologist"
     And I should not see "Trainer"
-    And I should not see "Psychologist"
+    And I should not see "Groomer"
 
+  @admin
   Scenario: Admin can see an application with multiple business categories given
     Given I am logged in as "emma@random.com"
     And I am on the "landing" page
@@ -76,9 +92,9 @@ Feature: As an Admin
     And I select "Psychologist" Category
     And I click on t("membership_applications.edit.submit_button_label")
     And I am Logged out
-    And I am logged in as "admin@sgf.com"
+    And I am logged in as "admin@shf.com"
     And I am on the list applications page
-    Then I should see "5" applications
+    Then I should see "7" applications
     And I click on "Emma Lastname"
     Then I should be on the application page for "Emma"
     And I should see "Emma Lastname"
@@ -87,25 +103,56 @@ Feature: As an Admin
     And I should see "Psychologist"
     And I should not see "Groomer"
 
+  @member
   Scenario: Approved member should see membership number
     Given I am logged in as "nils_member@bowwowwow.se"
     And I am on the "landing" page
     And I click on t("menus.nav.members.my_application")
     Then I should see t("membership_applications.show.membership_number")
 
+  @user
   Scenario: Listing incoming Applications restricted for Non-admins
     Given I am logged in as "hans@random.com"
     And I am on the list applications page
     Then I should see t("errors.not_permitted")
 
+
+  @admin
   Scenario: Clicking the edit button on show page
-    Given I am logged in as "admin@sgf.com"
+    Given I am logged in as "admin@shf.com"
     When I am on the application page for "NilsApproved"
     Then I should see t("membership_applications.accepted")
     And I click on t("membership_applications.edit_membership_application")
     Then I should be on the edit application page for "NilsApproved"
 
+  @user
   Scenario: User does not see edit-link
     Given I am logged in as "emma@random.com"
     When I am on the application page for "Emma"
     Then I should not see t("membership_applications.edit_membership_application")
+
+
+  @admin
+  Scenario: Admin sees business categories for user under_review
+    Given I am logged in as "admin@shf.se"
+    When I am on the application page for "EmmaUnderReview"
+    Then I should see "rehab"
+
+  @admin
+  Scenario: Admin sees business categories for user that is ready_for_review
+    Given I am logged in as "admin@shf.se"
+    When I am on the application page for "HansReadyForReview"
+    Then I should see "dog grooming"
+
+  @admin
+  Scenario: Admin sees business categories for user that is waiting_for_applicant
+    Given I am logged in as "admin@shf.se"
+    When I am on the application page for "Emma"
+    Then I should see "Psychologist"
+
+
+  @admin
+  Scenario: Admin sees business categories for user that is accepted
+    Given I am logged in as "admin@shf.se"
+    When I am on the application page for "NilsApproved"
+    Then I should see "Groomer"

--- a/features/show_membership_application.feature
+++ b/features/show_membership_application.feature
@@ -74,7 +74,7 @@ Feature: As an Admin
     Given I am logged in as "admin@shf.com"
     And I am on the list applications page
     Then I should see "7" applications
-    And I click on "Hans Lastname"
+    And I click on "Lastname, Hans"
     Then I should be on the application page for "Hans"
     And I should see "Hans Lastname"
     And I should see "5560360793"
@@ -95,8 +95,7 @@ Feature: As an Admin
     And I am logged in as "admin@shf.com"
     And I am on the list applications page
     Then I should see "7" applications
-    And I click on "Emma Lastname"
-
+    And I click on "Lastname, Emma"
     Then I should be on the application page for "Emma"
     And I should see "Emma Lastname"
     And I should see "5562252998"

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -39,6 +39,7 @@ Feature: As an Admin
     And time is frozen at 2016-12-16
 
 
+  @user
   Scenario: Application submitter can see but not update the Application status
     Given I am Logged out
     And I am logged in as "emma_under_review@happymutts.se"
@@ -50,12 +51,15 @@ Feature: As an Admin
 
   # From under_review to...
 
+  @admin @user
   Scenario: Admin requests more info from user (from under_review to 'waiting for applicant')
     Given I am on "EmmaUnderReview" application page
+    Then I should see "rehab"
     When I click on t("membership_applications.ask_applicant_for_info_btn")
     Then I should see t("membership_applications.need_info.success")
     And I should see status line with status t("membership_applications.waiting_for_applicant")
     And I should not see t("membership_applications.update.enter_member_number")
+    And I should see "rehab"
     When I am on the "landing" page
     Then I should see 2 t("membership_applications.waiting_for_applicant")
     And I should see 1 t("membership_applications.under_review")
@@ -66,50 +70,56 @@ Feature: As an Admin
     And I am on the "edit my application" page
     And I should see the checkbox with id "membership_application_marked_ready_for_review" unchecked
 
-
+  @admin
   Scenario: Admin changed from under_review to accepted
     Given I am on "EmmaUnderReview" application page
+    Then I should see "rehab"
     When I click on t("membership_applications.accept_btn")
     Then I should see t("membership_applications.accept.success")
     And I should see t("membership_applications.update.enter_member_number")
+    And I should see "rehab"
     When I am on the "landing" page
     Then I should see 1 t("membership_applications.waiting_for_applicant")
     And I should see 1 t("membership_applications.under_review")
     And I should see 2 t("membership_applications.accepted")
     And I should see 1 t("membership_applications.rejected")
 
-
+  @admin
   Scenario: Admin changed from under_review to rejected
     Given I am on "EmmaUnderReview" application page
+    Then I should see "rehab"
     When I click on t("membership_applications.reject_btn")
     Then I should see t("membership_applications.reject.success")
     And I should see status line with status t("membership_applications.rejected")
     And I should not see t("membership_applications.update.enter_member_number")
+    And I should see "rehab"
     When I am on the "landing" page
     Then I should see 1 t("membership_applications.waiting_for_applicant")
     And I should see 1 t("membership_applications.under_review")
     And I should see 2 t("membership_applications.rejected")
     And I should see 1 t("membership_applications.accepted")
 
-
+  @admin
   Scenario: Admin cannot change from under_review to 'cancel waiting for applicant'
     Given I am on "EmmaUnderReview" application page
     Then I should not see button t("membership_applications.cancel_waiting_for_applicant_btn")
 
-
+  @admin
   Scenario: Admin rejects an application (under_review to rejected)
     Given I am on "EmmaUnderReview" application page
+    Then I should see "rehab"
     When I click on t("membership_applications.reject_btn")
     Then I should see t("membership_applications.reject.success")
     And I should see status line with status t("membership_applications.rejected")
     And I should not see t("membership_applications.update.enter_member_number")
+    And I should see "rehab"
     When I am on the "landing" page
     Then I should see 2 t("membership_applications.rejected")
     And I should see 1 t("membership_applications.under_review")
     And I should see 1 t("membership_applications.waiting_for_applicant")
     And I should see 1 t("membership_applications.accepted")
 
-
+  @admin @user
   Scenario: Admin rejects an application that had uploaded files (under_review to rejected)
     Given  I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
     And I am on the "edit my application" page
@@ -118,6 +128,7 @@ Feature: As an Admin
     And I am Logged out
     And I am logged in as "admin@shf.se"
     And I am on "AnnaWaiting" application page
+    And I should see "rehab"
     Then I click on t("membership_applications.ask_applicant_for_info_btn")
     And  I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
     And I am on the "edit my application" page
@@ -132,10 +143,11 @@ Feature: As an Admin
     And I should see 0 uploaded files listed
     And I should not see "diploma.pdf"
     And I should not see "image.png"
+    And I should see "rehab"
 
 
   # From waiting for applicant to...
-
+  @member
   Scenario: Anna updates her application but doesn't mark it as ready to be reviewed yet
     Given I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
     And I am on the "edit my application" page
@@ -146,7 +158,7 @@ Feature: As an Admin
     And I should not see status line with status t("membership_applications.ready_for_review")
 
 
-
+  @user @admin
   Scenario: Anna marks her application as ready to be reviewed again
     Given I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
     And I am on the "edit my application" page
@@ -160,42 +172,45 @@ Feature: As an Admin
     And I am logged in as "admin@shf.se"
     And I am on "AnnaWaiting" application page
     Then I should see status line with status t("membership_applications.ready_for_review")
+    And I should see "rehab"
     And I am on the "landing" page
     And I should see 1 t("membership_applications.ready_for_review")
     And I should see 1 t("membership_applications.accepted")
     And I should see 2 t("membership_applications.under_review")
     And I should see 1 t("membership_applications.rejected")
 
-
+  @admin
   Scenario: Admin changed from 'waiting for applicant' to 'under review'
     Given I am on "AnnaWaiting" application page
+    And I should see "rehab"
     When I click on t("membership_applications.cancel_waiting_for_applicant_btn")
     Then I should see t("membership_applications.cancel_need_info.success")
     And I should see status line with status t("membership_applications.under_review")
     And I should not see t("membership_applications.waiting_for_applicant")
     And I should not see t("membership_applications.update.enter_member_number")
+    And I should see "rehab"
     When I am on the "landing" page
     And I should see 3 t("membership_applications.under_review")
     And I should not see t("membership_applications.waiting_for_applicant")
     And I should see 1 t("membership_applications.accepted")
     And I should see 1 t("membership_applications.rejected")
 
-
+  @admin
   Scenario: Admin cannot change from 'waiting for applicant' to rejected
     Given I am on "AnnaWaiting" application page
     Then I should not see button t("membership_applications.reject_btn")
 
-
+  @admin
   Scenario: Admin cannot change from 'waiting for applicant' to accepted
     Given I am on "AnnaWaiting" application page
     Then I should not see button t("membership_applications.accepted_btn")
 
-
+  @admin
   Scenario: Admin cannot change from 'waiting for applicant' to 'waiting for applicant'
     Given I am on "AnnaWaiting" application page
     Then I should not see button t("membership_applications.waiting_for_applicant_btn")
 
-
+  @admin
   Scenario: 'Waiting for applicant' status is not changed if admin edits the application
     Given I am on "AnnaWaiting" application page
     And I click on t("membership_applications.edit_membership_application")
@@ -207,23 +222,26 @@ Feature: As an Admin
 
 
   # From accepted to...
+  @admin
   Scenario: Admin changed from accepted to rejected
     Given I am on "NilsAccepted" application page
+    And I should see "dog crooning"
     When I click on t("membership_applications.reject_btn")
     Then I should see t("membership_applications.reject.success")
     And I should see status line with status t("membership_applications.rejected")
+    And I should see "dog crooning"
     When I am on the "landing" page
     And I should see 2 t("membership_applications.under_review")
     And I should see 1 t("membership_applications.waiting_for_applicant")
     And I should see 0 t("membership_applications.accepted")
     And I should see 2 t("membership_applications.rejected")
 
-
+  @admin
   Scenario: Admin cannot change from accepted to accepted
     Given I am on "NilsAccepted" application page
     Then I should not see button t("membership_applications.accept_btn")
 
-
+  @admin
   Scenario: Admin cannot change from accepted to 'waiting for applicant'
     Given I am on "NilsAccepted" application page
     Then I should not see button t("membership_applications.waiting_for_applicant_btn")
@@ -232,56 +250,62 @@ Feature: As an Admin
     And I should not see button t("membership_applications.cancel_waiting_for_applicant_btn")
 
 
-
+  @admin
   Scenario: Admin cannot change from accepted to cancel waiting for applicant
     Given I am on "NilsAccepted" application page
     Then I should not see button t("membership_applications.cancel_waiting_for_applicant_btn")
 
 
   # From rejected to...
+  @user
   Scenario: User can only view application if it's rejected, they cannot edit it
     Given I am logged in as "lars_rejected@snarkybark.se"
     And I am on "LarsRejected" application page
     Then I should see t("membership_applications.show.title", member_full_name: "LarsRejected Lastname")
     And I should not see t("membership_applications.edit.title")
+    And I should see "rehab"
 
-
+  @admin
   Scenario: Admin cannot edit an application if it is rejected
     Given I am on "LarsRejected" application page
+    And I should see "rehab"
     When I click on t("membership_applications.edit_membership_application")
     And I fill in t("membership_applications.show.last_name") with "BadBadLars"
     And I click on t("membership_applications.edit.submit_button_label")
     Then I should see t("membership_applications.update.success")
     And I should see status line with status t("membership_applications.rejected")
+    And I should see "rehab"
     When I am on the "landing" page
     And I should see 2 t("membership_applications.under_review")
     And I should see 1 t("membership_applications.waiting_for_applicant")
     And I should see 1 t("membership_applications.accepted")
     And I should see 1 t("membership_applications.rejected")
 
-
+  @admin
   Scenario: Admin cannot change from rejected to 'waiting for applicant'
     Given I am on "LarsRejected" application page
     Then I should not see button t("membership_applications.waiting_for_applicant_btn")
 
-
+  @admin
   Scenario: Admin changed from rejected to accepted
     Given I am on "LarsRejected" application page
+    And I should see "rehab"
     When I click on t("membership_applications.accept_btn")
     Then I should see t("membership_applications.accept.success")
     And I should see t("membership_applications.update.enter_member_number")
+    And I should see "rehab"
     When I am on the "landing" page
     Then I should see 1 t("membership_applications.waiting_for_applicant")
     And I should see 2 t("membership_applications.under_review")
     And I should see 2 t("membership_applications.accepted")
     And I should see 0 t("membership_applications.rejected")
 
-
+  @admin
   Scenario: Admin cannot change from rejected to rejected
     Given I am on "LarsRejected" application page
     Then I should not see button t("membership_applications.reject_btn")
 
-
+  @admin
   Scenario: Admin cannot change from rejected to cancel needs info
     Given I am on "LarsRejected" application page
     Then I should not see button t("membership_applications.cancel_waiting_for_applicant_btn")


### PR DESCRIPTION
PT Story:  Don't hide categories in review process
https://www.pivotaltracker.com/story/show/140427055

Changes proposed in this pull request:
1. added scenarios and assertions in features to check that the business categories are being displayed
2. `MembershipApplicationController`: when a membership application if fetched, set the business categories for it to `@categories` so the views can display them


### Screenshots

Here are some screenshots to show that the business categories always display:

<img width="644" alt="accepted" src="https://cloud.githubusercontent.com/assets/673794/23335999/eba2cd12-fb76-11e6-8f5f-41c288322496.png">

---
<img width="652" alt="waiting-for-info" src="https://cloud.githubusercontent.com/assets/673794/23336000/eba42b26-fb76-11e6-9b08-dcfbb78b2b12.png">

---
<img width="643" alt="under-review" src="https://cloud.githubusercontent.com/assets/673794/23336001/eba5a2d0-fb76-11e6-9484-025902ed37dd.png">


Ready for review:
@thesuss @patmbolger 
