### PR TITLE
user list (index): translate,  use 'most recent login time' helper

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -5,6 +5,15 @@ $admin-color: #ff0000;
   font-weight: bold;
 }
 
+td.is-member {
+  .yes {
+    background-color: LightGreen;
+  }
+  .no {
+    background-color: LemonChiffon;
+  }
+}
+
 .panel.admin-set-new-password-form {
   margin-left: 2em;
   margin-right: 2em;

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -18,17 +18,17 @@
     %tbody
       - @users.each do |user|
         %tr
-          %td= link_to user.email, user
-          %td
-            %small= "#{time_ago_in_words(user.created_at)} ago"
-          %td
+          %td.email{id: "user-#{user.id}"}= link_to user.email, user
+          %td.created-at
+            %small= "#{i18n_time_ago_in_words(user.created_at)}"
+          %td.last-sign-in-at
             %small= user.last_sign_in_at ?                          |
-              "#{time_ago_in_words(user.last_sign_in_at)} ago" : '' |
-          %td= user.sign_in_count
-          %td= user.membership_applications.open.count
-          - if user.is_member?
-            %td
-              %span{ style: 'background-color: LightGreen;' }= t('.yes')
-          - else
-            %td
-              %span{ style: 'background-color: LemonChiffon;' }= t('.no')
+              "#{i18n_time_ago_in_words(most_recent_login_time user)}" : '' |
+          %td.sign-in-count= user.sign_in_count
+          %td.applications-open= user.membership_applications.open.count
+
+          %td.is-member
+            - if user.is_member?
+              %span.yes= t('.yes')
+            - else
+              %span.no= t('.no')

--- a/features/manage_users.feature
+++ b/features/manage_users.feature
@@ -2,45 +2,58 @@ Feature: As an admin
   In order to understand and manage our user base
   I need to be able to view and make changes to user records
 
-Background:
-  Given the following users exist
-    | email               | admin | is_member |
-    | emma@happymutts.com |       | true      |
-    | anna@sadmutts.com   |       | true      |
-    | ernt@mutts.com      |       | false     |
-    | admin@shf.se        | true  |           |
+  Background:
+    Given the following users exist
+      | email               | admin |
+      | emma@happymutts.com |       |
+      | anna@sadmutts.com   |       |
+      | ernt@mutts.com      |       |
+      | admin@shf.se        | true  |
 
-  And the following business categories exist
-    | name         |
-    | Groomer      |
-    | Psychologist |
-    | Trainer      |
+    And the following business categories exist
+      | name         |
+      | Groomer      |
+      | Psychologist |
+      | Trainer      |
 
-  And the following applications exist:
-    | first_name | user_email          | company_number | category_name | state    |
-    | Emma       | emma@happymutts.com | 5562252998     | Trainer       | accepted |
-    | Ernt       | ernt@mutts.com      | 5569467466     | Groomer       | accepted |
-    | Anna       | anna@sadmutts.com   | 2120000142     | Psychologist  | accepted |
+    And the following applications exist:
+      | first_name | user_email          | company_number | category_name | state    |
+      | Emma       | emma@happymutts.com | 5562252998     | Trainer       | accepted |
+      | Anna       | anna@sadmutts.com   | 2120000142     | Psychologist  | accepted |
+      | Ernt       | ernt@mutts.com      | 2120000142     | Psychologist  | new      |
 
-Scenario: Admin can view all users
-  Given I am logged in as "admin@shf.se"
-  When I am on the "all users" page
-  And I should see "admin@shf.se"
-  And I should see "emma@happymutts.com"
-  And I should see "anna@sadmutts.com"
-  And I should see "ernt@mutts.com"
+  Scenario: Admin can view all users
+    Given I am logged in as "admin@shf.se"
+    When I am on the "all users" page
+    And I should see "admin@shf.se"
+    And I should see "emma@happymutts.com"
+    And I should see "anna@sadmutts.com"
+    And I should see "ernt@mutts.com"
 
-Scenario: Member cannot view all users
-  Given I am logged in as "anna@sadmutts.com"
-  When I am on the "all users" page
-  And I should see t("errors.not_permitted")
+  Scenario: The right info is displayed for a user
+    Given The user "emma@happymutts.com" last logged in 100 days ago
+    And I am logged in as "admin@shf.se"
+    When I am on the "all users" page
+    Then I should see "emma@happymutts.com"
+    And I should see "mindre än en minut sedan" for class "created-at" in the row for user "emma@happymutts.com"
+    And I should see "3 månader sedan" for class "last-sign-in-at" in the row for user "emma@happymutts.com"
+    And I should see "1" for class "sign-in-count" in the row for user "emma@happymutts.com"
+    And I should see t("yes") for class "is-member" in the row for user "emma@happymutts.com"
+    And I should not see "3 månader sedan" in the row for user "ernt@mutts.com"
+    And I should see "1" for class "applications-open" in the row for user "ernt@mutts.com"
+    And I should see t("no") for class "is-member" in the row for user "ernt@mutts.com"
 
-Scenario: User (non-member) cannot view all users
-  Given I am logged in as "ernt@mutts.com"
-  When I am on the "all users" page
-  And I should see t("errors.not_permitted")
+  Scenario: Member cannot view all users
+    Given I am logged in as "anna@sadmutts.com"
+    When I am on the "all users" page
+    And I should see t("errors.not_permitted")
 
-Scenario: Visitor cannot view all users
-  Given I am Logged out
-  When I am on the "all users" page
-  And I should see t("errors.not_permitted")
+  Scenario: User (non-member) cannot view all users
+    Given I am logged in as "ernt@mutts.com"
+    When I am on the "all users" page
+    And I should see t("errors.not_permitted")
+
+  Scenario: Visitor cannot view all users
+    Given I am Logged out
+    When I am on the "all users" page
+    And I should see t("errors.not_permitted")

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -277,3 +277,57 @@ And(/^I should see flash text t\("([^"]*)"\)$/) do | i18n_key |
   expect(page).to have_selector('#flashes', text: I18n.t(i18n_key) )
 end
 
+And(/^I should see "([^"]*)" in the row for user "([^"]*)"$/) do | expected_text, user_email |
+  td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
+  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
+  expect(tr.text).to match(Regexp.new(expected_text))
+end
+
+And(/^I should see t\("([^"]*)"\) in the row for user "([^"]*)"$/) do | expected_text, user_email |
+  td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
+  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
+  expect(tr.text).to match(Regexp.new(I18n.t(expected_text)))
+end
+
+
+And(/^I should not see "([^"]*)" in the row for user "([^"]*)"$/)do | expected_text, user_email |
+  td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
+  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
+  expect(tr.text).not_to match(Regexp.new(expected_text))
+end
+
+
+And(/^I should not see t\("([^"]*)"\) in the row for user "([^"]*)"$/) do | expected_text, user_email |
+  td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
+  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
+  expect(tr.text).not_to match(Regexp.new(I18n.t(expected_text)))
+end
+
+And(/^I should see "([^"]*)" for class "([^"]*)" in the row for user "([^"]*)"$/) do |expected_text, css_class, user_email |
+  td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
+  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
+
+  expect(tr).to have_css(".#{css_class}", text: expected_text)
+end
+
+And(/^I should not see "([^"]*)" for class "([^"]*)" in the row for user "([^"]*)"$/) do |expected_text, css_class, user_email |
+  td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
+  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
+
+  expect(tr).not_to have_css(".#{css_class}", text: expected_text)
+end
+
+
+And(/^I should see t\("([^"]*)"\) for class "([^"]*)" in the row for user "([^"]*)"$/) do |expected_text, css_class, user_email |
+  td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
+  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
+
+  expect(tr).to have_css(".#{css_class}", text: I18n.t(expected_text))
+end
+
+And(/^I should not see t\("([^"]*)"\) for class "([^"]*)" in the row for user "([^"]*)"$/) do |expected_text, css_class, user_email |
+  td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
+  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
+
+  expect(tr).not_to have_css(".#{css_class}", text: I18n.t(expected_text))
+end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -37,6 +37,7 @@ end
 Given(/^The user "([^"]*)" last logged in (\d+) days? ago$/) do |email, num_days|
   @user = User.find_by(email: email)
   @user.update(last_sign_in_at: (Time.now - 1.day * num_days.to_i))
+  @user.update(sign_in_count: (@user.sign_in_count + 1))
 end
 
 Given(/^The user "([^"]*)" has logged in (\d+) times?$/) do |email, num_logins|


### PR DESCRIPTION
PT Stories:  use the `most_recent_login_time` helper and translate correctly on the user index page
https://www.pivotaltracker.com/story/show/140897375
https://www.pivotaltracker.com/story/show/141168939

(I started to do _"use the `most_recent_login_time` helper"_ and it was trivial to also take care of the translation.)

Changes proposed in this pull request:
1.  use `i18n_time_ago_in_words(most_recent_login_time user)` on the user index page
2. move styles into .css file
3. add scenario
4. add some new steps that are helpful for looking at a particular row in a table that's being shown


Ready for review:
@thesuss @patmbolger 
