### PR TITLE
Turn jQuery effects/animations off during testing

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,6 +16,20 @@
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.2/js/select2.full.min.js'
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/i18n/sv.js'
 
+    - if Rails.env.test?
+      -#
+        Disable jQuery animations in the test environment to
+        increase speed of the test suite and fix intermittent integration test failures.
+
+        Without this, we were seeing frequent intermittent test failures with
+        jquery functions that invovle animations, especially with show() and hide().
+        @see https://github.com/guidance-guarantee-programme/pension_guidance/pull/610
+
+      :javascript
+        $.fx.off = true;
+
+
+
   %body.page.page-template.page-template-page-sidebar-none
     // This embedded script sets the locale for I18n on the client side.
     // It needs to be in the body since only the body will be re-rendered


### PR DESCRIPTION
PT Story:  integration tests randomly failing (jquery animations)
https://www.pivotaltracker.com/story/show/141189311

Changes proposed in this pull request:
1.  If Rails.env == test, add a tiny script into the main application layout that turns off jQuery effects/animations

### Background and Tracking Down This Solution:

(Copied from PivotalTracker so the info is here, too):

Cucumber (integration) tests that used `utilities.js` started randomly failing for me.
(Elements that should be  shown after clicking on a button that changes the display state where not found and so tests were failing.)

I tracked the problem down to jquery animations.

**Solution:**  Turn off jquery effects (animations) for tests.   (This will have the side-effect of speeding up the tests.)

**How I tracked down the problem and solution:**

This capybara / poltergeist issue:
https://github.com/teampoltergeist/poltergeist/issues/530

... led me to this particular comment:
https://github.com/teampoltergeist/poltergeist/issues/530#issuecomment-129264353

... which led me to this specific fix:
https://github.com/guidance-guarantee-programme/pension_guidance/pull/610

---

Ready for review:
@patmbolger @thesuss 
