### PR TITLE
Add latitude, longitude to Address and implement geocoding, fix country default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,14 @@
 # The following values are only necessary for deployment.
 # Contact the project admin to get them if you want to deploy some changes to
 # the production server
+
+# for deploying:
 PRODUCTION_SERVER=xxx.xxx.xxx.xxx
 DEPLOY_USER=some_user
 APP_PATH=/path/to/app
 BRANCH=vcs_branch
+
+# used by the system:
+GOOGLE_MAP_API=1234567890
+SHF_ADMIN_PWD='hello'
+SHF_ADMIN_EMAIL='hello@example.com'

--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,43 @@
-# The following values are only necessary for deployment.
-# Contact the project admin to get them if you want to deploy some changes to
-# the production server
+# The system expects the following variables (keys) and values to be set
+# in the operating system environment or in a .env file.
+#
+# This file is an *example* to show you the variables that are expected.
+# The deployment keys and values MUST be in a file named '.env'  (See below)
+#
+# Contact the project admin to get the real values.
+#
+# DO NOT EVER COMMIT THE .env FILE TO GitHub OR ANY OTHER REPOSITIORY.
+#  YOUR .gitignore SHOULD INCLUDE .env SO THIS NEVER HAPPENS.
 
-# for deploying:
+
+# -----------------------------------
+# Keys and values used by the system:
+# -----------------------------------
+#
+#  These must be defined as environment variables in your operating system.
+
+# You must have a valid Google API key.  (Contact the project admin for the
+#  key for this project.)
+GOOGLE_MAP_API=1234567890
+
+SHF_ADMIN_PWD='hello'
+SHF_ADMIN_EMAIL='hello@example.com'
+
+
+# ----------------------------------------
+# Keys and values required for deployment:
+# ----------------------------------------
+#
+# You must have a file named '.env' with these keys and values set.
+# The Capistrano scripts use the 'dotenv' gem to read them from a .env file.
+#
+# You should make a copy of this file and name it '.env' and
+# replace the values below with the real values needed.
+#
+#  (If you are not deploying to the production server, you do not need worry
+#   about the real values for these.)
+
 PRODUCTION_SERVER=xxx.xxx.xxx.xxx
 DEPLOY_USER=some_user
 APP_PATH=/path/to/app
 BRANCH=vcs_branch
-
-# used by the system:
-GOOGLE_MAP_API=1234567890
-SHF_ADMIN_PWD='hello'
-SHF_ADMIN_EMAIL='hello@example.com'

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'whenever'
 
 gem 'smarter_csv'
 
+gem 'geocoder'
+
 group :development, :test do
   gem 'rspec-rails'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
     ffi (1.9.17)
     font-awesome-sass (4.7.0)
       sass (>= 3.2)
+    geocoder (1.4.3)
     gherkin (4.0.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -378,6 +379,7 @@ DEPENDENCIES
   factory_girl_rails
   ffaker
   font-awesome-sass
+  geocoder
   haml-rails
   high_voltage (~> 3.0.0)
   i18n-js (>= 3.0.0.rc11)

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -25,7 +25,7 @@ class Address < ApplicationRecord
 
   def entire_address
     [street_address, city, post_code, sverige_if_nil].compact.join(', ')
-end
+  end
 
 
   # Geocode the address, starting with all of the data.
@@ -43,7 +43,7 @@ end
 
     geo_result = nil
 
-    until most_specific > least_specific || !geo_result.nil?
+    until most_specific > least_specific || geo_result.present?
       geocode_address = specificity_order[most_specific..least_specific].compact.join(', ')
       geo_result = Geocoder.coordinates(geocode_address)
       most_specific += 1

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -16,4 +16,53 @@ class Address < ApplicationRecord
 
   scope :lacking_region, -> { where('region_id IS NULL') }
 
+
+  geocoded_by :entire_address
+
+  after_validation :geocode_best_possible,
+                   :if => lambda { |obj| obj.changed? }
+
+
+  def entire_address
+    [street_address, city, post_code, sverige_if_nil].compact.join(', ')
+end
+
+
+  # Geocode the address, starting with all of the data.
+  #  If we don't get a geocoded result, then keep trying,
+  #  using less and less 'specific' address information
+  #  until we can get a latitude, longitude returned from geocoding.
+  # This will handle addresses that aren't correct (ex: generated with FFaker or possibly entered wrong)
+  # and so will guarantee that at least *some* map can be displayed.  (Important for a company!)
+  def geocode_best_possible
+
+    specificity_order = [street_address, post_code, city, sverige_if_nil]
+
+    most_specific = 0
+    least_specific = specificity_order.size - 1
+
+    geo_result = nil
+
+    until most_specific > least_specific || !geo_result.nil?
+      geocode_address = specificity_order[most_specific..least_specific].compact.join(', ')
+      geo_result = Geocoder.coordinates(geocode_address)
+      most_specific += 1
+    end
+
+    unless geo_result.nil?
+      self.latitude = geo_result.first
+      self.longitude = geo_result.last
+    end
+
+  end
+
+
+  private
+
+
+  def sverige_if_nil
+    country = 'Sverige' if country.nil?
+    country
+  end
+
 end

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+    # Geocoding options
+    # timeout: 3,                 # geocoding service timeout (secs)
+    # lookup: :google,            # name of geocoding service (symbol)
+
+    language: :sv,              # ISO-639 language code
+
+    # use_https: false,           # use HTTPS for lookup requests? (if supported)
+    # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+    # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+
+    # API key for geocoding service
+    api_key: ENV['GOOGLE_MAP_API'],
+
+    # cache: nil,                 # cache object (must respond to #[], #[]=, and #keys)
+    # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
+
+    # Exceptions that should not be rescued by default
+    # (if you want to implement custom error handling);
+    # supports SocketError and Timeout::Error
+    # always_raise: [],
+
+    # Calculation options
+    units: :km,                 # :km for kilometers or :mi for miles
+
+    # distances: :linear          # :spherical or :linear
+)

--- a/db/migrate/20170305190917_add_latitude_longitude_to_address.rb
+++ b/db/migrate/20170305190917_add_latitude_longitude_to_address.rb
@@ -1,0 +1,11 @@
+class AddLatitudeLongitudeToAddress < ActiveRecord::Migration[5.0]
+
+  def change
+    add_column :addresses, :latitude, :float
+    add_column :addresses, :longitude, :float
+
+    add_index :addresses, [:latitude, :longitude]
+
+  end
+
+end

--- a/db/migrate/20170310224421_fix_country_default_in_addresses.rb
+++ b/db/migrate/20170310224421_fix_country_default_in_addresses.rb
@@ -1,0 +1,9 @@
+class FixCountryDefaultInAddresses < ActiveRecord::Migration[5.0]
+
+  def change
+
+    change_column_default :addresses, :country, from: "Sveriges", to: "Sverige"
+
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170305130437) do
+ActiveRecord::Schema.define(version: 20170310224421) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,13 +19,16 @@ ActiveRecord::Schema.define(version: 20170305130437) do
     t.string  "street_address"
     t.string  "post_code"
     t.string  "city"
-    t.string  "country",          default: "Sveriges", null: false
+    t.string  "country",          default: "Sverige", null: false
     t.integer "region_id"
     t.string  "addressable_type"
     t.integer "addressable_id"
     t.integer "kommun_id"
+    t.float   "latitude"
+    t.float   "longitude"
     t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable_type_and_addressable_id", using: :btree
     t.index ["kommun_id"], name: "index_addresses_on_kommun_id", using: :btree
+    t.index ["latitude", "longitude"], name: "index_addresses_on_latitude_and_longitude", using: :btree
     t.index ["region_id"], name: "index_addresses_on_region_id", using: :btree
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -105,6 +105,10 @@ if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_STAGING']
 
     applications = []
 
+    puts "Now creating membership applications."
+    puts "  As companies are created for accepted applications, their address has to be geocoded/located."
+    puts "  This takes time to do. Be patient. (You can look at the /log/development.log to be sure that things are happening and this is not stuck.)"
+
     2.times do
       r.rand(1..NUM_USERS).times do |i|
 

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe Address, type: :model do
 
       addr.validate
 
-      expect(addr.latitude).to eq(56.7440333)
-      expect(addr.longitude).to eq(12.727637)
+      expect(addr.latitude.round(3)).to eq(56.7440333.round(3))
+      expect(addr.longitude.round(3)).to eq(12.727637.round(3))
     end
 
 
@@ -124,8 +124,8 @@ RSpec.describe Address, type: :model do
         expect(addr.latitude).not_to eq(orig_lat)
         expect(addr.longitude).not_to eq(orig_long)
 
-        expect(addr.latitude).to eq(56.7442343)
-        expect(addr.longitude).to eq(12.7255982)
+        expect(addr.latitude.round(3)).to eq(56.7442343.round(3))
+        expect(addr.longitude.round(3)).to eq(12.7255982.round(3))
       end
 
       it 'changed kommun' do
@@ -135,8 +135,8 @@ RSpec.describe Address, type: :model do
         expect(addr.latitude).not_to eq(orig_lat)
         expect(addr.longitude).not_to eq(orig_long)
 
-        expect(addr.latitude).to eq(56.7440333)
-        expect(addr.longitude).to eq(12.727637)
+        expect(addr.latitude.round(3)).to eq(56.7440333.round(3))
+        expect(addr.longitude.round(3)).to eq(12.727637.round(3))
       end
 
       it 'changed city' do
@@ -149,8 +149,8 @@ RSpec.describe Address, type: :model do
         expect(addr.latitude).not_to eq(orig_lat)
         expect(addr.longitude).not_to eq(orig_long)
 
-        expect(addr.latitude).to eq(56.633333)
-        expect(addr.longitude).to eq(13.2)
+        expect(addr.latitude.round(3)).to eq(56.633333.round(3))
+        expect(addr.longitude.round(3)).to eq(13.2.round(3))
       end
 
       it 'changed region' do
@@ -161,8 +161,8 @@ RSpec.describe Address, type: :model do
         expect(addr.latitude).not_to eq(orig_lat)
         expect(addr.longitude).not_to eq(orig_long)
 
-        expect(addr.latitude).to eq(56.7440333)
-        expect(addr.longitude).to eq(12.727637)
+        expect(addr.latitude.round(3)).to eq(56.7440333.round(3))
+        expect(addr.longitude.round(3)).to eq(12.727637.round(3))
       end
 
       it 'changed country' do
@@ -172,8 +172,8 @@ RSpec.describe Address, type: :model do
         expect(addr.latitude).not_to eq(orig_lat)
         expect(addr.longitude).not_to eq(orig_long)
 
-        expect(addr.latitude).to eq(56.7440333)
-        expect(addr.longitude).to eq(12.727637)
+        expect(addr.latitude.round(3)).to eq(56.7440333.round(3))
+        expect(addr.longitude.round(3)).to eq(12.727637.round(3))
       end
 
 
@@ -189,63 +189,63 @@ RSpec.describe Address, type: :model do
 
       addr.validate
 
-      expect(addr.latitude).to eq(60.12816100000001)
-      expect(addr.longitude).to eq(18.643501)
+      expect(addr.latitude.round(3)).to eq(60.12816100000001.round(3))
+      expect(addr.longitude.round(3)).to eq(18.643501.round(3))
     end
+
 
     describe '#geocode_best_possible' do
 
-      let(:addr) { create(:company_address, street_address: 'Matarengivägen 24',
-                            post_code: '957 31',
-                            city: 'Övertorneå')}
-
-
       it 'all valid address components' do
-        addr.validate
-        expect(addr.latitude).to eq(66.39025389999999)
-        expect(addr.longitude).to eq(23.6601303)
+        address = Address.new(street_address: 'Matarengivägen 24',
+                       post_code: '957 31',
+                       city: 'Övertorneå')
+        address.validate
+        expect(address.latitude.round(3)).to eq(66.3902539.round(3))
+        expect(address.longitude.round(3)).to eq(23.6601303.round(3))
       end
 
 
       it 'invalid street_address' do
-        addr.street_address = 'blorf'
-        addr.validate
-
-        expect(addr.latitude).to eq(66.3887731)
-        expect(addr.longitude).to eq(23.6734973)
+        address = Address.new(street_address: 'blorf',
+                          post_code: '957 31',
+                          city: 'Övertorneå')
+        address.validate
+        expect(address.latitude.round(3)).to eq(66.3887731.round(3))
+        expect(address.longitude.round(3)).to eq(23.6734973.round(3))
       end
 
 
       it 'invalid post_code, street_address' do
-        addr.street_address = 'blorf'
-        addr.post_code = 'x'
-        addr.validate
-
-        expect(addr.latitude).to eq(66.3884436)
-        expect(addr.longitude).to eq(23.639283)
+        address = Address.new(street_address: 'blorf',
+                              post_code: 'x',
+                              city: 'Övertorneå')
+        address.validate
+        expect(address.latitude.round(3)).to eq(66.3884436.round(3))
+        expect(address.longitude.round(3)).to eq(23.639283.round(3))
       end
 
 
       it 'invalid city, post_code, street_address' do
-        addr.street_address = 'blorf'
-        addr.post_code = 'x'
-        addr.city = 'x'
-        addr.validate
+        address = Address.new(street_address: 'blorf',
+                              post_code: 'x',
+                              city: 'y')
+        address.validate
 
-        expect(addr.latitude).to eq(60.12816100000001)
-        expect(addr.longitude).to eq(18.643501)
+        expect(address.latitude.round(3)).to eq(60.128161.round(3))
+        expect(address.longitude.round(3)).to eq(18.643501.round(3))
       end
 
 
       it 'no address info should = Sverige' do
-        addr.street_address = 'blorf'
-        addr.post_code = 'x'
-        addr.city = 'x'
-        addr.country = nil
-        addr.validate
+        address = Address.new(street_address: nil,
+                              post_code: nil,
+                              city: nil,
+                              country: nil)
+        address.validate
 
-        expect(addr.latitude).to eq(60.12816100000001)
-        expect(addr.longitude).to eq(18.643501)
+        expect(address.latitude.round(3)).to eq(60.128161.round(3))
+        expect(address.longitude.round(3)).to eq(18.643501.round(3))
       end
 
     end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Address, type: :model do
     it { is_expected.to have_db_column :region_id }
     it { is_expected.to have_db_column :addressable_id }
     it { is_expected.to have_db_column :addressable_type }
+    it { is_expected.to have_db_column :latitude }
+    it { is_expected.to have_db_column :longitude }
   end
 
   describe 'Validations' do
@@ -36,9 +38,9 @@ RSpec.describe Address, type: :model do
     let(:co_has_regions) { create(:company, name: 'Has Region', company_number: '4268582063', city: 'HasRegionBorg') }
     let(:co_missing_region) { create(:company, name: 'Missing Region', company_number: '6112107039', city: 'NoRegionBorg') }
 
-    let(:addr_has_region) { co_has_regions.addresses.first }
+    let(:addr_has_region) { co_has_regions.main_address }
 
-    let(:no_region) { addr_no_region = co_missing_region.addresses.first
+    let(:no_region) { addr_no_region = co_missing_region.main_address
                       addr_no_region.update(region: nil)
                       addr_no_region
     }
@@ -79,4 +81,174 @@ RSpec.describe Address, type: :model do
 
   end
 
+
+  describe 'gecoding' do
+
+    let(:expected_streetaddress) { 'Kvarnliden 10' }
+    let(:expected_postcode) { '310 40' }
+    let(:expected_kommun) { create(:kommun, name: 'Halmstad V') }
+    let(:expected_city) { 'Harplinge' }
+    let(:expected_country) { 'Sverige' }
+
+    # orig lat and long, which is wrong and should be updated if the address changes
+    let(:orig_lat) { 56.7439545 }
+    let(:orig_long) { 12.7276875 }
+
+
+    it 'geocode from address' do
+      addr = Address.new(street_address: expected_streetaddress,
+                         city: expected_city,
+                         post_code: expected_postcode,
+                         country: 'Sweden')
+
+      addr.validate
+
+      expect(addr.latitude).to eq(56.7440333)
+      expect(addr.longitude).to eq(12.727637)
+    end
+
+
+    describe 'changed address so update latitude, longitude' do
+
+      let(:addr) { Address.new(street_address: expected_streetaddress,
+                               city: expected_city,
+                               post_code: expected_postcode,
+                               kommun: expected_kommun,
+                               country: expected_country)
+      }
+
+      it 'changed street address' do
+        addr.street_address = 'Kvarnliden 2'
+        addr.validate
+
+        expect(addr.latitude).not_to eq(orig_lat)
+        expect(addr.longitude).not_to eq(orig_long)
+
+        expect(addr.latitude).to eq(56.7442343)
+        expect(addr.longitude).to eq(12.7255982)
+      end
+
+      it 'changed kommun' do
+        addr.kommun = create(:kommun, name: 'Halmstad Ö')
+        addr.validate
+
+        expect(addr.latitude).not_to eq(orig_lat)
+        expect(addr.longitude).not_to eq(orig_long)
+
+        expect(addr.latitude).to eq(56.7440333)
+        expect(addr.longitude).to eq(12.727637)
+      end
+
+      it 'changed city' do
+        addr.city = 'Plingshult'
+        addr.street_address = ''
+        addr.post_code = ''
+
+        addr.validate
+
+        expect(addr.latitude).not_to eq(orig_lat)
+        expect(addr.longitude).not_to eq(orig_long)
+
+        expect(addr.latitude).to eq(56.633333)
+        expect(addr.longitude).to eq(13.2)
+      end
+
+      it 'changed region' do
+        new_region = create(:region, name: 'New Region', code: 'NR')
+        addr.region = new_region
+        addr.validate
+
+        expect(addr.latitude).not_to eq(orig_lat)
+        expect(addr.longitude).not_to eq(orig_long)
+
+        expect(addr.latitude).to eq(56.7440333)
+        expect(addr.longitude).to eq(12.727637)
+      end
+
+      it 'changed country' do
+        addr.country = 'Norway'
+        addr.validate
+
+        expect(addr.latitude).not_to eq(orig_lat)
+        expect(addr.longitude).not_to eq(orig_long)
+
+        expect(addr.latitude).to eq(56.7440333)
+        expect(addr.longitude).to eq(12.727637)
+      end
+
+
+    end
+
+
+    it 'if all info is nil, will at least return lat/long of Sweden' do
+
+      addr = Address.new(street_address: nil,
+                         city: nil,
+                         post_code: nil,
+                         country: nil)
+
+      addr.validate
+
+      expect(addr.latitude).to eq(60.12816100000001)
+      expect(addr.longitude).to eq(18.643501)
+    end
+
+    describe '#geocode_best_possible' do
+
+      let(:addr) { create(:company_address, street_address: 'Matarengivägen 24',
+                            post_code: '957 31',
+                            city: 'Övertorneå')}
+
+
+      it 'all valid address components' do
+        addr.validate
+        expect(addr.latitude).to eq(66.39025389999999)
+        expect(addr.longitude).to eq(23.6601303)
+      end
+
+
+      it 'invalid street_address' do
+        addr.street_address = 'blorf'
+        addr.validate
+
+        expect(addr.latitude).to eq(66.3887731)
+        expect(addr.longitude).to eq(23.6734973)
+      end
+
+
+      it 'invalid post_code, street_address' do
+        addr.street_address = 'blorf'
+        addr.post_code = 'x'
+        addr.validate
+
+        expect(addr.latitude).to eq(66.3884436)
+        expect(addr.longitude).to eq(23.639283)
+      end
+
+
+      it 'invalid city, post_code, street_address' do
+        addr.street_address = 'blorf'
+        addr.post_code = 'x'
+        addr.city = 'x'
+        addr.validate
+
+        expect(addr.latitude).to eq(60.12816100000001)
+        expect(addr.longitude).to eq(18.643501)
+      end
+
+
+      it 'no address info should = Sverige' do
+        addr.street_address = 'blorf'
+        addr.post_code = 'x'
+        addr.city = 'x'
+        addr.country = nil
+        addr.validate
+
+        expect(addr.latitude).to eq(60.12816100000001)
+        expect(addr.longitude).to eq(18.643501)
+      end
+
+    end
+
+  end
 end


### PR DESCRIPTION
PT Story:  Add coordinates to Address class
https://www.pivotaltracker.com/story/show/140865585

(This  is part of what was done in the big, messy, exploratory PR #178.  This replaces part of it; I'll close #178 without merging once I've completely refactored it into smaller PRs and the new PRs are all successfully merged. )

Changes proposed in this pull request:
1. add gecoder gem
2. get the Google API key from the environment (update the env.example file to note it)
1.  add latitude, longitude to migration
2. fix the default for country (was "Sveriges" but should be "Sverige")
3. geocode the address using the most specific info possible
4. add spec tests for geocoding


Ready for review:
@thesuss @patmbolger 
