### PR TITLE
Hotfix: move smarter_csv gem so it's available for production 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem 'backup'
 gem 'dotenv'  # used in our backup definition file
 gem 'whenever'
 
+gem 'smarter_csv'
+
 group :development, :test do
   gem 'rspec-rails'
   gem 'shoulda-matchers'
@@ -51,7 +53,6 @@ group :development, :test do
   gem 'launchy'
   gem 'cucumber-timecop', require: false
 
-  gem 'smarter_csv'
 end
 
 group :development do


### PR DESCRIPTION
`smarter_csv` gem is required for the rake task to populate the `kommun` table.
Needed to quickly update the Gemfile so that the table on the production server could be populated


Changes proposed in this pull request:
1.  Changed Gemfile

Ready for review:
@thesuss 
