### PR TITLE
Only load assets when needed by a view

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,6 +16,8 @@
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.2/js/select2.full.min.js'
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/i18n/sv.js'
 
+    = yield :head_content if content_for?(:head_content)
+
   %body.page.page-template.page-template-page-sidebar-none
     // This embedded script sets the locale for I18n on the client side.
     // It needs to be in the body since only the body will be re-rendered
@@ -35,3 +37,6 @@
                 = yield
                 = render 'page_footer'
     = render 'bottom'
+
+
+    = yield :last_content if content_for?(:last_content)


### PR DESCRIPTION
PT Story:  Only load assets and javascripts for individual pages that use them
https://www.pivotaltracker.com/story/show/140374579

Put in yield statements so that a view can load assets (stylesheets, javascripts) that only _it_ needs.
This becomes important now that we are loading javascript needed only when we display maps.  (And it's just generally a good pattern.)

Changes proposed in this pull request:
1.  add `yield` statements that load header content or bottom (last) content if the view has it


Ready for review:
@patmbolger @thesuss 
