### PR TITLE
Add 'better_errors' and 'binding_of_caller' gems 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,9 @@ group :development, :test do
   gem 'launchy'
   gem 'cucumber-timecop', require: false
 
+  gem 'better_errors'
+  gem 'binding_of_caller'  # needed to make better_errors work well
+
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,12 @@ GEM
       open4 (~> 1.3.0)
       thor (>= 0.15.4, < 2)
     bcrypt (3.1.11)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -368,6 +374,8 @@ DEPENDENCIES
   aasm (~> 4.11.1)
   backup
   bcrypt (~> 3.1.7)
+  better_errors
+  binding_of_caller
   bootstrap-sass (~> 3.3.6)
   capistrano (~> 3.6.0)
   capistrano-bundler (~> 1.1.2)


### PR DESCRIPTION
These gems make errors easier to work with in the browser (during development)

PT Story: https://www.pivotaltracker.com/story/show/140983989


Changes proposed in this pull request:
1.  added 'better_errors' and 'binding_of_caller' gems

Ready for review:
@patmbolger 
