### PR TITLE
db: seed Accepted membership_app must be the last one for a user

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,10 +17,21 @@ DEFAULT_PASSWORD = 'whatever'
 
 MA_ACCEPTED_STATE = :accepted
 
+NUM_USERS =  100
+
+MAX_APPS_PER_USER = 4
+
+FIRST_MEMBERSHIP_NUMBER = 100
+
+
+# --------------------
+
+
 private def env_invalid_blank(env_key)
   raise SeedAdminENVError, SEED_ERROR_MSG if (env_val = ENV.fetch(env_key)).blank?
   env_val
 end
+
 
 private def get_company_number(r)
   company_number = nil
@@ -37,6 +48,171 @@ private def get_company_number(r)
   end
   company_number
 end
+
+
+#---
+# Create some number of membership applications for a user.
+#
+# for 10% users, do not make any applications (they are just registered Users)
+# for 60% users, just make 1 application with a status chosen randomly
+# for 30% users, make multiple applications
+#   randomly select some number, and randomly select a state for each application
+#     Note that if there is an accepted application, it must be the LAST one
+#      because the code currently assumes that if a member has a company, that
+#       company can be accessed via the LAST membership application (user.membership_applications.last)
+#
+private def make_applications_for(user)
+
+  num_apps = Random.new.rand(1..10)
+
+  case num_apps
+    when 1..6
+      make_n_save_multiple_apps(user, MAX_APPS_PER_USER) # multiple applications
+    when 7..9
+      make_n_save_accepted_app(user)
+    else # no app; do nothing.
+  end
+
+  user
+end
+
+
+# make 'num_apps' number of applications for a user, ensure that if there is
+# an accepted application, it is the LAST one
+private def make_n_save_multiple_apps(user, max_apps)
+
+  append_accepted_app = false
+
+  company_number = get_company_number(Random.new)
+
+  states = MembershipApplication.aasm.states.map(&:name)
+
+  chosen_states = FFaker.fetch_sample( states, { count: (max_apps < states.count ? max_apps : states.count) } )
+
+  if chosen_states.include? MA_ACCEPTED_STATE
+    chosen_states = chosen_states - [MA_ACCEPTED_STATE]
+    append_accepted_app = true
+  end
+
+  chosen_states.each do | app_state |
+    ma = make_app(user, company_number)
+    ma.state = app_state
+    user.membership_applications << ma
+  end
+
+  user.save
+
+  if append_accepted_app
+    make_n_save_accepted_app(user, company_number)
+  end
+
+  user
+end
+
+
+private def make_new_company(company_number)
+
+  regions = Region.all.to_a
+  kommuns = Kommun.all.to_a
+
+  num_regions = regions.size
+  num_kommuns = kommuns.size
+
+  # make a full company instance
+  company = Company.new(company_number: company_number,
+                        email: FFaker::InternetSE.free_email,
+                        name: FFaker::CompanySE.name,
+                        phone_number: FFaker::PhoneNumberSE.phone_number,
+                        website: FFaker::InternetSE.http_url)
+  company.save
+
+  address = Address.new(addressable: company,
+                        city: FFaker::AddressSE.city,
+                        street_address: FFaker::AddressSE.street_address,
+                        post_code: FFaker::AddressSE.zip_code,
+                        region: regions[FFaker.rand(0..num_regions-1)],
+                        kommun: kommuns[FFaker.rand(0..num_kommuns-1)])
+
+  address.save
+
+  company
+end
+
+
+private def get_next_membership_number
+
+  MembershipApplication.last.nil? ? FIRST_MEMBERSHIP_NUMBER : MembershipApplication.last.id + FIRST_MEMBERSHIP_NUMBER
+end
+
+
+private def make_n_save_accepted_app(user, co_number = get_company_number(Random.new))
+
+  # create a basic app
+  ma = make_app(user, co_number )
+
+  # set the state to accepted
+  ma.state = MA_ACCEPTED_STATE
+
+  # make a full company object (instance) for the accepted membership application
+  ma.company = make_new_company(ma.company_number)
+
+  ma.membership_number = get_next_membership_number
+
+  # ensure that this is the *last* application for the user
+  user.membership_applications << ma
+
+  user.save
+  user
+end
+
+
+#  If the user already has a membership application, use the same names.
+# (They would only use different name if they made a mistake and submitted
+#   a whole new application.  We won't worry about that case here.)
+private def get_app_names(u)
+
+  if (m = MembershipApplication.find_by(user_id: u.id))
+    first_n = m.first_name
+    last_n = m.last_name
+  else
+    first_n = FFaker::NameSE.first_name
+    last_n = FFaker::NameSE.last_name
+  end
+
+  return first_n, last_n
+end
+
+
+private def make_app(u, company_number)
+
+  r = Random.new
+
+  business_categories = BusinessCategory.all.to_a
+  num_cats = business_categories.size
+
+  first_n, last_n = get_app_names(u)
+
+  # for 1 in 8 apps, use a different contact email than the user's email
+  ma = MembershipApplication.new(first_name: first_n,
+                                 last_name: last_n,
+                                 contact_email: ( (Random.new.rand(1..8)) == 0 ? FFaker::InternetSE.free_email : u.email),
+                                 company_number: company_number,
+                                 user: u)
+
+  # add 1 to 3 business_categories, picked at random from them
+  cats = FFaker.fetch_sample(business_categories, { count: (r.rand(1..3)) })
+
+  cats.each do | category |
+    ma.business_categories << category
+  end
+
+  ma
+end
+
+
+
+#---------------------------
+
 
 
 if Rails.env.production?
@@ -65,6 +241,7 @@ csv.each do |row|
   end
 end
 
+
 business_categories = %w(Träning Psykologi Rehab Butik Trim Friskvård Dagis Pensionat Skola)
 business_categories.each { |b_category| BusinessCategory.find_or_create_by(name: b_category) }
 BusinessCategory.find_or_create_by(name: 'Sociala tjänstehundar', description: 'Terapi-, vård- & skolhund dvs hundar som jobbar tillsammans med sin förare/ägare inom vård, skola och omsorg.')
@@ -83,9 +260,6 @@ if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_STAGING']
     puts 'Seeding the db with users...'
 
     r = Random.new
-    NUM_USERS = 100
-    num_regions = regions.size
-    num_kommuns = kommuns.size
 
     # Create users
     users = []
@@ -97,108 +271,16 @@ if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_STAGING']
 
     puts "Users created: #{NUM_USERS}"
 
-    # Create membership application for some users
-    # (two rounds - so some of the users have more than one application)
 
-    business_categories = BusinessCategory.all.to_a
-    num_cats = business_categories.size
-
-    applications = []
-
-    puts "Now creating membership applications."
+    puts "\nNow creating membership applications."
     puts "  As companies are created for accepted applications, their address has to be geocoded/located."
     puts "  This takes time to do. Be patient. (You can look at the /log/development.log to be sure that things are happening and this is not stuck.)"
 
-    2.times do
-      r.rand(1..NUM_USERS).times do |i|
+    users.each { |u| make_applications_for u }
 
-        next unless (company_number = get_company_number(r))
 
-        u = users[r.rand(0..NUM_USERS-1)]
-
-        #  If the user already has a membership application, use the same names.
-          # (They would only use different name if they made a mistake and submitted a whole new application.  We won't worry about that case here.)
-        if (m = MembershipApplication.find_by(user_id: u.id))
-          first_n = m.first_name
-          last_n = m.last_name
-        else
-          first_n = FFaker::NameSE.first_name
-          last_n = FFaker::NameSE.last_name
-        end
-
-        # Every 6th user has a different membership application contact email than the email they use to log in to SHF
-        ma = MembershipApplication.new(first_name: first_n,
-                                       last_name: last_n,
-                                       contact_email: (i.divmod(6).last == 0 ? FFaker::InternetSE.free_email : u.email),
-                                       company_number: company_number,
-                                       user: u)
-
-        idx1 = r.rand(0..num_cats-1)
-        ma.business_categories << business_categories[idx1]
-        idx2 = r.rand(0..num_cats-1)
-        ma.business_categories << business_categories[idx2] if idx2 != idx1
-        idx3 = r.rand(0..num_cats-1)
-        ma.business_categories << business_categories[idx3] if (idx3 != idx1 && idx3 != idx2)
-
-        ma.save
-
-        applications << ma
-      end
-    end
-
-    puts "Applications created: #{MembershipApplication.all.count}"
-
-    #---
-    # Membership Application status
-
-    # Ensure we have a good variation of different statuses (some accepted, some rejected, etc.)
-
-    #  We're most interested in accepted applications, so first make <some random number> of those
-
-    r.rand(1..applications.size).times do
-
-      ma = applications[r.rand(0..(applications.size-1))]
-
-      next if ma.is_accepted?
-
-      ma.state = MA_ACCEPTED_STATE
-      ma.user.save
-
-      company = Company.new(company_number: ma.company_number,
-                            email: FFaker::InternetSE.free_email,
-                            name: FFaker::CompanySE.name,
-                            phone_number: FFaker::PhoneNumberSE.phone_number,
-                            website: FFaker::InternetSE.http_url)
-      company.save
-
-      address = Address.new(addressable: company,
-                            city: FFaker::AddressSE.city,
-                            street_address: FFaker::AddressSE.street_address,
-                            post_code: FFaker::AddressSE.zip_code,
-                            region: regions[r.rand(0..num_regions-1)],
-                            kommun: kommuns[r.rand(0..num_kommuns-1)])
-
-      address.save
-
-      ma.company = company
-      ma.save
-    end
-
-    #  Then with the remaining applications, evenly distribute the remaining states:
-
-    remaining_apps = MembershipApplication.where.not(state: MA_ACCEPTED_STATE)
-
-    remaining_states = MembershipApplication.aasm.states.map(&:name) - [MA_ACCEPTED_STATE]
-
-    remaining_apps.each_with_index do | app, i |
-
-      # distribute the remaining possible states equally
-      app.update(state: remaining_states[ i.divmod(remaining_states.count).last  ] )
-
-    end
-
-    puts "Membership Applications by state:"
-    states = remaining_states +  [MA_ACCEPTED_STATE]
+    puts "\n Membership Applications by state:"
+    states = MembershipApplication.aasm.states.map(&:name)
     states.sort.each do | state |
       puts "  #{state}: #{MembershipApplication.where(state: state).count }"
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -210,7 +210,6 @@ private def make_app(u, company_number)
 end
 
 
-
 #---------------------------
 
 


### PR DESCRIPTION
Found an error when working with db:seeded (development || testing) data
 Accepted membership applications were not the _last_ application in a list of applications for a user.  
The navigation menu depends on this.  (See comments in this code for more info).


PT Story: https://www.pivotaltracker.com/story/show/142418279

Changes proposed in this pull request:
1.  If a user should have an `accepted` membership_application, that is added _last_ to the user
2.  Refactored the large rake task into smaller methods. It's slower now, but will be easier to maintain.


Ready for review:
@patmbolger @thesuss 
