### PR TITLE
Admin can change the password for user

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -36,6 +36,9 @@ document.addEventListener('turbolinks:load', function() {
     // Bind 'show/hide' search form toggle switch
     $('#toggle_search_form').click(Utility.toggle);
 
+    $('#toggle_admin_set_password_form').click(Utility.toggle);
+
+
     // Paginate link sends AJAX request to controller, which renders new page
     // in JS response.  These callbacks execute at that point and replaces
     // the prior pagination page (DOM element) with the new page.

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -117,4 +117,4 @@ document.addEventListener('turbolinks:load', function() {
 
 });
 //Set timeout for flashes
-setTimeout("$('.flashes').fadeOut('slow');", 7000);
+setTimeout("$('.flashes').fadeOut('slow');", 5000);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -117,4 +117,4 @@ document.addEventListener('turbolinks:load', function() {
 
 });
 //Set timeout for flashes
-setTimeout("$('.flashes').fadeOut('slow');", 5000);
+setTimeout("$('.flashes').fadeOut('slow');", 7000);

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -4,3 +4,19 @@ $admin-color: #ff0000;
   color: $admin-color;
   font-weight: bold;
 }
+
+.panel.admin-set-new-password-form {
+  margin-left: 2em;
+  margin-right: 2em;
+  margin-top: 1em;
+}
+
+.form-horizontal.edit-user.admin-set-password {
+
+  padding: 1em;
+
+  .field.form-group {
+    margin-left: 0;
+  }
+
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,12 +1,23 @@
 class UsersController < ApplicationController
   before_action :authorize_user
-  before_action :set_user, only: :show
+  before_action :set_user, except: :index
 
 
   def index
     @users = User.all.order(last_sign_in_at: :asc)
   end
 
+
+  def update
+
+    if passwords_match(user_params) && @user.update(user_params)
+      redirect_to @user, notice: t('.success')
+    else
+      flash[:alert] = t('.error') + '  ' + t('.passwords_dont_match')
+      render :show
+    end
+
+  end
 
 
   private
@@ -15,8 +26,22 @@ class UsersController < ApplicationController
     authorize User
   end
 
+
   def set_user
     @user = User.find(params[:id])
   end
+
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def user_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
+
+
+  # if the password was changed, ensure the confirmation matches the 1st one entered
+  def passwords_match(u_params)
+    u_params.key?('password') && u_params.key?('password_confirmation') && u_params['password'] == u_params['password_confirmation']
+  end
+
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,10 +10,13 @@ class UsersController < ApplicationController
 
   def update
 
-    if passwords_match(user_params) && @user.update(user_params)
+    if @user.update(user_params)
       redirect_to @user, notice: t('.success')
     else
-      flash[:alert] = t('.error') + '  ' + t('.passwords_dont_match')
+      helpers.flash_message(:alert, t('.error'))
+
+      @user.errors.full_messages.each { |err_message| helpers.flash_message(:alert, err_message) }
+
       render :show
     end
 
@@ -35,12 +38,6 @@ class UsersController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation)
-  end
-
-
-  # if the password was changed, ensure the confirmation matches the 1st one entered
-  def passwords_match(u_params)
-    u_params.key?('password') && u_params.key?('password_confirmation') && u_params['password'] == u_params['password_confirmation']
   end
 
 

--- a/app/views/application/_flash.html.haml
+++ b/app/views/application/_flash.html.haml
@@ -1,4 +1,4 @@
-.flashes
+#flashes.flashes
   - flash.each do |key, value|
     %div{class: "alert alert-#{flash_class(key)} center"}= render_flash_message(value)
 

--- a/app/views/application/_flash.html.haml
+++ b/app/views/application/_flash.html.haml
@@ -1,3 +1,5 @@
 .flashes
   - flash.each do |key, value|
     %div{class: "alert alert-#{flash_class(key)} center"}= render_flash_message(value)
+
+  - flash.clear

--- a/app/views/users/_password_form.html.haml
+++ b/app/views/users/_password_form.html.haml
@@ -1,0 +1,18 @@
+= form_for(@user,  html: {class: 'form-horizontal edit-user admin-set-password'}) do |f|
+
+
+  .field.form-group
+    = f.label :password, "#{t('users.show.new_password')}", class: 'required col-sm-4 control-label'
+    = f.text_field :password, autocomplete: 'off',  class: 'wpcf7-form-control col-sm-6'
+
+
+  .field.form-group
+    = f.label :password_confirmation, "#{t('users.show.re_enter_new_password')}", class: 'required col-sm-4 control-label'
+    = f.text_field :password_confirmation, autocomplete: 'off',  class: 'wpcf7-form-control col-sm-6'
+
+
+  %p.new-password-warn.row
+    = t('users.show.please_note_new_password')
+
+  .row
+    = submit_tag( :submit, value: "#{t('users.show.submit_new_password')}", class: 'btn', data: { confirm: "#{t('users.show.confirm_reset_password')}"})

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,7 +1,7 @@
 %header.entry-header
   - if @user.admin?
     %h1.entry-title.is-admin
-      =@user.email
+      = @user.email
       %span.small
         (#{t('.is_an_admin')})
 
@@ -29,7 +29,7 @@
 
   %p
     - if @user.reset_password_sent_at.blank?
-      =t('.password_never_reset')
+      = t('.password_never_reset')
     - else
       %b #{t('.reset_password_sent_at')}:
       #{@user.reset_password_sent_at}
@@ -40,3 +40,16 @@
     %b #{t('.created')}:
     = @user.created_at
     (#{i18n_time_ago_in_words(@user.created_at)})
+
+  %hr
+
+  %button.btn.alert-danger.admin-set-new-password{ id: 'toggle_admin_set_password_form',
+               href: '#set_new_password_form',
+               style: 'text-transform:none;' }
+
+    #{ t('toggle.set_new_password_form.show') }
+
+  .panel.panel-default.admin-set-new-password-form{ id: 'set_new_password_form' ,
+                        style: 'display: none;'}
+
+    = render 'password_form'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,9 @@ en:
     application_search_form:
       hide: Hide Form
       show: Show Form
+    set_new_password_form:
+      hide: "Hide the Change Password info"
+      show: "Change the User's Password"
 
   will_paginate:
       previous_label: "« Previous"
@@ -427,6 +430,17 @@ en:
       is_an_admin: Is an Admin
       'yes': *yes
       'no': *no
+      reset_password: Change the Password
+      confirm_reset_password: "Are you sure?\rThis will overwrite the current password for this user!\r(If you have not recorded the password yet, choose Cancel.)"
+      new_password: New Password
+      re_enter_new_password: Re-Enter the Password
+      please_note_new_password: Please record this in a safe and secure place. Once you press the Save button below you will not be able to see the password again and there is no way to display it again.
+      submit_new_password: Save the New Password
+
+    update:
+      passwords_dont_match: "The two passwords entered don't match."
+      success: The user was updated.
+      error: A problem kept the user from being updated.
 
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -425,7 +425,7 @@ en:
       logged_in_count: *sign_in_count
       created: *created
       reset_password_sent_at: *user_reset_password_sent_at
-      password_never_reset: Password has never been reset.
+      password_never_reset: Password has never been reset by the user.
       user_has_never_signed_in: has never logged in.
       is_an_admin: Is an Admin
       'yes': *yes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,7 @@ en:
       user:
         email: &email Email
         password: *password
+        password_confirmation: Password confirmation
         created: &created Created
         current_sign_in_at: &user_current_signed_in_time Currently signed in at
         current_sign_in_ip: &user_current_ip Currently signed in from IP address
@@ -143,6 +144,12 @@ en:
           company_number:
             taken: This company (organization number) already exists in the system.
           company_has_active_memberships: "The company has active (accepted) membership applications."
+
+        user:
+          attributes:
+            password_confirmation:
+              confirmation: doesn't match with the password entered.
+
 
       messages:
         record_invalid: "Validation failed: %{errors}"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -57,7 +57,7 @@ sv:
       show: Visa Sökfunktionen
     set_new_password_form:
       hide: "Dölj the 'Change Password' info"
-      show: "Change the User's Password"
+      show: "Ändra användarens lösenord"
 
 
   will_paginate:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -431,17 +431,17 @@ sv:
       is_an_admin: Är en admin
       'yes': *yes
       'no': *no
-      reset_password: Change the Password
-      confirm_reset_password: "Are you sure?  This will over-write the current password for this user!\n  (If you have not recorded the password yet, choose Cancel.)"
-      new_password: Nytt Password
-      re_enter_new_password: Re-Enter the Password
-      please_note_new_password: Please record this in a safe and secure place. Once you press the Save button below you will not be able to see the password again and there is no way to display it again.
-      submit_new_password: Save the New Password
+      reset_password: Byt lösenord
+      confirm_reset_password: "Är du säker? Detta skriver över nuvarande lösenord för denna användare!\n (Om du inte har noterat lösenordet, välj Avbryt.)"
+      new_password: Nytt lösenord
+      re_enter_new_password: Skriv in lösenordet igen
+      please_note_new_password: Spara detta på ett säkert ställe. När du klickar på spara nedan kommer du inte att kunna se lösenordet igen och det finns ingen möjlighet att åter visa det.
+      submit_new_password: Spara det nya lösenordet
 
     update:
-      passwords_dont_match: "The two passwords entered don't match."
-      success: Användar uppdaterad.
-      error: Ett problem hindrade användar från att raderas.
+      passwords_dont_match: De två lösenord du angivit matchar inte.
+      success: Användarens information uppdaterad.
+      error: Ett problem hindrade användarinformationen från att uppdateras.
 
 
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -55,6 +55,10 @@ sv:
     application_search_form:
       hide: Dölj Sökfunktionen
       show: Visa Sökfunktionen
+    set_new_password_form:
+      hide: "Dölj the 'Change Password' info"
+      show: "Change the User's Password"
+
 
   will_paginate:
     previous_label: "« Föregående"
@@ -427,6 +431,17 @@ sv:
       is_an_admin: Är en admin
       'yes': *yes
       'no': *no
+      reset_password: Change the Password
+      confirm_reset_password: "Are you sure?  This will over-write the current password for this user!\n  (If you have not recorded the password yet, choose Cancel.)"
+      new_password: Nytt Password
+      re_enter_new_password: Re-Enter the Password
+      please_note_new_password: Please record this in a safe and secure place. Once you press the Save button below you will not be able to see the password again and there is no way to display it again.
+      submit_new_password: Save the New Password
+
+    update:
+      passwords_dont_match: "The two passwords entered don't match."
+      success: Användar uppdaterad.
+      error: Ett problem hindrade användar från att raderas.
 
 
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -85,6 +85,7 @@ sv:
       user:
         email: &email E-post
         password: *password
+        password_confirmation: Lösenordsbekräftelse
         created: &created Skapad
         current_sign_in_at: &user_current_signed_in_time Inloggad
         current_sign_in_ip: &user_current_ip Inloggad med IP
@@ -143,6 +144,11 @@ sv:
           company_number:
             taken: Detta företag (org nr) finns redan i systemet.
           company_has_active_memberships: "Företaget har aktiva (godkända) medlemskap."
+
+        user:
+          attributes:
+            password_confirmation:
+              confirmation: stämmer inte med det angivna lösenordet.
 
       messages:
         record_invalid: 'Ett fel uppstod: %{errors}'
@@ -594,7 +600,7 @@ sv:
       accepted: måste accepteras
       blank: måste anges
       present: får inte anges
-      confirmation: stämmer inte överens
+      confirmation: De två lösenord du angivit matchar inte.
       empty: får ej vara tom
       equal_to: måste vara samma som
       even: måste vara jämnt

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -426,7 +426,7 @@ sv:
       logged_in_count: *sign_in_count
       created: *created
       reset_password_sent_at: *user_reset_password_sent_at
-      password_never_reset: Lösenord har aldrig återställts.
+      password_never_reset: Användaren har aldrig återställt lösenordet.
       user_has_never_signed_in: har aldrig loggat in.
       is_an_admin: Är en admin
       'yes': *yes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
 
     resources :companies, path: 'hundforetag'
 
-    resources :users, path: 'anvandare', only: [:index, :show]
+    resources :users, path: 'anvandare'
   end
 
   get 'information', to: 'membership_applications#information'

--- a/features/admin-resets-users-password.feature
+++ b/features/admin-resets-users-password.feature
@@ -1,0 +1,84 @@
+Feature: As an admin
+  So that I can help users that forgot their password (who can't reset it themselves via email)
+  I need to be able to reset passwords for users
+
+
+  Background:
+
+    Given the following users exists
+      | email               | admin |
+      | emma@happymutts.com |       |
+      | bob@snarkybarky.se  |       |
+      | admin@shf.se        | true  |
+
+    And the following companies exist:
+      | name        | company_number | email               |
+      | Happy Mutts | 2120000142     | bowwow@bowsersy.com |
+
+    And the following applications exist:
+      | first_name | user_email          | company_number | state    |
+      | Emma       | emma@happymutts.com | 2120000142     | accepted |
+
+
+    And I am logged in as "admin@shf.se"
+
+  @poltergeist @member
+  Scenario: A member needs their password reset
+    Given I am on the "user details" page for "emma@happymutts.com"
+    Then I should not see t("users.show.new_password")
+    And I should not see t("users.show.re_enter_new_password")
+    And I should not see t("users.show.submit_new_password")
+    And I should not see t("users.show.submit_new_password")
+    When I click on t("toggle.set_new_password_form.show") button
+    Then I should see t("users.show.new_password")
+    And I should see t("users.show.re_enter_new_password")
+    When I fill in t("users.show.new_password") with "newpassword"
+    And I fill in t("users.show.re_enter_new_password") with "newpassword"
+    And I should see t("users.show.please_note_new_password")
+    And I click on t("users.show.submit_new_password") button
+    And I confirm popup with message t("users.show.confirm_reset_password")
+    Then I should see t("users.update.success")
+    And I am Logged out
+    And I am on the "login" page
+    When I fill in t("activerecord.attributes.user.email") with "emma@happymutts.com"
+    And I fill in t("activerecord.attributes.user.password") with "newpassword"
+    And I click on t("devise.sessions.new.log_in") button
+    Then I should see t("devise.sessions.signed_in")
+
+
+  @poltergeist @user
+  Scenario: A user needs their password reset
+    Given I am on the "user details" page for "bob@snarkybarky.se"
+    Then I should not see t("users.show.new_password")
+    And I should not see t("users.show.re_enter_new_password")
+    And I should not see t("users.show.submit_new_password")
+    And I should not see t("users.show.submit_new_password")
+    When I click on t("toggle.set_new_password_form.show") button
+    Then I should see t("users.show.new_password")
+    And I should see t("users.show.re_enter_new_password")
+    When I fill in t("users.show.new_password") with "snarkywoofwoof"
+    And I fill in t("users.show.re_enter_new_password") with "snarkywoofwoof"
+    And I should see t("users.show.please_note_new_password")
+    And I click on t("users.show.submit_new_password") button
+    And I confirm popup with message t("users.show.confirm_reset_password")
+    Then I should see t("users.update.success")
+    And I am Logged out
+    And I am on the "login" page
+    When I fill in t("activerecord.attributes.user.email") with "bob@snarkybarky.se"
+    And I fill in t("activerecord.attributes.user.password") with "snarkywoofwoof"
+    And I click on t("devise.sessions.new.log_in") button
+    Then I should see t("devise.sessions.signed_in")
+
+
+  @poltergeist @user
+  Scenario: New password and confirmation don't match (sad path)
+    Given I am on the "user details" page for "bob@snarkybarky.se"
+    When I click on t("toggle.set_new_password_form.show") button
+    Then I should see t("users.show.new_password")
+    When I fill in t("users.show.new_password") with "snarkywoofwoof"
+    And I fill in t("users.show.re_enter_new_password") with "not-a-match"
+    And I should see t("users.show.please_note_new_password")
+    And I click on t("users.show.submit_new_password") button
+    And I confirm popup with message t("users.show.confirm_reset_password")
+    Then I should see t("users.update.error")
+    And I should see t("users.update.passwords_dont_match")

--- a/features/admin-resets-users-password.feature
+++ b/features/admin-resets-users-password.feature
@@ -36,7 +36,7 @@ Feature: As an admin
     And I fill in t("users.show.re_enter_new_password") with "newpassword"
     And I should see t("users.show.please_note_new_password")
     And I click on t("users.show.submit_new_password") button
-    And I confirm popup with message t("users.show.confirm_reset_password")
+    And I confirm popup
     Then I should see t("users.update.success")
     And I am Logged out
     And I am on the "login" page

--- a/features/admin-resets-users-password.feature
+++ b/features/admin-resets-users-password.feature
@@ -69,7 +69,7 @@ Feature: As an admin
 
 
   @poltergeist @user
-  Scenario: New password and confirmation don't match (sad path)
+  Scenario: New password and confirmation don't match [SAD PATH]
     Given I am on the "user details" page for "bob@snarkybarky.se"
     When I click on t("toggle.set_new_password_form.show") button
     Then I should see t("users.show.new_password")
@@ -79,4 +79,34 @@ Feature: As an admin
     And I click on t("users.show.submit_new_password") button
     And I confirm popup with message t("users.show.confirm_reset_password")
     Then I should see t("users.update.error")
-    And I should see t("users.update.passwords_dont_match")
+    And I should see t("activerecord.errors.models.user.attributes.password_confirmation.confirmation")
+
+
+  @poltergeist @user
+  Scenario: New password is too short (not valid) [SAD PATH]
+    Given I am on the "user details" page for "bob@snarkybarky.se"
+    When I click on t("toggle.set_new_password_form.show") button
+    Then I should see t("users.show.new_password")
+    When I fill in t("users.show.new_password") with "woof"
+    And I fill in t("users.show.re_enter_new_password") with "woof"
+    And I should see t("users.show.please_note_new_password")
+    And I click on t("users.show.submit_new_password") button
+    And I confirm popup
+    Then I should see t("users.update.error")
+    And I should see t("errors.messages.too_short", count: 6)
+    And I should not see t("activerecord.errors.models.user.attributes.password_confirmation.confirmation")
+
+
+  @poltergeist @user
+  Scenario: New password and confirmation don't match AND new one is too short [SAD PATH]
+    Given I am on the "user details" page for "bob@snarkybarky.se"
+    When I click on t("toggle.set_new_password_form.show") button
+    Then I should see t("users.show.new_password")
+    When I fill in t("users.show.new_password") with "woof"
+    And I fill in t("users.show.re_enter_new_password") with "nomatch"
+    And I should see t("users.show.please_note_new_password")
+    And I click on t("users.show.submit_new_password") button
+    And I confirm popup with message t("users.show.confirm_reset_password")
+    Then I should see t("users.update.error")
+    And I should see t("activerecord.errors.models.user.attributes.password_confirmation.confirmation")
+    And I should see t("errors.messages.too_short", count: 6)

--- a/features/admin-resets-users-password.feature
+++ b/features/admin-resets-users-password.feature
@@ -36,7 +36,6 @@ Feature: As an admin
     And I fill in t("users.show.re_enter_new_password") with "newpassword"
     And I should see t("users.show.please_note_new_password")
     And I click on t("users.show.submit_new_password") button
-    And I confirm popup
     Then I should see t("users.update.success")
     And I am Logged out
     And I am on the "login" page
@@ -60,7 +59,6 @@ Feature: As an admin
     And I fill in t("users.show.re_enter_new_password") with "snarkywoofwoof"
     And I should see t("users.show.please_note_new_password")
     And I click on t("users.show.submit_new_password") button
-    And I confirm popup with message t("users.show.confirm_reset_password")
     Then I should see t("users.update.success")
     And I am Logged out
     And I am on the "login" page
@@ -79,6 +77,5 @@ Feature: As an admin
     And I fill in t("users.show.re_enter_new_password") with "not-a-match"
     And I should see t("users.show.please_note_new_password")
     And I click on t("users.show.submit_new_password") button
-    And I confirm popup with message t("users.show.confirm_reset_password")
     Then I should see t("users.update.error")
     And I should see t("users.update.passwords_dont_match")

--- a/features/admin-resets-users-password.feature
+++ b/features/admin-resets-users-password.feature
@@ -77,5 +77,6 @@ Feature: As an admin
     And I fill in t("users.show.re_enter_new_password") with "not-a-match"
     And I should see t("users.show.please_note_new_password")
     And I click on t("users.show.submit_new_password") button
+    And I confirm popup with message t("users.show.confirm_reset_password")
     Then I should see t("users.update.error")
     And I should see t("users.update.passwords_dont_match")

--- a/features/admin-resets-users-password.feature
+++ b/features/admin-resets-users-password.feature
@@ -36,14 +36,9 @@ Feature: As an admin
     And I fill in t("users.show.re_enter_new_password") with "newpassword"
     And I should see t("users.show.please_note_new_password")
     And I click on t("users.show.submit_new_password") button
-    Then I should see the selector "#flashes"
-    And I should see t("users.update.success")
-    And I am Logged out
-    And I am on the "login" page
-    When I fill in t("activerecord.attributes.user.email") with "emma@happymutts.com"
-    And I fill in t("activerecord.attributes.user.password") with "newpassword"
-    And I click on t("devise.sessions.new.log_in") button
-    Then I should see t("devise.sessions.signed_in")
+    #And I confirm popup
+    Then I should see flash text t("users.update.success")
+
 
 
   @poltergeist @user
@@ -60,14 +55,10 @@ Feature: As an admin
     And I fill in t("users.show.re_enter_new_password") with "snarkywoofwoof"
     And I should see t("users.show.please_note_new_password")
     And I click on t("users.show.submit_new_password") button
-    Then I should see the selector "#flashes"
+    #And I confirm popup
+    Then I should see flash text t("users.update.success")
     And I should see t("users.update.success")
-    When I am Logged out
-    And I am on the "login" page
-    When I fill in t("activerecord.attributes.user.email") with "bob@snarkybarky.se"
-    And I fill in t("activerecord.attributes.user.password") with "snarkywoofwoof"
-    And I click on t("devise.sessions.new.log_in") button
-    Then I should see t("devise.sessions.signed_in")
+
 
 
   @poltergeist @user
@@ -79,7 +70,7 @@ Feature: As an admin
     And I fill in t("users.show.re_enter_new_password") with "not-a-match"
     And I should see t("users.show.please_note_new_password")
     And I click on t("users.show.submit_new_password") button
-    And I confirm popup with message t("users.show.confirm_reset_password")
+    #And I confirm popup
     Then I should see t("users.update.error")
     And I should see t("activerecord.errors.models.user.attributes.password_confirmation.confirmation")
 
@@ -93,7 +84,7 @@ Feature: As an admin
     And I fill in t("users.show.re_enter_new_password") with "woof"
     And I should see t("users.show.please_note_new_password")
     And I click on t("users.show.submit_new_password") button
-    And I confirm popup
+    #And I confirm popup
     Then I should see t("users.update.error")
     And I should see t("errors.messages.too_short", count: 6)
     And I should not see t("activerecord.errors.models.user.attributes.password_confirmation.confirmation")
@@ -108,7 +99,7 @@ Feature: As an admin
     And I fill in t("users.show.re_enter_new_password") with "nomatch"
     And I should see t("users.show.please_note_new_password")
     And I click on t("users.show.submit_new_password") button
-    And I confirm popup with message t("users.show.confirm_reset_password")
+    #And I confirm popup
     Then I should see t("users.update.error")
     And I should see t("activerecord.errors.models.user.attributes.password_confirmation.confirmation")
     And I should see t("errors.messages.too_short", count: 6)

--- a/features/admin-resets-users-password.feature
+++ b/features/admin-resets-users-password.feature
@@ -59,8 +59,9 @@ Feature: As an admin
     And I fill in t("users.show.re_enter_new_password") with "snarkywoofwoof"
     And I should see t("users.show.please_note_new_password")
     And I click on t("users.show.submit_new_password") button
-    Then I should see t("users.update.success")
-    And I am Logged out
+    Then I should see the selector "#flashes"
+    And I should see t("users.update.success")
+    When I am Logged out
     And I am on the "login" page
     When I fill in t("activerecord.attributes.user.email") with "bob@snarkybarky.se"
     And I fill in t("activerecord.attributes.user.password") with "snarkywoofwoof"

--- a/features/admin-resets-users-password.feature
+++ b/features/admin-resets-users-password.feature
@@ -36,7 +36,8 @@ Feature: As an admin
     And I fill in t("users.show.re_enter_new_password") with "newpassword"
     And I should see t("users.show.please_note_new_password")
     And I click on t("users.show.submit_new_password") button
-    Then I should see t("users.update.success")
+    Then I should see the selector "#flashes"
+    And I should see t("users.update.success")
     And I am Logged out
     And I am on the "login" page
     When I fill in t("activerecord.attributes.user.email") with "emma@happymutts.com"

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -272,3 +272,8 @@ end
 And(/^I should see the selector "([^"]*)"$/) do | s |
   expect(page).to have_selector(s)
 end
+
+And(/^I should see flash text t\("([^"]*)"\)$/) do | i18n_key |
+  expect(page).to have_selector('#flashes', text: I18n.t(i18n_key) )
+end
+

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -268,3 +268,7 @@ end
 And(/^I should not see t\("([^"]*)"\), locale: :(\w\w)$/) do |i18n_key, locale|
   expect(page).not_to have_content I18n.t(i18n_key, locale: locale)
 end
+
+And(/^I should see the selector "([^"]*)"$/) do | s |
+  expect(page).to have_selector(s)
+end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -11,6 +11,11 @@ When /^I confirm popup$/ do
   page.driver.accept_modal(:confirm)
 end
 
+When /^I confirm popup with message t\("([^"]*)"\)$/ do | modal_text |
+  # requires poltergeist:
+  page.driver.accept_modal(:confirm, {text: i18n_content("#{modal_text}")}) # will wait until it finds the text (or reaches Capybara max wait time)
+end
+
 When /^I dismiss popup$/ do
   page.driver.dismiss_modal(:confirm)
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -8,12 +8,16 @@ end
 
 When /^I confirm popup$/ do
   # requires poltergeist:
-  page.driver.accept_modal(:confirm)
+  using_wait_time 3 do
+    page.driver.accept_modal(:confirm)
+  end
 end
 
 When /^I confirm popup with message t\("([^"]*)"\)$/ do | modal_text |
   # requires poltergeist:
-  page.driver.accept_modal(:confirm, {text: i18n_content("#{modal_text}")}) # will wait until it finds the text (or reaches Capybara max wait time)
+  using_wait_time 3 do
+    page.driver.accept_modal(:confirm, {text: i18n_content("#{modal_text}")}) # will wait until it finds the text (or reaches Capybara max wait time)
+  end
 end
 
 When /^I dismiss popup$/ do


### PR DESCRIPTION
PT Story:  https://www.pivotaltracker.com/story/show/139158857

Changes proposed in this pull request:
1.  Added button on user details view. Uses javascript to toggle hiding/showing the password form
2.  Added actions in the controller to update the user info, and to check to be sure that the 2 entered passwords match


NEEDS TRANSLATION for sveriges!

Screenshots (Optional):

<img width="567" alt="screen shot 2017-03-05 at 1 50 54 pm" src="https://cloud.githubusercontent.com/assets/673794/23591794/f326b6ae-01aa-11e7-89ca-ddb8ff7b07d0.png">


<img width="606" alt="screen shot 2017-03-05 at 1 51 09 pm" src="https://cloud.githubusercontent.com/assets/673794/23591796/f32d1cba-01aa-11e7-8349-ce46f627a217.png">

<img width="661" alt="screen shot 2017-03-05 at 1 51 25 pm" src="https://cloud.githubusercontent.com/assets/673794/23591795/f328b47c-01aa-11e7-8d17-b17d92b036d4.png">


Ready for review:
@thesuss @patmbolger 
