### PR TITLE
Helper methods: don't display empty field

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -85,7 +85,7 @@ module ApplicationHelper
 
 
     if value.blank?
-      ''
+      default
     else
       content_tag(tag, tag_options) do
         concat content_tag(:span, "#{label}#{separator}", class: label_class)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,15 @@
 module ApplicationHelper
+
+
   def flash_class(level)
     case level.to_sym
-      when :notice then 'success'
-      when :alert then 'danger'
+      when :notice then
+        'success'
+      when :alert then
+        'danger'
     end
   end
+
 
   def flash_message(type, text)
     flash[type] ||= []
@@ -14,6 +19,7 @@ module ApplicationHelper
     flash[type] << text
   end
 
+
   def render_flash_message(flash_value)
     if flash_value.instance_of? String
       flash_value
@@ -22,9 +28,11 @@ module ApplicationHelper
     end
   end
 
+
   def translate_and_join(error_list)
-    error_list.map{|e| I18n.t(e)}.join(', ')
+    error_list.map { |e| I18n.t(e) }.join(', ')
   end
+
 
   # ActiveRecord::Assocations::CollectionAssociation is a proxy and won't
   # always load info. see the class documentation for more info
@@ -35,7 +43,56 @@ module ApplicationHelper
 
 
   def i18n_time_ago_in_words(past_time)
-    "#{t('time_ago', amount_of_time: time_ago_in_words(past_time) )}"
+    "#{t('time_ago', amount_of_time: time_ago_in_words(past_time))}"
+  end
+
+
+  # call field_or_default with the default value = an empty String
+  def field_or_none(label, value, tag: :p, tag_options: {}, separator: ': ',
+                    label_class: 'field-label', value_class: 'field-value')
+
+    field_or_default(label, value, default: '', tag: tag, tag_options: tag_options, separator: separator,
+                     label_class: label_class, value_class: value_class)
+  end
+
+
+  # Return the HTML for a simple field with "Label: Value"
+  # If value is blank, return the value of default (default value for default = '')
+  # Surround it with the given content tag (default = :p if none provided)
+  # and use the tag options (if any provided).
+  # Default class to surround the label and separator is 'field-label'
+  # Default class to surround the value is 'field-value'
+  #
+  # Separate the Label and Value with the separator string (default = ': ')
+  #
+  #  Ex:  field_or_none('Name', 'Bob Ross')
+  #     will produce:  "<p><span class='field-label'>Name: </span><span class='field-value'>Bob Ross</span></p>"
+  #
+  #  Ex:  field_or_default('Name', '', default: '(no name provided)')
+  #     will produce:  "(no name provided)"
+  #
+  #  Ex:  field_or_default('Name', '', default: content_tag( :h4, '(no name provided)', class: 'empty-warning') )
+  #     will produce:  "<h4 class='empty-warning'>(no name provided)</h4>"
+  #
+  # Ex: field_or_none('Name', 'Bob Ross', tag: :h2, separator: ' = ')
+  #     will produce:  "<h2><span class='field-label'>Name = </span><span class='field-value'>Bob Ross</span></h2>"
+  #
+  # Ex: field_or_none('Name', 'Bob Ross', tag_options: {id: 'bob-ross'}, value_class: 'special-value')
+  #     will produce:  "<p id='bob-ross'><span class='field-label'>Name: </span><span class='special-value'>Bob Ross</span></p>"
+  #
+  def field_or_default(label, value, default: '', tag: :p, tag_options: {}, separator: ': ',
+                       label_class: 'field-label', value_class: 'field-value')
+
+
+    if value.blank?
+      ''
+    else
+      content_tag(tag, tag_options) do
+        concat content_tag(:span, "#{label}#{separator}", class: label_class)
+        concat content_tag(:span, value, class: value_class)
+      end
+    end
+
   end
 
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     describe 'adds message to a flash[type] that already has messages' do
 
-      before (:each) do
+      before(:each) do
         helper.flash_message @flash_type, @second_message
       end
 
@@ -71,5 +71,70 @@ RSpec.describe ApplicationHelper, type: :helper do
     t = Time.now - 1.day
     expect(helper.i18n_time_ago_in_words(t)).to eq("#{I18n.t('time_ago', amount_of_time: time_ago_in_words(t))}")
   end
+
+
+
+  #
+  # Separate the Label and Value with the separator string (default = ': ')
+  #
+  #  Ex:  field_or_default('Name', 'Bob Ross')
+  #     will produce:  "<p><span class='field-label'>Name: </span><span class='field-value'>Bob Ross</span></p>"
+  #
+  # Ex: field_or_default('Name', 'Bob Ross', tag: :h2, separator: ' = ')
+  #     will produce:  "<h2><span class='field-label'>Name = </span><span class='field-value'>Bob Ross</span></h2>"
+  #
+  # Ex: field_or_default('Name', 'Bob Ross', tag_options: {id: 'bob-ross'}, value_class: 'special-value')
+  #     will produce:  "<p id='bob-ross'><span class='field-label'>Name: </span><span class='special-value'>Bob Ross</span></p>"
+
+  describe '#field_or_default' do
+
+    it 'nil value returns an empty string' do
+      expect(helper.field_or_default('some label', nil)).to eq ''
+    end
+
+    it 'empty value returns an empty string by default' do
+      expect(helper.field_or_default('some label', '')).to eq ''
+    end
+
+
+    it "can set the default string to a complicated content_tag " do
+    #  expect(helper.field_or_default('some label', [], default: (content_tag(:div, class: ["strong", "highlight"]) { 'some default' }) )).to eq('some default')
+    end
+
+
+    it 'non-empty value with defaults == <p><span class="field-label">labelseparator</span><span class="field-value">value</span></p>' do
+      expect(helper.field_or_default('label', 'value')).to eq('<p><span class="field-label">label: </span><span class="field-value">value</span></p>')
+    end
+
+
+    it 'can set a custom separator' do
+      expect(helper.field_or_default('label', 'value', separator: '???')).to eq('<p><span class="field-label">label???</span><span class="field-value">value</span></p>')
+    end
+
+
+    it 'can set the class of the surrounding tag' do
+      expect(helper.field_or_default('label', 'value', tag: :h2)).to eq('<h2><span class="field-label">label: </span><span class="field-value">value</span></h2>')
+    end
+
+
+    it 'can set html options for the surrounding tag' do
+      expect(helper.field_or_default('label', 'value', tag_options: {class: "blorf", id: "blorfid"})).to eq('<p class="blorf" id="blorfid"><span class="field-label">label: </span><span class="field-value">value</span></p>')
+      #eq("<p class=\"blorf\" id=\"blorfid\"><b>label</b>: value</p>")
+    end
+
+
+    it "can set class for the label + separator = 'special-label-class'" do
+      expect(helper.field_or_default('label', 'value', label_class: 'special-label-class')).to eq('<p><span class="special-label-class">label: </span><span class="field-value">value</span></p>')
+    end
+
+
+    it "default class for the value = 'special-value-class'" do
+      expect(helper.field_or_default('label', 'value', value_class: 'special-value-class')).to eq('<p><span class="field-label">label: </span><span class="special-value-class">value</span></p>')
+    end
+
+  end
+
+
+
 
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -119,7 +119,6 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     it 'can set html options for the surrounding tag' do
       expect(helper.field_or_default('label', 'value', tag_options: {class: "blorf", id: "blorfid"})).to eq('<p class="blorf" id="blorfid"><span class="field-label">label: </span><span class="field-value">value</span></p>')
-      #eq("<p class=\"blorf\" id=\"blorfid\"><b>label</b>: value</p>")
     end
 
 


### PR DESCRIPTION
PT Story:  If there is no information, don't show the label (and blank/empty)
https://www.pivotaltracker.com/story/show/140162709

Helper methods that can used in views so that if a field doesn't have a value (`isBlank?`), we don't display it.

Defaults to producing the same code we're currently using to display a field label and value on the `show` views.  It produces the same tags, and puts in some additional classes so that we can apply more specific CSS styling to elements as needed.

Instead of using the defaults, you can override any of the defaults:
- the surrounding tag (instead of `%p`)
- the text used to separate the label from the value (default = `: `)
- the class(es) for the label, and the value

And you can pass in a hash of options to apply to the surrounding tag, just as you can do with `content_tag`.

### Simple example:

Instead of this code in a view:
```
 %p
    %b #{t('.phone_number')}:
    = @company.phone_number
```

Just use this 1 line with the helper method:
```field_or_none( t('.phone_number'), @company.phone_number)```

###  More complicated example:
Use the `h4` tag instead of `p`, a different separator, and different classes to style the label and value.  If the value is _blank_ display `p.need_info (No website entered.)` instead of returning an empty String:

Instead of this code in a view:
```
- if @company.website.blank?
  %p.need_info '(No website entered.)`
-else
   %h4
     .website-large #{t('.website')}:
     .website = @company.website
```

You can use the helper method:
```
field_or_none( t('.website'), @company.website, 
                            default: content_for(:p, '(No website entered.)', class: 'need_info'  ),
                            label_class: 'website-large',
                            value_class: 'website')
```


### Changes proposed in this pull request:
1.  added specification (RSpec) for the `field_or_default` helper method
2. added `field_or_default` helper: what to display (the `default`) if the `value` is emtpy,
   otherwise return the HTML needed to render the given content_tag, options, class names. (See the code and spec for the defaults and examples.)

3. added `field_or_none` helper -- which just calls the `field_or_default` method with the default to show (if the field value is empty) set to and empty String.


Ready for review:
@patmbolger @thesuss 
