### PR TITLE
search and sort applications #140427133

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -231,9 +231,10 @@ Metrics/CyclomaticComplexity:
   Enabled: true
 
 Metrics/LineLength:
-  Description: 'Limit lines to 80 characters.'
+  Description: 'Limit lines to 90 characters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
   Enabled: false
+  Max: 90
 
 Metrics/MethodLength:
   Description: 'Avoid methods longer than 30 lines of code.'

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,7 +20,7 @@
 document.addEventListener('turbolinks:load', function() {
     'use strict';
 
-    $.each($('.company_search'), function (index, ele) {
+    $.each($('.search_field'), function (index, ele) {
       if ($(ele).data('select2') === undefined &&
           $(ele).next().hasClass('select2-container')) {
         $(ele).next().remove();
@@ -37,10 +37,14 @@ document.addEventListener('turbolinks:load', function() {
     $('#toggle_search_form').click(Utility.toggle);
 
     // Paginate link sends AJAX request to controller, which renders new page
-    // in JS response.  This callback executes at that point and replaces
-    // the prior pagination page with the new page.
+    // in JS response.  These callbacks execute at that point and replaces
+    // the prior pagination page (DOM element) with the new page.
     $('body').on('ajax:success', '.companies_pagination', function (e, data) {
       $('#companies_list').html(data);
+    });
+
+    $('body').on('ajax:success', '.applications_pagination', function (e, data) {
+      $('#membership_applications_list').html(data);
     });
 
     // Slide mobile navigation from left

--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -12,7 +12,12 @@ class MembershipApplicationsController < ApplicationController
 
   def index
     authorize MembershipApplication
-    @membership_applications = MembershipApplication.all
+
+    @search_params = MembershipApplication.ransack(params[:q])
+
+    @membership_applications = @search_params.result.page(params[:page]).per_page(10)
+
+    render partial: 'membership_applications_list' if request.xhr?
   end
 
 

--- a/app/views/companies/_search_form.html.haml
+++ b/app/views/companies/_search_form.html.haml
@@ -10,7 +10,7 @@
                       BusinessCategory.order(:name).distinct,
                       :id, :name, { include_blank: false },
                       { multiple: true, size: 5, style: 'width: 100%;',
-                        class: 'form-control company_search',
+                        class: 'form-control search_field',
                         data: {language: "#{@locale}" } }
     .col-sm-4
       = f.label :region_id_in,
@@ -21,7 +21,7 @@
                       Region.all,
                       :id, :name, { include_blank: false },
                       { multiple: true, size: 5, style: 'width: 100%;',
-                        class: 'form-control company_search',
+                        class: 'form-control search_field',
                         data: {language: "#{@locale}" } }
 
     .col-sm-3
@@ -33,7 +33,7 @@
                      Company.complete.distinct.order(:city).pluck(:city),
                      :to_s, :to_s, { include_blank: false },
                      { multiple: true, size: 5, style: 'width: 100%;',
-                       class: 'form-control company_search',
+                       class: 'form-control search_field',
                        data: {language: "#{@locale}" } }
   .form-group
     .col-sm-8
@@ -45,7 +45,7 @@
                       Company.complete.order(:name),
                       :name, :name, { include_blank: false },
                       { multiple: true, size: 5, style: 'width: 100%;',
-                        class: 'form-control company_search',
+                        class: 'form-control search_field',
                         data: {language: "#{@locale}" } }
 
     .col-sm-4

--- a/app/views/membership_applications/_membership_applications_list.html.haml
+++ b/app/views/membership_applications/_membership_applications_list.html.haml
@@ -1,0 +1,27 @@
+#membership_applications_list
+  %table
+    %thead
+      %tr
+        %th
+          = sort_link(@search_params, :last_name,
+                      t('membership_applications.index.name'))
+        %th
+          = sort_link(@search_params, :company_number,
+                      t('membership_applications.index.org_nr'))
+        %th
+          = sort_link(@search_params, :state,
+                      t('membership_applications.index.state'))
+        %th
+    %tbody
+      - @membership_applications.each do | membership_application |
+        %tr.applicant
+          %td.name= link_to "#{membership_application.last_name + ', ' + membership_application.first_name}", membership_application_path(membership_application.id)
+          %td.company_number= membership_application.company_number
+          %td.state= t("membership_applications.state.#{membership_application.state}")
+          %td.action= link_to "#{t('manage')}", membership_application_path(membership_application.id)
+
+  .center
+    = will_paginate @membership_applications,
+                    renderer: BootstrapPagination::Rails,
+                    link_options: { 'data-remote': true,
+                                    class: 'applications_pagination' }

--- a/app/views/membership_applications/_membership_applications_list.html.haml
+++ b/app/views/membership_applications/_membership_applications_list.html.haml
@@ -13,7 +13,7 @@
                       t('membership_applications.index.state'))
         %th
     %tbody
-      - @membership_applications.each do | membership_application |
+      - @membership_applications.each do |membership_application|
         %tr.applicant
           %td.name= link_to "#{membership_application.last_name + ', ' + membership_application.first_name}", membership_application_path(membership_application.id)
           %td.company_number= membership_application.company_number

--- a/app/views/membership_applications/_search_form.html.haml
+++ b/app/views/membership_applications/_search_form.html.haml
@@ -1,0 +1,41 @@
+= search_form_for @search_params, method: :get, url: membership_applications_path,
+                                  class: 'form-horizontal' do |f|
+  .form-group
+    .col-sm-5
+      = f.label :last_name_in,
+                "#{t('activerecord.attributes.membership_application.last_name')}",
+                class: 'control-label',
+                style: 'text-align: left; font-size: 12px;'
+      = f.collection_select :last_name_in,
+                      MembershipApplication.distinct.order(:last_name).pluck(:last_name),
+                      :to_s, :to_s, { include_blank: false },
+                      { multiple: true, size: 5, style: 'width: 100%;',
+                        class: 'form-control search_field',
+                        data: {language: "#{@locale}" } }
+    .col-sm-3
+      = f.label :company_number_in,
+                "#{t('membership_applications.index.org_nr')}",
+                class: 'control-label',
+                style: 'text-align: left; font-size: 12px;'
+      = f.collection_select :company_number_in,
+                      MembershipApplication.order(:company_number).pluck(:company_number),
+                      :to_s, :to_s, { include_blank: false },
+                      { multiple: true, size: 5, style: 'width: 100%;',
+                        class: 'form-control search_field',
+                        data: {language: "#{@locale}" } }
+
+    .col-sm-4
+      = f.label :state_in,
+                "#{t('membership_applications.index.state')}",
+               class: 'control-label',
+               style: 'text-align: left; font-size: 12px;'
+      = f.collection_select :state_in,
+                     MembershipApplication.aasm.states_for_select,
+                     :second, :first, { include_blank: false },
+                     { multiple: true, size: 5, style: 'width: 100%;',
+                       class: 'form-control search_field',
+                       data: {language: "#{@locale}" } }
+
+    .col-sm-12
+      %br
+      = submit_tag "#{t('search')}", class: 'btn btn-primary pull-right'

--- a/app/views/membership_applications/index.html.haml
+++ b/app/views/membership_applications/index.html.haml
@@ -3,17 +3,20 @@
 .post-title-divider
   %span
 .entry-content
-  %table
-    %thead
-      %tr
-        %th= t('.name')
-        %th= t('.org_nr')
-        %th= t('.state')
-        %th
-    %tbody
-      - @membership_applications.each do | membership_application |
-        %tr.applicant
-          %td.name= link_to "#{membership_application.first_name + ' ' + membership_application.last_name}", membership_application_path(membership_application.id)
-          %td.company_number= membership_application.company_number
-          %td.state= t("membership_applications.state.#{membership_application.state}")
-          %td.action= link_to "#{t('.manage')}", membership_application_path(membership_application.id)
+  %p{ style: 'margin-bottom: 30px;' }
+    %button.btn.btn-success.btn-xs.pull-right{ id: 'toggle_search_form',
+                                      href: '#application_search_form',
+                                      style: 'color:black; text-transform:none;' }
+      #{t('toggle.application_search_form.hide')}
+
+  .clearfix
+
+  .panel.panel-default{ style: 'padding-left: 5px; padding-right: 5px;',
+                    id: 'application_search_form' }
+    = render 'search_form'
+
+  - if @membership_applications.empty?
+    %strong
+      #{t('.no_search_results')}
+  - else
+    = render partial: 'membership_applications_list'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,9 @@ en:
     company_search_form:
       hide: Hide Form
       show: Show Form
+    application_search_form:
+      hide: Hide Form
+      show: Show Form
 
   will_paginate:
       previous_label: "« Previous"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -49,6 +49,9 @@ sv:
     company_search_form:
       hide: Dölj Sökfunktionen
       show: Visa Sökfunktionen
+    application_search_form:
+      hide: Dölj Sökfunktionen
+      show: Visa Sökfunktionen
 
   will_paginate:
     previous_label: "« Föregående"

--- a/features/search_applications.feature
+++ b/features/search_applications.feature
@@ -1,0 +1,102 @@
+Feature: Search Membership Applications
+
+As an admin for the site
+In order to find find and manage applications
+I want to search for applications by various criteria
+
+Background:
+  Given the following users exists
+    | email                | admin |
+    | fred@barkyboys.com   |       |
+    | john@happymutts.com  |       |
+    | anna@dogsrus.com     |       |
+    | emma@weluvdogs.com   |       |
+    | admin@shf.se         | true  |
+
+  And the following business categories exist
+    | name         |
+    | Groomer      |
+    | Psychologist |
+    | Trainer      |
+    | Walker       |
+
+  Given the following regions exist:
+    | name         |
+    | Stockholm    |
+    | Västerbotten |
+    | Norrbotten   |
+    | Sweden       |
+
+  And the following companies exist:
+    | name        | company_number | email                | region       | city        |
+    | Barky Boys  | 5560360793     | barky@barkyboys.com  | Stockholm    | Bagarmossen |
+    | HappyMutts  | 2120000142     | woof@happymutts.com  | Västerbotten | Kusmark     |
+    | Dogs R Us   | 5562252998     | chief@dogsrus.com    | Norrbotten   | Morjarv     |
+    | We Luv Dogs | 5569467466     | alpha@weluvdogs.com  | Sweden       |             |
+
+  And the following applications exist:
+    | first_name | last_name  | user_email          | company_number | state        | category_name |
+    | Fred       | Fransson   | fred@barkyboys.com  | 5560360793     | rejected     | Groomer       |
+    | John       | Johanssen  | john@happymutts.com | 2120000142     | accepted     | Psychologist  |
+    | Anna       | Anderson   | anna@dogsrus.com    | 5562252998     | new          | Trainer       |
+    | Emma       | Eriksson   | emma@weluvdogs.com  | 5569467466     | under_review | Walker        |
+
+  And I am logged in as "admin@shf.se"
+  And I am on the "membership applications" page
+
+@javascript
+Scenario: Search by user's last name
+  And I should see "Fred"
+  And I should see "John"
+  And I should see "Anna"
+  And I should see "Emma"
+  Then I select "Fransson" in select list t("activerecord.attributes.membership_application.last_name")
+  And I click on t("search") button
+  And I should see "Fransson, Fred"
+  And I should not see "John"
+  And I should not see "Anna"
+  And I should not see "Emma"
+
+@javascript
+Scenario: Search by company (org) number
+  Then I select "5569467466" in select list t("membership_applications.index.org_nr")
+  And I click on t("search") button
+  Then I should see "Eriksson, Emma"
+  And I should not see "John"
+  And I should not see "Anna"
+  And I should not see "Fred"
+  Then I select "2120000142" in select list t("membership_applications.index.org_nr")
+  And I click on t("search") button
+  Then I should see "Eriksson, Emma"
+  Then I should see "Johanssen, John"
+
+@javascript
+Scenario: Search by status
+  Then I select "Under review" in select list t("membership_applications.index.state")
+  And I click on t("search") button
+  And I should see "Eriksson, Emma"
+  And I should not see "John"
+  And I should not see "Anna"
+  And I should not see "Fred"
+  Then I select "New" in select list t("membership_applications.index.state")
+  And I click on t("search") button
+  And I should see "Eriksson, Emma"
+  And I should see "Anderson, Anna"
+  And I should not see "John"
+  And I should not see "Fred"
+
+@javascript
+Scenario: Search by status and company number
+  Then I select "Under review" in select list t("membership_applications.index.state")
+  Then I select "2120000142" in select list t("membership_applications.index.org_nr")
+  And I click on t("search") button
+  And I should not see "Emma"
+  And I should not see "John"
+  And I should not see "Anna"
+  And I should not see "Fred"
+  Then I select "5569467466" in select list t("membership_applications.index.org_nr")
+  And I click on t("search") button
+  And I should see "Eriksson, Emma"
+  And I should not see "John"
+  And I should not see "Anna"
+  And I should not see "Fred"

--- a/features/show_membership_application.feature
+++ b/features/show_membership_application.feature
@@ -42,7 +42,7 @@ Feature: As an Admin
     And I should see 1 t("membership_applications.accepted")
     And I should see 3 t("membership_applications.waiting_for_applicant")
     And I should see 1 t("membership_applications.rejected")
-    And I click on "Emma Lastname"
+    And I click on "Lastname, Emma"
     Then I should be on the application page for "Emma"
     And I should see "Emma Lastname"
     And I should see "5562252998"
@@ -59,7 +59,7 @@ Feature: As an Admin
     And I am logged in as "admin@sgf.com"
     And I am on the list applications page
     Then I should see "5" applications
-    And I click on "Hans Lastname"
+    And I click on "Lastname, Hans"
     Then I should be on the application page for "Hans"
     And I should see "Hans Lastname"
     And I should see "5560360793"
@@ -79,7 +79,7 @@ Feature: As an Admin
     And I am logged in as "admin@sgf.com"
     And I am on the list applications page
     Then I should see "5" applications
-    And I click on "Emma Lastname"
+    And I click on "Lastname, Emma"
     Then I should be on the application page for "Emma"
     And I should see "Emma Lastname"
     And I should see "5562252998"

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -9,6 +9,8 @@ Given(/^I am on the "([^"]*)" page$/) do |page|
       path = edit_membership_application_path(user.membership_applications.last)
     when 'business categories'
       path = business_categories_path
+    when 'membership applications'
+      path = membership_applications_path
     when 'all companies'
       path = companies_path
     when 'create a new company'


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/140427133

Changes proposed in this pull request:
1. Add search form for applications
2. Add ability to sort columns in applications index view
3. Add paginations (JS-driven)to applications index view
4. Make generic the JS function that enables "select2" functionality for search form fields (now used in both companies index view and applications index view)
5. Adjusted Houndci setting to complain about "line too long" only if the line exceeds 90 chars (instead of 80)

Screenshots (Optional):
<hr>
<img width="884" alt="screen shot 2017-02-26 at 3 46 02 pm" src="https://cloud.githubusercontent.com/assets/9968213/23343513/ed47b60e-fc3a-11e6-926e-316efff51f0e.png">

<hr>
<img width="857" alt="screen shot 2017-02-26 at 3 47 04 pm" src="https://cloud.githubusercontent.com/assets/9968213/23343515/f26f9250-fc3a-11e6-8f22-9fd4a1563c6b.png">

<hr>

Ready for review:
@weedySeaDragon 
@thesuss 