### PR TITLE
company.main_address instead of company.addresses.first

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -43,7 +43,7 @@ class CompaniesController < ApplicationController
 
 
     @company = Company.new(company_params)
-    @company.addresses.first.addressable = @company  # not sure why Rails doesn't assign this automatically
+    @company.main_address.addressable = @company  # not sure why Rails doesn't assign this automatically
 
     if @company.save
       redirect_to @company, notice: t('.success')

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -61,4 +61,10 @@ class Company < ApplicationRecord
     true
 
   end
+
+  def main_address
+    addresses.first
+  end
+
+
 end

--- a/app/views/business_categories/show.html.haml
+++ b/app/views/business_categories/show.html.haml
@@ -24,7 +24,7 @@
         - @companies.each do | company |
           %tr.company
             %td= link_to company.name, company
-            %td= company.addresses.first.region ?  company.addresses.first.region.name  : ''
+            %td= company.main_address.region ?  company.main_address.region.name  : ''
             - if current_user.try(:admin)
               %td= company.company_number
               %td= link_to t('edit'), edit_company_path(company)

--- a/app/views/companies/_companies_list.html.haml
+++ b/app/views/companies/_companies_list.html.haml
@@ -34,8 +34,8 @@
                 <br/>
                 = bc.name
           %td= link_to company.name, company
-          %td= company.addresses.first.region&.name
-          %td= company.addresses.first.kommun&.name
+          %td= company.main_address.region&.name
+          %td= company.main_address.kommun&.name
           - if current_user.try(:admin)
             %td= company.company_number
             %td= link_to "#{t('edit')}", edit_company_path(company)

--- a/app/views/companies/show.html.haml
+++ b/app/views/companies/show.html.haml
@@ -27,19 +27,19 @@
   %h2 #{t('.address')}:
   %p
     %b #{t('.street')}:
-    = @company.addresses.first.street_address
+    = @company.main_address.street_address
   %p
     %b #{t('.post_code')}:
-    = @company.addresses.first.post_code
+    = @company.main_address.post_code
   %p
     %b #{t('.city')}:
-    = @company.addresses.first.city
+    = @company.main_address.city
   %p
     %b #{t('.kommun')}:
-    = @company.addresses.first.kommun.name
+    = @company.main_address.kommun.name
   %p
     %b #{t('.region')}:
-    = @company.addresses.first.region.name if @company.addresses.first.region
+    = @company.main_address.region.name if @company.main_address.region
 
   - if current_user.try(:admin)
     = link_to "#{t('.delete')}", @company, method: :delete, class:'btn btn-danger', data: { confirm: "#{t('.confirm_are_you_sure')}" }

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -133,4 +133,17 @@ RSpec.describe Company, type: :model do
           .to contain_exactly('cat1')
     end
   end
+
+
+  describe '#main_address' do
+
+    let(:company) { create(:company, num_addresses: 3) }
+
+    it 'returns the first address for the company' do
+      expect(company.addresses.count).to eq 3
+      expect(company.main_address).to eq(company.addresses.first)
+    end
+
+  end
+
 end


### PR DESCRIPTION
PT Story:  use company.main_address instead of company.addresses.first
https://www.pivotaltracker.com/story/show/141191681

Changes proposed in this pull request:
1.  add method to Company
2. add spec
3. replace all `company.addresses.first` with `company.main_address`

Ready for review:
@patmbolger @thesuss 
