### PR TITLE
SHF documents for admins and members (= Board meeting docs)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,4 @@
 @import "pagination";
 @import "companies";
 @import "maps";
+@import "shf-documents";

--- a/app/assets/stylesheets/shf-documents.scss
+++ b/app/assets/stylesheets/shf-documents.scss
@@ -1,0 +1,45 @@
+$shf-docs-table-not-striped-background: #ffffff;
+$shf-docs-table-striped-background: #fafafa;
+
+.shf_documents.index {
+
+  .entry-content {
+
+    padding: 30px;
+
+    table#shf-documents {
+
+      thead {
+
+        background: $shf-docs-table-not-striped-background;
+        border-bottom: solid 1pt;
+
+        th {
+          padding-bottom: 0;
+        }
+
+      }
+
+      //  striped, but don't stripe the table header row:
+      tr:nth-child(even) {
+        background-color: $shf-docs-table-striped-background;
+      }
+
+      tr:nth-child(odd) {
+        background-color: $shf-docs-table-not-striped-background;
+      }
+
+      th,
+      td {
+        padding-left: 0;
+      }
+
+      td.title {
+        font-weight: bold;
+      }
+
+    }
+
+  }
+
+}

--- a/app/controllers/shf_documents_controller.rb
+++ b/app/controllers/shf_documents_controller.rb
@@ -1,0 +1,95 @@
+class ShfDocumentsController < ApplicationController
+
+  before_action :set_shf_document, only:  [ :show, :edit, :update, :destroy ]
+  before_action :authorize_shf_doc, only: [ :show, :edit, :update, :destroy ]
+  before_action :authorize_shf_doc_class, only: [:index, :new, :create, :historika_meeting_minutes ]
+
+
+  def index
+    # ShfDocument.all
+    @ransack_query_results = ShfDocument.ransack(params[:q])
+    @shf_documents = @ransack_query_results.result(distinct: true)
+  end
+
+
+  def show
+  end
+
+
+  def new
+    @shf_document = ShfDocument.new
+    @shf_document.uploader = @current_user
+  end
+
+
+  def edit
+  end
+
+
+  def create
+    @shf_document = ShfDocument.new(shf_document_params)
+
+    if @shf_document.save
+      redirect_to @shf_document, notice: t('.success', document_title: @shf_document.title)
+    else
+      render :new, notice: t('.error', document_title: @shf_document.title )
+    end
+
+  end
+
+
+  def update
+
+    if @shf_document.update(shf_document_params)
+      redirect_to @shf_document, notice: t('.success', document_title: @shf_document.title )
+    else
+      render :edit, notice: t('.error', document_title: @shf_document.title )
+    end
+
+  end
+
+
+  def destroy
+
+    @shf_document.destroy
+
+    redirect_to shf_documents_url, notice: t('.success', document_title: @shf_document.title )
+
+  end
+
+
+
+  private
+
+  def authorize_shf_doc_class
+    authorize ShfDocument
+  end
+
+
+  def authorize_shf_doc
+    authorize @shf_document
+  end
+
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_shf_document
+    @shf_document = ShfDocument.find(params[:id])
+  end
+
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def shf_document_params
+    params.require(:shf_document).permit(:uploader_id,
+                                         :title,
+                                         :description,
+                                         :actual_file,
+                                         :actual_file_file_name,
+                                         :actual_file_file_size,
+                                         :actual_file_content_type,
+                                         :actual_file_updated_at,
+                                         :_destroy
+    )
+  end
+
+
+end

--- a/app/controllers/shf_documents_controller.rb
+++ b/app/controllers/shf_documents_controller.rb
@@ -58,6 +58,9 @@ class ShfDocumentsController < ApplicationController
   end
 
 
+  def minutes_and_static_pages
+  end
+
 
   private
 

--- a/app/models/shf_document.rb
+++ b/app/models/shf_document.rb
@@ -1,0 +1,65 @@
+# This is a document that is uploaded by a SHF user
+# (see the Controller for the Policy [rules for access]).
+#
+# For example, an Admin might upload SHF board meeting minutes so that
+#  SHF members can view it.  The SHF board meeting minutes are a ShfDocument.
+#
+
+class ShfDocument < ApplicationRecord
+
+  belongs_to :uploader, class_name: User
+
+  has_attached_file :actual_file
+  validates_attachment :actual_file, content_type: {content_type: ['image/jpeg',
+                                                                   'image/gif',
+                                                                   'image/png',
+                                                                   'text/plain',
+                                                                   'text/rtf',
+                                                                   'application/pdf',
+                                                                   'application/msword',
+                                                                   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                                                                   'application/vnd.ms-word.document.macroEnabled.12'],
+                                                    message: I18n.t('shf_documents.invalid_upload_type')},
+                       size: { in: 0..5.megabytes,
+                               message: :file_too_large
+                       }
+
+=begin
+
+  If the size validation fails, then the error message is looked up in the
+  locale file(s) starting based on I18n conventions, then adding 'actual_file_file'
+  as the attribute, and finally adding 'file_too_large' which is what is specified by the
+  'message' key within the 'size' hash above.  For some reason, the Paperclip gem will
+  raise (or find) 2 error messages:  the one for 'actual_file_file_size' and
+  one for 'actual_file'.
+
+  Here's an example of the error messages in the en.yml locale file:
+
+  en:
+    errors:
+      models:
+        shf_document:
+          attributes:
+            actual_file_file_size:
+              file_too_large: 'The uploaded file is too big.'
+            actual_file:
+              file_too_large: 'The uploaded file size must be smaller than %{max}. (Your file is %{value} bytes.)'
+
+
+  Paperclip makes some instance variables available to you so that you can use them
+  in the error messages if you want.  These variables are made available by the
+  size validator:  Paperclip::Validators::AttachmentSizeValidator.  Specifically,
+  the 'validate_each' method adds the instance variables :min, :max, and :count
+  available and passes them to the error messages.  You can choose to
+  use them in the messages (in the locale .yml files) or not.
+
+    min = the lower bound of the file size
+    max = the upper bound of the file size
+    count = the upper bound, converted to 'human_size' by ActiveSupport::NumberHelper.number_to_human_size(size)
+    value = the actual size of the file
+
+
+
+=end
+
+end

--- a/app/models/uploaded_file.rb
+++ b/app/models/uploaded_file.rb
@@ -28,7 +28,7 @@ class UploadedFile < ApplicationRecord
   Here's an example of the error messages in the en.yml locale file:
 
   en:
-    activerecord:
+    errors:
       models:
         uploaded_file:
           attributes:

--- a/app/policies/shf_document_policy.rb
+++ b/app/policies/shf_document_policy.rb
@@ -1,0 +1,28 @@
+class ShfDocumentPolicy < ApplicationPolicy
+
+
+  def index?
+    @user.is_member_or_admin? if @user
+  end
+
+  def update?
+    is_admin?
+  end
+
+
+  def show?
+    is_admin?
+  end
+
+
+  def new?
+    create?
+  end
+
+
+  def create?
+    is_admin?
+  end
+
+
+end

--- a/app/policies/shf_document_policy.rb
+++ b/app/policies/shf_document_policy.rb
@@ -24,5 +24,8 @@ class ShfDocumentPolicy < ApplicationPolicy
     is_admin?
   end
 
+  def minutes_and_static_pages?
+    index?
+  end
 
 end

--- a/app/views/application/_navigation.html.haml
+++ b/app/views/application/_navigation.html.haml
@@ -27,13 +27,7 @@
                 = link_to t('menus.nav.members.shf_companies'), root_path
 
               - if current_user.is_member_or_admin?
-                %li.menu-item.menu-item-has-children
-                  = link_to t('menus.nav.members.member_pages'), page_path('index')
-                  %ul.sub-menu
-                    - HighVoltage.page_ids.each do |page|
-                      - unless page == 'index'
-                        %li.menu-item
-                          = link_to page.capitalize, page_path(page)
+                = render 'navigation_member_pages'
 
                 - if current_user.has_company?
                   %li.menu-item.menu-item-has-children
@@ -56,13 +50,7 @@
         - if current_user && current_user.admin?
           .menu#menu-menu-3-container
             %ul.menu#menu-menu-3
-              %li.menu-item.menu-item-has-children
-                = link_to t('menus.nav.admin.member_pages'), page_path('index')
-                %ul.sub-menu
-                  - HighVoltage.page_ids.each do |page|
-                    - unless page == 'index'
-                      %li.menu-item
-                        = link_to page.capitalize, page_path(page)
+              = render 'navigation_member_pages'
 
               = render 'navigation_admin'
 

--- a/app/views/application/_navigation_member_pages.html.haml
+++ b/app/views/application/_navigation_member_pages.html.haml
@@ -1,0 +1,12 @@
+%li.menu-item.menu-item-has-children
+  = link_to t('menus.nav.members.member_pages'), member_pages_path
+
+  %ul.sub-menu
+
+    %li.menu-item
+      = link_to t('menus.nav.members.shf_meeting_minutes'), shf_documents_path
+
+    - HighVoltage.page_ids.each do |page|
+      - unless page == 'index'
+        %li.menu-item
+          = link_to page.capitalize, page_path(page)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -30,7 +30,7 @@
 
 
 
-  %body.page.page-template.page-template-page-sidebar-none
+  %body{class: "#{controller_name} #{action_name} page page-template page-template-page-sidebar-none"}
     // This embedded script sets the locale for I18n on the client side.
     // It needs to be in the body since only the body will be re-rendered
     // by default when turbolinks is enabled.

--- a/app/views/shf_documents/_form.html.haml
+++ b/app/views/shf_documents/_form.html.haml
@@ -1,0 +1,30 @@
+= form_for @shf_document do |f|
+
+  - if @shf_document.errors.any?
+    .wpcf7-response-output
+      #error_explanation
+        - @shf_document.errors.full_messages.each do |msg|
+          = msg
+
+
+  = f.label :title
+  = f.text_field :title
+
+
+  = f.label :description
+  = f.text_area :description
+
+
+
+  = f.label :uploader_id, "#{t('shf_documents.edit.uploaded_by')}"
+  = f.collection_select(:uploader_id,[@shf_document.uploader], :id, :email)
+
+
+
+  %p= t('shf_documents.edit.upload_the_document')
+
+  = f.file_field 'actual_file', multiple: false, name: 'shf_document[actual_file]'
+
+
+  .actions
+    = f.submit t('submit')

--- a/app/views/shf_documents/edit.html.haml
+++ b/app/views/shf_documents/edit.html.haml
@@ -1,0 +1,15 @@
+%header.entry-header
+  %h1.entry-title= t('.page_title', document_title: @shf_document.title)
+
+.post-title-divider
+  %span
+
+
+.entry-content.wpcf7
+  = render 'form'
+
+%br
+  .center
+    = link_to "#{t('shf_documents.view_shf_document')}", @shf_document, class: 'btn btn-default shf-document-view'
+
+    = link_to "#{t('shf_documents.all_shf_documents')}", shf_documents_path, class: 'btn btn-default shf-document-all'

--- a/app/views/shf_documents/index.html.haml
+++ b/app/views/shf_documents/index.html.haml
@@ -1,0 +1,36 @@
+%header.entry-header
+  %h1.entry-title= t('.page_title')
+
+.post-title-divider
+  %span
+
+.entry-content
+
+  %p= t('.instructions')
+
+  %table#shf-documents
+    %thead
+      %tr
+        %th= sort_link(@ransack_query_results, :title, t('.title'))
+
+        %th= sort_link(@ransack_query_results, :description, t('.description'))
+
+        - if current_user.try(:admin)
+          %th
+          %th
+
+    %tbody
+      - @shf_documents.each do |shf_document|
+        %tr.shf-document
+          %td.title= link_to shf_document.title, shf_document.actual_file.url, target: "_blank", id: "shf-document-link-#{shf_document.id}", class: "shf-document-file-link"
+
+          %td.description= shf_document.description
+
+          - if current_user.try(:admin)
+            %td= link_to t('.view_details'), shf_document
+            %td= link_to t('delete'), shf_document, :method => :delete, :data => { :confirm => t('.delete_confirm', document_title: shf_document.title) }
+
+  - if current_user.try(:admin)
+    %br
+    .center
+      = link_to t('shf_documents.new_shf_document'), new_shf_document_path, class: 'btn btn-default btn-shf-document-new'

--- a/app/views/shf_documents/minutes_and_static_pages.html.haml
+++ b/app/views/shf_documents/minutes_and_static_pages.html.haml
@@ -1,0 +1,14 @@
+%header.entry-header
+  %h1.entry-title= t('.member_pages')
+
+.post-title-divider
+  %span
+
+.entry-content
+
+  %ul
+    %li= link_to t('.shf_meeting_minutes'), shf_documents_path
+
+    - HighVoltage.page_ids.each do |page|
+      - unless page == 'index'
+        %li= link_to page.capitalize, page_path(page)

--- a/app/views/shf_documents/new.html.haml
+++ b/app/views/shf_documents/new.html.haml
@@ -1,0 +1,14 @@
+.shf-document.new#shf-document-new
+
+  %header.entry-header
+    %h1.entry-title= t('.page_title')
+
+  .post-title-divider
+    %span
+
+  .entry-content.wpcf7
+
+    = render 'form'
+
+  .center
+    = link_to "#{t('shf_documents.all_shf_documents')}", shf_documents_path, class: 'btn btn-default btn-shf-documents-all'

--- a/app/views/shf_documents/show.html.haml
+++ b/app/views/shf_documents/show.html.haml
@@ -1,0 +1,32 @@
+-# div{ :id => "#{unique_css_id(@shf_document)}", class: "#{item_view_class(@shf_document, controller.action_name)}" }
+.shf-document.show#shf-document
+
+  %header.entry-header
+    %h1.entry-title= @shf_document.title
+
+  .post-title-divider
+    %span
+
+  .entry-content
+
+    = field_or_none t('.title'), @shf_document.title, tag_options: {class: 'shf-document-title'}
+
+    = field_or_none t('.description'), @shf_document.description, tag_options: {class: 'shf-document-description'}
+
+    = field_or_none t('.uploaded_by'), @shf_document.uploader.email, tag_options: {class: 'shf-document-uploader'}
+
+    = field_or_none t('.uploaded_on'), @shf_document.created_at, tag_options: {class: 'shf-document-uploaded-on'}
+
+    %h3
+      = t('.filename')
+      = link_to @shf_document.actual_file_file_name, @shf_document.actual_file.url, target: "_blank", id: "shf-document-link-#{@shf_document.id}", class: "shf-document-file-link"
+
+    .row.center.item-nav-buttons#item-nav-buttons
+      - if policy(@shf_document).update?
+        = link_to "#{t('shf_documents.edit_shf_document')}", edit_shf_document_path(@shf_document), class: 'btn btn-default edit-shf-document'
+
+      -if policy(@shf_document).index?
+        = link_to "#{t('shf_documents.all_shf_documents')}", shf_documents_path, class: 'btn btn-default all-shf-documents'
+
+      - if policy(@shf_document).destroy?
+        = link_to "#{t('delete')}", @shf_document, method: :delete, class:'btn btn-danger delete-shf-document', data: { confirm: "#{t('.delete_confirm', document_title: @shf_document.title)}" }

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -15,3 +15,5 @@ Rails.application.config.assets.precompile += %w( custom-membership-application-
 Rails.application.config.assets.precompile += %w( users.scss )
 Rails.application.config.assets.precompile += %w{ maps.scss }
 Rails.application.config.assets.precompile += %w{ companies.scss }
+Rails.application.config.assets.precompile += %w{ shf-documents.scss }
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,10 @@ en:
         one: Company
         other: Companies
 
+      shf_document:
+        one: SHF Document
+        other: SHF Documents
+
 
     attributes:
 
@@ -130,6 +134,10 @@ en:
         name: &business_category_name  Name
         description: &description  Description
 
+      shf_document:
+        title: &title Title
+        description: *description
+        uploader: &uploader Uploader
 
 
     errors:
@@ -152,12 +160,20 @@ en:
             password_confirmation:
               confirmation: doesn't match with the password entered.
 
+        shf_document:
+          attributes:
+            actual_file_file_size:
+              file_too_large: 'The uploaded file is too big.'
+            actual_file:
+              file_too_large: 'The uploaded file size must be smaller than %{max}. (Your file is %{value} bytes.)'
+
 
       messages:
         record_invalid: "Validation failed: %{errors}"
         restrict_dependent_destroy:
           has_one: "Cannot delete record because a dependent %{record} exists"
           has_many: "Cannot delete record because dependent %{record} exist"
+
 
  # Automatic and manual lookup for views:
   membership_applications:
@@ -302,8 +318,8 @@ en:
       filename: Filename
       file_was_uploaded: 'This file was uploaded: %{filename}'
       confirm_delete: 'Are you sure you want to delete %{filename}?'
-      invalid_upload_type: Sorry, this is not a file type you can upload.
-      file_too_large: The file must be smaller than 5 MB
+      invalid_upload_type: &invalid_upload_type Sorry, this is not a file type you can upload.
+      file_too_large: &file_too_large_5MB The file must be smaller than 5 MB
 
 
     update_the_status: Update the status
@@ -468,6 +484,60 @@ en:
     export_ansokan_csv:
       success: Export successful. Check your browser downloads for the file.
       error: There was a problem with the export.
+
+
+  shf_documents:
+
+    new_shf_document: &new_shf_document New SHF Document
+    edit_shf_document: Edit the SHF Document
+    view_shf_document: View the SHF Document
+    all_shf_documents: All SHF Documents
+
+    invalid_upload_type: Sorry, this is not a file type you can upload.
+    file_too_large: *file_too_large_5MB
+
+    index:
+      page_title: 'Historical Documents: Board Meeting Minutes'
+      instructions: 'These are SHF Board meeting minutes.  Click on the title of a document to view it.  Depending on your browser settings, it might open in a new window or it might download.'
+      title: *title
+      description: *description
+      delete_confirm: 'Are you sure you want to delete %{document_title}?'
+      view_details: View details
+
+    show:
+      page_title: 'SHF Document: %{document_title}'
+      title: *title
+      description: *description
+      uploaded_by: &uploaded_by Uploaded by
+      uploaded_on: &uploaded_on Uploaded on
+      filename: 'File:'
+      delete_confirm: 'Are you sure you want to delete %{document_title}?'
+
+    new:
+      page_title: *new_shf_document
+      title: *title
+      description: *description
+      uploaded_by: *uploaded_by
+      uploaded_on: *uploaded_on
+
+    create:
+      success: '%{document_title} was uploaded successfully.'
+      error: 'There was a problem uploading %{document_title}'
+
+    edit:
+      page_title: 'Edit SHF Document: %{document_title}'
+      title: *title
+      description: *description
+      uploaded_by: *uploaded_by
+      uploaded_on: *uploaded_on
+      upload_the_document: Upload the document
+
+    update:
+      success: '%{document_title} was updated successfully.'
+      error: 'There was a problem updating %{document_title}'
+
+    destroy:
+      success: '%{document_title} deleted.'
 
 
   devise:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -539,6 +539,9 @@ en:
     destroy:
       success: '%{document_title} deleted.'
 
+    minutes_and_static_pages:
+      member_pages: &member_pages Member pages
+      shf_meeting_minutes: &member_pages_board_meetings SHF Board Meeting Minutes
 
   devise:
     min_length: '(at least %{minimum_length} characters)'
@@ -641,7 +644,8 @@ en:
 
       members:
         shf_companies: SHF Companies
-        member_pages: &member_pages Member pages
+        member_pages: *member_pages
+        shf_meeting_minutes: *member_pages_board_meetings
         manage_company:
           submenu_title: Manage my company
           view_company: View Company
@@ -651,6 +655,7 @@ en:
       admin:
         shf_main_site: *shf_main_site
         member_pages: *member_pages
+        shf_meeting_minutes: *member_pages_board_meetings
         manage_applications: Manage Applications
         categories:
           submenu_title: Categories

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -501,8 +501,8 @@ en:
   shf_documents:
 
     new_shf_document: &new_shf_document New SHF Document
-    edit_shf_document: Edit the SHF Document
-    view_shf_document: View the SHF Document
+    edit_shf_document: Edit the SHF document details
+    view_shf_document: View the SHF document details
     all_shf_documents: All SHF Documents
 
     invalid_upload_type: Sorry, this is not a file type you can upload.
@@ -537,7 +537,7 @@ en:
       error: 'There was a problem uploading %{document_title}'
 
     edit:
-      page_title: 'Edit SHF Document: %{document_title}'
+      page_title: 'Edit Details for SHF Document: %{document_title}'
       title: *title
       description: *description
       uploaded_by: *uploaded_by

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -502,8 +502,8 @@ sv:
   shf_documents:
 
     new_shf_document: &new_shf_document Ny SHF Dokument
-    edit_shf_document: Redigera SHF Document
-    view_shf_document: Visa SHF Document
+    edit_shf_document: Redigera informationen SHF dokument
+    view_shf_document: Visa informationen SHF dokument
     all_shf_documents: Alla SHF Dokument
 
     invalid_upload_type: *invalid_upload_type
@@ -538,7 +538,7 @@ sv:
       error: 'Det fanns ett problem att ladda upp %{document_title}'
 
     edit:
-      page_title: 'Redigera SHF Dokument: %{document_title}'
+      page_title: 'Redigera Informationen SHF Dokument: %{document_title}'
       title: *title
       description: *description
       uploaded_by: *uploaded_by

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -542,8 +542,9 @@ sv:
     destroy:
       success: '%{document_title} deleted.'
 
-
-
+    minutes_and_static_pages:
+      member_pages: &member_pages Medlemssidor
+      shf_meeting_minutes: &member_pages_board_meetings SHF Styrelseprotokoll Minuter
 
   devise:
     min_length: '(minst %{minimum_length} tecken)'
@@ -646,7 +647,8 @@ sv:
 
       members:
         shf_companies: SHF-företag
-        member_pages: &member_pages Medlemssidor
+        member_pages: *member_pages
+        shf_meeting_minutes: *member_pages_board_meetings
         manage_company:
           submenu_title: Hantera företag
           view_company: Visa företagssida
@@ -656,6 +658,7 @@ sv:
       admin:
         shf_main_site: *shf_main_site
         member_pages: *member_pages
+        shf_meeting_minutes: *member_pages_board_meetings
         manage_applications: Hantera ansökningar
         categories:
           submenu_title: Kategorier

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -80,6 +80,11 @@ sv:
         one: Företag
         other: Företag
 
+      shf_document:
+        one: SHF Dokument
+        other: SHF Dokument
+
+
     attributes:
 
       user:
@@ -130,6 +135,11 @@ sv:
         name: &business_category_name  Namn
         description: &description  Beskrivning
 
+      shf_document:
+        title: &title Titel
+        description: *description
+        uploader: &uploader Uppladdare
+
     errors:
 
       models:
@@ -137,7 +147,7 @@ sv:
         uploaded_file:
           attributes:
             actual_file_file_size:
-              file_too_large: 'Den uppladdade är alltför stor.'
+              file_too_large: &file_too_large 'Den uppladdade är alltför stor.'
             actual_file:
               file_too_large: 'Filen måste vara mindre än %{max}. (Filen är %{value} byte.)'
 
@@ -151,6 +161,14 @@ sv:
           attributes:
             password_confirmation:
               confirmation: stämmer inte med det angivna lösenordet.
+
+        shf_document:
+          attributes:
+            actual_file_file_size:
+              file_too_large: *file_too_large
+            actual_file:
+              file_too_large: 'Filen måste vara mindre än %{max}. (Filen är %{value} byte.)'
+
 
       messages:
         record_invalid: 'Ett fel uppstod: %{errors}'
@@ -303,8 +321,8 @@ sv:
       filename: Filnamn
       file_was_uploaded: 'Filen laddades upp: %{filename}'
       confirm_delete: 'Är du säker på att du vill radera %{filename}?'
-      invalid_upload_type: Tyvärr kan du inte ladda upp denna filtypen.
-      file_too_large: Filen måste vara mindre än 5 MB
+      invalid_upload_type: &invalid_upload_type Tyvärr kan du inte ladda upp denna filtypen.
+      file_too_large: &file_too_large_5MB Filen måste vara mindre än 5 MB
 
     update_the_status: Uppdatera status
     application_deleted: Ansökan raderad.
@@ -469,6 +487,63 @@ sv:
     export_ansokan_csv:
       success: Exporten lyckades. Du hittar filen bland din webbläsares nedladdade filer.
       error: Ett problem uppstod med exporten.
+
+
+  shf_documents:
+
+    new_shf_document: &new_shf_document Ny SHF Dokument
+    edit_shf_document: Redigera SHF Document
+    view_shf_document: Visa SHF Document
+    all_shf_documents: Alla SHF Dokument
+
+    invalid_upload_type: *invalid_upload_type
+    file_too_large: *file_too_large_5MB
+
+    index:
+      page_title: 'Historika Dokument: Styrelseprotkoll'
+      instructions: 'These are SHF Board meeting minutes.  Click on the title of a document to view it.  Depending on your browser settings, it might open in a new window or it might download.'
+      title: *title
+      description: *description
+      delete_confirm: 'Är du säker på att du vill radera %{document_title}?'
+      view_details: Visa detaljer
+
+    show:
+      page_title: 'SHF Document: %{document_title}'
+      title: *title
+      description: *description
+      uploaded_by: &uploaded_by Uppladdad av
+      uploaded_on: &uploaded_on Datum upp
+      filename: 'Filen:'
+      delete_confirm: 'Är du säker på att du vill radera %{document_title}?'
+
+    new:
+      page_title: *new_shf_document
+      title: *title
+      description: *description
+      uploaded_by: *uploaded_by
+      uploaded_on: *uploaded_on
+
+    create:
+      success: 'Filen laddades upp: %{document_title}'
+      error: 'Det fanns ett problem att ladda upp %{document_title}'
+
+    edit:
+      page_title: 'Redigera SHF Dokument: %{document_title}'
+      title: *title
+      description: *description
+      uploaded_by: *uploaded_by
+      uploaded_on: *uploaded_on
+      upload_the_document: Ladda dokument
+
+    update:
+      success: '%{document_title} uppdaterad.'
+      error: 'Det fanns ett problem att uppdatera dokumentet.'
+
+    destroy:
+      success: '%{document_title} deleted.'
+
+
+
 
   devise:
     min_length: '(minst %{minimum_length} tecken)'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -147,7 +147,7 @@ sv:
       shf_document:
         title: &title Titel
         description: *description
-        uploader: &uploader Uppladdare
+        uploader: &uploader Uppladdad av
 
     errors:
 
@@ -156,7 +156,7 @@ sv:
         uploaded_file:
           attributes:
             actual_file_file_size:
-              file_too_large: &file_too_large 'Den uppladdade är alltför stor.'
+              file_too_large: &file_too_large 'Filen är för stor för att laddas upp.'
             actual_file:
               file_too_large: 'Filen måste vara mindre än %{max}. (Filen är %{value} byte.)'
 
@@ -501,29 +501,29 @@ sv:
 
   shf_documents:
 
-    new_shf_document: &new_shf_document Ny SHF Dokument
-    edit_shf_document: Redigera informationen SHF dokument
-    view_shf_document: Visa informationen SHF dokument
-    all_shf_documents: Alla SHF Dokument
+    new_shf_document: &new_shf_document Nytt dokument
+    edit_shf_document: Redigera info om dokument
+    view_shf_document: Information om dokument
+    all_shf_documents: Alla uppladdade dokument
 
     invalid_upload_type: *invalid_upload_type
     file_too_large: *file_too_large_5MB
 
     index:
-      page_title: 'Historika Dokument: Styrelseprotkoll'
-      instructions: 'These are SHF Board meeting minutes.  Click on the title of a document to view it.  Depending on your browser settings, it might open in a new window or it might download.'
+      page_title: 'Styrelseprotokoll'
+      instructions: 'Här hittar du våra senaste styrelsemötesprotokoll. Klicka på titeln på ett dokument för att visa det. Beroende på dina webbläsarinställningar kan det öppnas i ett nytt fönster eller så laddas det ner.'
       title: *title
       description: *description
       delete_confirm: 'Är du säker på att du vill radera %{document_title}?'
       view_details: Visa detaljer
 
     show:
-      page_title: 'SHF Document: %{document_title}'
+      page_title: 'Information om: %{document_title}'
       title: *title
       description: *description
       uploaded_by: &uploaded_by Uppladdad av
-      uploaded_on: &uploaded_on Datum upp
-      filename: 'Filen:'
+      uploaded_on: &uploaded_on Datum
+      filename: 'Filnamn:'
       delete_confirm: 'Är du säker på att du vill radera %{document_title}?'
 
     new:
@@ -538,23 +538,23 @@ sv:
       error: 'Det fanns ett problem att ladda upp %{document_title}'
 
     edit:
-      page_title: 'Redigera Informationen SHF Dokument: %{document_title}'
+      page_title: 'Redigera uppladdat dokument: %{document_title}'
       title: *title
       description: *description
       uploaded_by: *uploaded_by
       uploaded_on: *uploaded_on
-      upload_the_document: Ladda dokument
+      upload_the_document: Ladda upp dokument
 
     update:
-      success: '%{document_title} uppdaterad.'
+      success: '%{document_title} uppdaterades utan problem.'
       error: 'Det fanns ett problem att uppdatera dokumentet.'
 
     destroy:
-      success: '%{document_title} deleted.'
+      success: '%{document_title} togs bort.'
 
     minutes_and_static_pages:
       member_pages: &member_pages Medlemssidor
-      shf_meeting_minutes: &member_pages_board_meetings SHF Styrelseprotokoll Minuter
+      shf_meeting_minutes: &member_pages_board_meetings Styrelseprotokoll
 
   devise:
     min_length: '(minst %{minimum_length} tecken)'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,9 @@ Rails.application.routes.draw do
     resources :companies, path: 'hundforetag'
 
     resources :users, path: 'anvandare'
+
+    resources :shf_documents
+
   end
 
   get 'information', to: 'membership_applications#information'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,8 @@ Rails.application.routes.draw do
 
     resources :shf_documents
 
+    get 'member-pages', to: 'shf_documents#minutes_and_static_pages'
+
   end
 
   get 'information', to: 'membership_applications#information'

--- a/db/migrate/20170323202941_create_shf_documents.rb
+++ b/db/migrate/20170323202941_create_shf_documents.rb
@@ -1,0 +1,15 @@
+class CreateShfDocuments < ActiveRecord::Migration[5.0]
+
+  def change
+
+    create_table :shf_documents do |t|
+      t.belongs_to :uploader,  null: false, foreign_key: { to_table: :users }
+      t.string :title
+      t.text :description
+
+      t.timestamps
+    end
+
+  end
+
+end

--- a/db/migrate/20170324015417_add_attachment_actual_file_to_shf_documents.rb
+++ b/db/migrate/20170324015417_add_attachment_actual_file_to_shf_documents.rb
@@ -1,0 +1,12 @@
+class AddAttachmentActualFileToShfDocuments < ActiveRecord::Migration[5.0]
+
+  def self.up
+    change_table :shf_documents do |t|
+      t.attachment :actual_file
+    end
+  end
+
+  def self.down
+    remove_attachment :shf_documents, :actual_file
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170316182702) do
+ActiveRecord::Schema.define(version: 20170324015417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -102,6 +102,19 @@ ActiveRecord::Schema.define(version: 20170316182702) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "shf_documents", force: :cascade do |t|
+    t.integer  "uploader_id",              null: false
+    t.string   "title"
+    t.text     "description"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.string   "actual_file_file_name"
+    t.string   "actual_file_content_type"
+    t.integer  "actual_file_file_size"
+    t.datetime "actual_file_updated_at"
+    t.index ["uploader_id"], name: "index_shf_documents_on_uploader_id", using: :btree
+  end
+
   create_table "uploaded_files", force: :cascade do |t|
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
@@ -135,5 +148,6 @@ ActiveRecord::Schema.define(version: 20170316182702) do
   add_foreign_key "addresses", "regions"
   add_foreign_key "ckeditor_assets", "companies"
   add_foreign_key "membership_applications", "users"
+  add_foreign_key "shf_documents", "users", column: "uploader_id"
   add_foreign_key "uploaded_files", "membership_applications"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170310224421) do
+ActiveRecord::Schema.define(version: 20170324015417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,19 @@ ActiveRecord::Schema.define(version: 20170310224421) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "shf_documents", force: :cascade do |t|
+    t.integer  "uploader_id",              null: false
+    t.string   "title"
+    t.text     "description"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.string   "actual_file_file_name"
+    t.string   "actual_file_content_type"
+    t.integer  "actual_file_file_size"
+    t.datetime "actual_file_updated_at"
+    t.index ["uploader_id"], name: "index_shf_documents_on_uploader_id", using: :btree
+  end
+
   create_table "uploaded_files", force: :cascade do |t|
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
@@ -118,5 +131,6 @@ ActiveRecord::Schema.define(version: 20170310224421) do
   add_foreign_key "addresses", "kommuns"
   add_foreign_key "addresses", "regions"
   add_foreign_key "membership_applications", "users"
+  add_foreign_key "shf_documents", "users", column: "uploader_id"
   add_foreign_key "uploaded_files", "membership_applications"
 end

--- a/features/shf-documents/admin-deletes-shf-document.feature
+++ b/features/shf-documents/admin-deletes-shf-document.feature
@@ -1,0 +1,56 @@
+Feature: Admin can delete uploaded SHF Documents
+
+  As an admin
+  So that get rid of SHF documents that shouldn't have been uploaded
+  I need to be able to delete a SHF document
+
+
+  Background:
+
+
+    Given the following users exists
+      | email              | admin |
+      | emma@happymutts.se |       |
+      | bob@snarkybarky.se |       |
+      | admin@shf.se       | true  |
+
+    And the following companies exist:
+      | name        | company_number | email               |
+      | Happy Mutts | 2120000142     | bowwow@bowsersy.com |
+
+    And the following applications exist:
+      | first_name | user_email         | company_number | state    |
+      | Emma       | emma@happymutts.se | 2120000142     | accepted |
+
+    And I am logged in as "admin@shf.se"
+
+
+  @admin @poltergeist
+  Scenario:  Admin can delete a SHF document - confirm delete
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | doc 1                   | description 1                 |
+    And I choose a shf-document named "diploma.pdf" to upload
+    And I click on t("submit") button
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | doc 2                   | description 2                 |
+    And I choose a shf-document named "image.jpg" to upload
+    And I click on t("submit") button
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | doc 3                   | description 3                 |
+    And I choose a shf-document named "image.png" to upload
+    And I click on t("submit") button
+    And I am on the "all shf documents" page
+    And I should see 3 shf-documents listed
+    And I should see t("delete")
+    When I click the t("delete") action for the row with "doc 1"
+    And I confirm popup
+    Then I should see t("shf_documents.destroy.success", document_title: "doc 1")
+    And I should see 2 shf-documents listed
+    And I should not see "description 1"
+

--- a/features/shf-documents/admin-deletes-shf-document.feature
+++ b/features/shf-documents/admin-deletes-shf-document.feature
@@ -1,7 +1,7 @@
 Feature: Admin can delete uploaded SHF Documents
 
   As an admin
-  So that get rid of SHF documents that shouldn't have been uploaded
+  So that I can get rid of SHF documents that shouldn't have been uploaded
   I need to be able to delete a SHF document
 
 

--- a/features/shf-documents/admin-edits-shf-document.feature
+++ b/features/shf-documents/admin-edits-shf-document.feature
@@ -1,0 +1,111 @@
+Feature: Admin can edit details about an uploaded SHF Document
+
+  As an admin
+  So that I can keep information about uploaded SHF Documents up to date and helpful
+  I need to be able to edit details about uploaded SHF Documents
+
+
+  Background:
+
+
+    Given the following users exists
+      | email               | admin |
+      | emma@happymutts.se |       |
+      | bob@snarkybarky.se  |       |
+      | admin@shf.se        | true  |
+
+    And the following companies exist:
+      | name        | company_number | email               |
+      | Happy Mutts | 2120000142     | bowwow@bowsersy.com |
+
+    And the following applications exist:
+      | first_name | user_email          | company_number | state    |
+      | Emma       | emma@happymutts.se | 2120000142     | accepted |
+
+    And I am logged in as "admin@shf.se"
+
+
+  @admin
+  Scenario:  Admin can edit a SHF document - change the file uploaded
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | Uploaded document        | some description              |
+    And I choose a shf-document named "diploma.pdf" to upload
+    And I click on t("submit") button
+    And I am on the edit SHF document page for "Uploaded document"
+    And I choose a shf-document named "image.png" to upload
+    When I click on t("submit") button
+    Then I should see t("shf_documents.update.success", document_title: "Uploaded document")
+    And I should be on the SHF document page for "Uploaded document"
+    And I should see "image.png"
+    And I should not see "diploma.pdf"
+
+
+  @admin
+  Scenario:  Admin can edit a SHF document - change the title
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | Uploaded document        | some description              |
+    And I choose a shf-document named "diploma.pdf" to upload
+    And I click on t("submit") button
+    And I am on the edit SHF document page for "Uploaded document"
+    And I fill in t("shf_documents.edit.title") with "Changed title"
+    When I click on t("submit") button
+    Then I should see t("shf_documents.update.success", document_title: "Changed title")
+    And I should be on the SHF document page for "Changed title"
+    And I should see "Changed title"
+
+
+  @admin
+  Scenario:  Admin can edit a SHF document - change the description
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | Uploaded document        | some description              |
+    And I choose a shf-document named "diploma.pdf" to upload
+    And I click on t("submit") button
+    And I am on the edit SHF document page for "Uploaded document"
+    And I fill in t("shf_documents.edit.description") with "Changed description"
+    When I click on t("submit") button
+    Then I should see t("shf_documents.update.success", document_title: "Uploaded document")
+    And I should be on the SHF document page for "Uploaded document"
+    And I should see "Changed description"
+
+
+  @visitor
+  Scenario: Visitor cannot upload a SHF document
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | Uploaded document        | some description              |
+    And I choose a shf-document named "diploma.pdf" to upload
+    And I click on t("submit") button
+    And I am logged out
+    When I am on the edit SHF document page for "Uploaded document"
+    Then I should see t("errors.not_permitted")
+
+  @user
+  Scenario: User cannot upload a SHF document
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | Uploaded document        | some description              |
+    And I choose a shf-document named "diploma.pdf" to upload
+    And I click on t("submit") button
+    And I am logged in as "bob@snarkybarky.se"
+    When I am on the edit SHF document page for "Uploaded document"
+    Then I should see t("errors.not_permitted")
+
+  @member
+  Scenario: Member cannot upload a SHF document
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | Uploaded document        | some description              |
+    And I choose a shf-document named "diploma.pdf" to upload
+    And I click on t("submit") button
+    And I am logged in as "emma@happymutts.se"
+    When I am on the edit SHF document page for "Uploaded document"
+    Then I should see t("errors.not_permitted")

--- a/features/shf-documents/admin-uploads-shf-documents.feature
+++ b/features/shf-documents/admin-uploads-shf-documents.feature
@@ -1,0 +1,67 @@
+Feature: Admin uploads meeting PDFs
+
+  As an admin
+  So that the members of the organization stay informed about their organization
+  I need to upload meeting minutes
+
+  Background:
+
+    Given the following users exists
+      | email               | admin |
+      | emma@happymutts.se |       |
+      | bob@snarkybarky.se  |       |
+      | admin@shf.se        | true  |
+
+    And the following companies exist:
+      | name        | company_number | email               |
+      | Happy Mutts | 2120000142     | bowwow@bowsersy.com |
+
+    And the following applications exist:
+      | first_name | user_email          | company_number | state    |
+      | Emma       | emma@happymutts.se | 2120000142     | accepted |
+
+
+    And I am logged in as "admin@shf.se"
+
+  @admin
+  Scenario: Upload a meeting PDF
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | Uploaded diploma        | some description              |
+    And I choose a shf-document named "diploma.pdf" to upload
+    When I click on t("submit") button
+    Then I should see t("shf_documents.create.success", document_title: "Uploaded diploma")
+    When I am on the "all SHF documents" page
+    Then I should see "Uploaded diploma"
+
+  @admin @sad_path
+  Scenario: Try to upload a file with unacceptable content type [SAD PATH]
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | Uploaded diploma        | some description              |
+    And I choose a shf-document named "tred.exe" to upload
+    When I click on t("submit") button
+    Then I should see t("shf_documents.invalid_upload_type")
+    When I am on the "all SHF documents" page
+    Then I should not see "Uploaded diploma"
+
+
+  @visitor
+  Scenario: Visitor cannot upload a SHF document
+    Given I am Logged out
+    And I am on the "new SHF document" page
+    Then I should see t("errors.not_permitted")
+
+  @user
+  Scenario: User cannot upload a SHF document
+    Given I am logged in as "bob@snarkybarky.se"
+    And I am on the "new SHF document" page
+    Then I should see t("errors.not_permitted")
+
+  @member
+  Scenario: Member cannot upload a SHF document
+    Given I am logged in as "emma@happymutts.se"
+    And I am on the "new SHF document" page
+    Then I should see t("errors.not_permitted")

--- a/features/shf-documents/admin-views-shf-document-details.feature
+++ b/features/shf-documents/admin-views-shf-document-details.feature
@@ -1,0 +1,80 @@
+Feature: Admin can edit details about an uploaded SHF Document
+
+  As an admin
+  So that I can verify that the information about an uploaded SHF Document is correct
+  I need to be able to view the details about an uploaded SHF Document
+
+
+  Background:
+
+
+    Given the following users exists
+      | email               | admin |
+      | emma@happymutts.se |       |
+      | bob@snarkybarky.se  |       |
+      | admin@shf.se        | true  |
+
+    And the following companies exist:
+      | name        | company_number | email               |
+      | Happy Mutts | 2120000142     | bowwow@bowsersy.com |
+
+    And the following applications exist:
+      | first_name | user_email          | company_number | state    |
+      | Emma       | emma@happymutts.se | 2120000142     | accepted |
+
+    And I am logged in as "admin@shf.se"
+
+
+  @admin
+  Scenario:  Admin can view all of the details for a SHF document
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | Uploaded document        | some description              |
+    And I choose a shf-document named "diploma.pdf" to upload
+    And I click on t("submit") button
+    And I am on the SHF document page for "Uploaded document"
+    Then I should see "Uploaded document"
+    And I should see "some description"
+    And I should see "diploma.pdf"
+    And I should see t("shf_documents.edit.uploaded_by")
+    And I should see "admin@shf.se"
+    And I should see t("shf_documents.edit.uploaded_on")
+
+
+
+  @visitor
+  Scenario: Visitor cannot view the details for a SHF document
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | Uploaded document        | some description              |
+    And I choose a shf-document named "diploma.pdf" to upload
+    And I click on t("submit") button
+    And I am logged out
+    When I am on the SHF document page for "Uploaded document"
+    Then I should see t("errors.not_permitted")
+
+  @user
+  Scenario: User cannot view the details for a SHF document
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | Uploaded document        | some description              |
+    And I choose a shf-document named "diploma.pdf" to upload
+    And I click on t("submit") button
+    And I am logged in as "bob@snarkybarky.se"
+    When I am on the SHF document page for "Uploaded document"
+    Then I should see t("errors.not_permitted")
+
+  @member
+  Scenario: Member cannot view the details for a SHF document
+    Given I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | Uploaded document        | some description              |
+    And I choose a shf-document named "diploma.pdf" to upload
+    And I click on t("submit") button
+    And I am logged in as "emma@happymutts.se"
+    When I am on the SHF document page for "Uploaded document"
+    Then I should see t("errors.not_permitted")

--- a/features/shf-documents/view-all-shf-documents.feature
+++ b/features/shf-documents/view-all-shf-documents.feature
@@ -1,0 +1,114 @@
+Feature: SHF members (and admins) can views board meeting minutes (SHF documents)
+  As a member
+  So that I keep up with the direction of this member-driven organization
+  I need to see SHF board meeting minutes (Styrelseprotokoll)
+
+  As an admin
+  So that I can track and manage all SHF documents
+  I need to see a list of all SHF documents and be abled to view and delete them.
+
+
+  Background:
+
+    Given the following users exists
+      | email              | admin |
+      | emma@happymutts.se |       |
+      | bob@snarkybarky.se |       |
+      | admin@shf.se       | true  |
+
+    And the following companies exist:
+      | name        | company_number | email               |
+      | Happy Mutts | 2120000142     | bowwow@bowsersy.com |
+
+    And the following applications exist:
+      | first_name | user_email         | company_number | state    |
+      | Emma       | emma@happymutts.se | 2120000142     | accepted |
+
+
+  Scenario: An admin can see the list of SHF documents and click on title link
+    Given I am logged in as "admin@shf.se"
+    And I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | Uploaded diploma        | some description              |
+    And I choose a shf-document named "diploma.pdf" to upload
+    When I click on t("submit") button
+    When I am on the "all SHF documents" page
+    Then I should see "Uploaded diploma"
+    And I should see "some description"
+    And I should see t("shf_documents.index.instructions")
+    And I should see t("shf_documents.index.view_details")
+    And I should see t("delete")
+    And I should see t("shf_documents.new_shf_document")
+    Then I should see link "shf-document-link-1" with target = "_blank"
+    And I click on "Uploaded diploma"
+     # clicking on a document title will show or download the actual document
+
+
+
+  Scenario: A member can see all SHF documents and click on title link
+    Given I am logged in as "admin@shf.se"
+    And I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | Uploaded diploma        | some description              |
+    And I choose a shf-document named "diploma.pdf" to upload
+    When I click on t("submit") button
+    And I am logged out
+    And I am logged in as "emma@happymutts.se"
+    And I am on the "all SHF documents" page
+    Then I should see "Uploaded diploma"
+    And I should see "some description"
+    And I should see t("shf_documents.index.instructions")
+    And I should not see t("shf_documents.index.view_details")
+    And I should not see t("delete")
+    And I should not see t("shf_documents.new_shf_document")
+    Then I should see link "shf-document-link-1" with target = "_blank"
+    And I click on "Uploaded diploma"
+     # clicking on a document title will show or download the actual document
+
+
+  Scenario: Can sort by title
+    Given I am logged in as "admin@shf.se"
+    And I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | 1 Doc                   | 1 description                 |
+    And I choose a shf-document named "diploma.pdf" to upload
+    And I click on t("submit") button
+    And I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | 2 Doc                   | 2 description                 |
+    And I choose a shf-document named "diploma.pdf" to upload
+    And I click on t("submit") button
+    And I am on the "new SHF document" page
+    And I fill in the translated form with data:
+      | shf_documents.new.title | shf_documents.new.description |
+      | 3 Doc                   | 3 description                 |
+    And I choose a shf-document named "diploma.pdf" to upload
+    And I click on t("submit") button
+    And I am logged out
+    And I am logged in as "emma@happymutts.se"
+    And I am on the "all SHF documents" page
+
+    Then I should see "1 Doc"
+    And I should see "2 Doc"
+    And I should see "3 Doc"
+    When I click on t("shf_documents.index.description")
+
+
+  Scenario: Can sort by description
+
+
+  Scenario: A visitor cannot see SHF documents
+    Given I am logged out
+    And I am on the "all SHF documents" page
+    Then I should see t("errors.not_permitted")
+
+
+  Scenario: A user cannot see SHF documents
+    Given I am logged in as "bob@snarkybarky.se "
+    And I am on the "all SHF documents" page
+    Then I should see t("errors.not_permitted")
+

--- a/features/shf-documents/view-all-shf-documents.feature
+++ b/features/shf-documents/view-all-shf-documents.feature
@@ -98,9 +98,6 @@ Feature: SHF members (and admins) can views board meeting minutes (SHF documents
     When I click on t("shf_documents.index.description")
 
 
-  Scenario: Can sort by description
-
-
   Scenario: A visitor cannot see SHF documents
     Given I am logged out
     And I am on the "all SHF documents" page

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -336,3 +336,9 @@ end
 And(/^I should see xpath "([^"]*)"$/) do | xp |
   expect(page).to have_xpath(xp)
 end
+
+
+And(/^I should be on the SHF document page for "([^"]*)"$/)  do | doc_title |
+    shf_doc = ShfDocument.find_by_title(doc_title)
+  expect(current_path_without_locale(current_path)).to eq shf_document_path(shf_doc)
+end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -37,6 +37,10 @@ Given(/^I am on the "([^"]*)" page$/) do |page|
       path = edit_user_registration_path
     when 'all users'
       path = users_path
+    when 'all shf documents'
+      path = shf_documents_path
+    when 'new shf document'
+      path = new_shf_document_path
     else
       path = 'no path set'
   end

--- a/features/step_definitions/shf_documents_steps.rb
+++ b/features/step_definitions/shf_documents_steps.rb
@@ -1,0 +1,20 @@
+When(/^I choose a shf-document named "([^"]*)" to upload$/) do | filename |
+  page.attach_file "shf_document[actual_file]", File.join(Rails.root, 'spec', 'fixtures','uploaded_files', filename)
+end
+
+
+And(/^I should see (\d+) shf-documents listed$/) do |number|
+  expect(page).to have_selector('.shf-document', count: number)
+end
+
+
+Given(/^I am on the edit SHF document page for "([^"]*)"$/) do | doc_title |
+  shf_doc = ShfDocument.find_by_title(doc_title)
+  visit path_with_locale(edit_shf_document_path shf_doc)
+end
+
+
+Given(/^I am on the SHF document page for "([^"]*)"$/) do | doc_title |
+  shf_doc = ShfDocument.find_by_title(doc_title)
+  visit path_with_locale(shf_document_path shf_doc)
+end

--- a/features/step_definitions/shf_documents_steps.rb
+++ b/features/step_definitions/shf_documents_steps.rb
@@ -4,7 +4,7 @@ end
 
 
 And(/^I should see (\d+) shf-documents listed$/) do |number|
-  expect(page).to have_selector('.shf-document', count: number)
+  page.assert_selector('.shf-document', count: number)
 end
 
 

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -24,7 +24,7 @@ Given(/^I am logged in as "([^"]*)"$/) do |email|
   login_as @user, scope: :user
 end
 
-Given(/^I am Logged out$/) do
+Given(/^I am [L|l]ogged out$/) do
   logout
 end
 

--- a/spec/factories/shf_documents.rb
+++ b/spec/factories/shf_documents.rb
@@ -1,0 +1,53 @@
+FactoryGirl.define do
+
+
+  # FIXTURE_DIR = File.join("#{Rails.root}",'spec','fixtures','uploaded_files')
+
+  factory :shf_document, class: ShfDocument do
+    title "SHF Doc Title"
+    description "SHF Doc description"
+    association :uploader, factory: :user, admin: true
+  end
+
+
+  trait :png do
+    actual_file { File.new(File.join(FIXTURE_DIR, 'image.png')) }
+  end
+
+  trait :gif do
+    actual_file { File.new(File.join(FIXTURE_DIR, 'image.gif')) }
+  end
+
+  trait :jpg do
+    actual_file { File.new(File.join(FIXTURE_DIR, 'image.jpg')) }
+  end
+
+  trait :pdf do
+    actual_file { File.new(File.join(FIXTURE_DIR, 'diploma.pdf')) }
+  end
+
+  trait :txt do
+    actual_file { File.new(File.join(FIXTURE_DIR, 'specifications.txt')) }
+  end
+
+  trait :doc do
+    actual_file { File.new(File.join(FIXTURE_DIR, 'microsoft-word.doc')) }
+  end
+
+  trait :docx do
+    actual_file { File.new(File.join(FIXTURE_DIR, 'microsoft-word.docx')) }
+  end
+
+  trait :docm do
+    actual_file { File.new(File.join(FIXTURE_DIR, 'microsoft-word.docm')) }
+  end
+
+  trait :exe do
+    actual_file { File.new(File.join(FIXTURE_DIR, 'tred.exe')) }
+  end
+
+  trait :bin do
+    actual_file { File.new(File.join(FIXTURE_DIR, 'tred.bin')) }
+  end
+
+end

--- a/spec/models/shf_document_spec.rb
+++ b/spec/models/shf_document_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe ShfDocument, type: :model do
+
+  describe 'Factory' do
+    it 'has a valid factory' do
+      expect(create(:shf_document)).to be_valid
+    end
+  end
+
+
+  describe 'DB Table' do
+    it { is_expected.to have_db_column :id }
+    it { is_expected.to have_db_column :title }
+    it { is_expected.to have_db_column :description }
+    it { is_expected.to have_db_column :actual_file_file_name }
+    it { is_expected.to have_db_column :actual_file_content_type }
+    it { is_expected.to have_db_column :actual_file_file_size }
+    it { is_expected.to have_db_column :actual_file_updated_at }
+  end
+
+
+  describe 'Associations' do
+    it { is_expected.to belong_to :uploader }
+  end
+
+
+  describe 'Validations' do
+
+    it { should validate_attachment_content_type(:actual_file)
+                    .allowing('image/jpeg', 'image/gif', 'image/png',
+                              'text/plain',
+                              'text/rtf',
+                              'application/pdf',
+                              'application/msword',
+                              'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                              'application/vnd.ms-word.document.macroEnabled.12')
+                    .rejecting('bin', 'exe') }
+  end
+
+
+  describe "accepted content types" do
+
+    it "png" do
+      expect(build(:uploaded_file, :png)).to be_valid
+    end
+
+    it "gif" do
+      expect(build(:uploaded_file, :gif)).to be_valid
+    end
+
+    it "jpg" do
+      expect(build(:uploaded_file, :jpg)).to be_valid
+    end
+
+    it "pdf" do
+      expect(build(:uploaded_file, :pdf)).to be_valid
+    end
+
+    it "txt" do
+      expect(build(:uploaded_file, :txt)).to be_valid
+    end
+
+    it "Microsoft Word doc" do
+      expect(build(:uploaded_file, :doc)).to be_valid
+    end
+
+    it "Microsoft Word .docx" do
+      expect(build(:uploaded_file, :docx)).to be_valid
+    end
+
+    it "Microsoft Word macro enabled doc (.docm)" do
+      expect(build(:uploaded_file, :docm)).to be_valid
+    end
+
+  end
+
+
+  describe "unacceptable contented types" do
+
+    it "binary" do
+      expect(build(:uploaded_file, :bin)).not_to be_valid
+    end
+
+    it ".exe" do
+      expect(build(:uploaded_file, :exe)).not_to be_valid
+    end
+
+  end
+
+
+end

--- a/spec/policies/shf_document_policy_spec.rb
+++ b/spec/policies/shf_document_policy_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe ShfDocumentPolicy do
     it { is_expected.to permit_action :destroy }
     it { is_expected.to permit_action :new }
     it { is_expected.to permit_action :create }
+    it { is_expected.to permit_action :minutes_and_static_pages }
 
   end
 
@@ -33,6 +34,7 @@ RSpec.describe ShfDocumentPolicy do
     it { is_expected.to forbid_action :destroy }
     it { is_expected.to forbid_action :new }
     it { is_expected.to forbid_action :create }
+    it { is_expected.to permit_action :minutes_and_static_pages }
   end
 
 
@@ -46,6 +48,7 @@ RSpec.describe ShfDocumentPolicy do
     it { is_expected.to forbid_action :destroy }
     it { is_expected.to forbid_action :new }
     it { is_expected.to forbid_action :create }
+    it { is_expected.to forbid_action :minutes_and_static_pages }
   end
 
 
@@ -59,5 +62,6 @@ RSpec.describe ShfDocumentPolicy do
     it { is_expected.to forbid_action :destroy }
     it { is_expected.to forbid_action :new }
     it { is_expected.to forbid_action :create }
+    it { is_expected.to forbid_action :minutes_and_static_pages }
   end
 end

--- a/spec/policies/shf_document_policy_spec.rb
+++ b/spec/policies/shf_document_policy_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe ShfDocumentPolicy do
+
+  let(:user_1) { create(:user, email: 'user@random.com') }
+  let(:member) { create(:member_with_membership_app, email: 'member@random.com', company_number: '5562728336')}
+  let(:admin)  { create(:user, email: 'admin@shf.se', admin: true) }
+  let(:shf_document) { create(:shf_document, uploader: (create(:user, email: 'admin2@shf.se', admin: true )) )}
+
+  subject { described_class }
+
+  describe 'For admin' do
+    subject { described_class.new(admin, shf_document) }
+
+    it { is_expected.to permit_action :index }
+    it { is_expected.to permit_action :show }
+    it { is_expected.to permit_action :edit }
+    it { is_expected.to permit_action :update }
+    it { is_expected.to permit_action :destroy }
+    it { is_expected.to permit_action :new }
+    it { is_expected.to permit_action :create }
+
+  end
+
+
+  describe 'For a member' do
+    subject { described_class.new(member, shf_document) }
+
+    it { is_expected.to permit_action :index }
+    it { is_expected.to forbid_action :show }
+    it { is_expected.to forbid_action :edit }
+    it { is_expected.to forbid_action :update }
+    it { is_expected.to forbid_action :destroy }
+    it { is_expected.to forbid_action :new }
+    it { is_expected.to forbid_action :create }
+  end
+
+
+  describe 'For a user (registered but not a member)' do
+    subject { described_class.new(user_1, shf_document) }
+
+    it { is_expected.to forbid_action :index }
+    it { is_expected.to forbid_action :show }
+    it { is_expected.to forbid_action :edit }
+    it { is_expected.to forbid_action :update }
+    it { is_expected.to forbid_action :destroy }
+    it { is_expected.to forbid_action :new }
+    it { is_expected.to forbid_action :create }
+  end
+
+
+  describe 'For a visitor (not logged in)' do
+    subject { described_class.new(nil, shf_document) }
+
+    it { is_expected.to forbid_action :index }
+    it { is_expected.to forbid_action :show }
+    it { is_expected.to forbid_action :edit }
+    it { is_expected.to forbid_action :update }
+    it { is_expected.to forbid_action :destroy }
+    it { is_expected.to forbid_action :new }
+    it { is_expected.to forbid_action :create }
+  end
+end


### PR DESCRIPTION
PT Stories: 
- Admin can upload meeting PDFs https://www.pivotaltracker.com/story/show/140999487
- Member can see meeting PDFs  https://www.pivotaltracker.com/story/show/140999549

I created a model named "SHF Document" (`ShfDocument`) to represent any document that an Admin uploads that is meant for SHF members.  Initially (for this PR & user stories), it can be used just for SHF Board Meeting Minutes.   But we can later build on this for any category of document. 

**NEEDS Translation check** (as usual)

After #192 is finished, we can apply the same UI changes to the File Upload button.

### Changes proposed in this pull request:
1.  Added "ShfDocument" model, controller, views
2. Revised navigation menu "Member Pages" to include a link to the new SHF Document index page
3. I put the features for this in a sub-directory to start to clean up the `/features` directory a bit.  
4. In the main application layout, I added code so that the `<body>` tag has the _current controller_ and the _current action_ added as CSS classes.  This makes applying styles much easier.  Ex: if the page is shown via the `CompanyController` and its `show` action, then the html will be:
```
  <body class="company show ....." >
```


### Screenshots (Optional):

**List of 'Meeting Minutes' docs for a MEMBER (sv)**

<img width="724" alt="member-index-shf-doc-sv" src="https://cloud.githubusercontent.com/assets/673794/24328180/0d005574-1198-11e7-9269-13475b8201d6.png">

---

**List of 'Meeting Minutes' docs for an ADMIN  (sv)  Note that the admin has links to view (visa), delete (radera), and a Ny (new)... button**

<img width="693" alt="admin-index-shf-doc-sv" src="https://cloud.githubusercontent.com/assets/673794/24328186/0d10afa0-1198-11e7-803e-39619b9c248c.png">

---

**English:**

<img width="699" alt="admin-index-shf-doc-en" src="https://cloud.githubusercontent.com/assets/673794/24328187/0d10dcd2-1198-11e7-8c9a-0a435ced5570.png">

---

**Admin views details for Meeting Minutes document: (sv)**

<img width="715" alt="view-shf-doc-sv" src="https://cloud.githubusercontent.com/assets/673794/24328188/0d16104e-1198-11e7-8e4a-3553f064549a.png">

---

**Admin edits details for Meeting Minutes document: (sv)**

<img width="716" alt="edit-shf-doc-sv" src="https://cloud.githubusercontent.com/assets/673794/24328185/0d04bf7e-1198-11e7-98cf-dfdc6e1f2b38.png">

---

**Menu showing addition to 'Member Pages' section (sv):**

<img width="284" alt="screen shot 2017-03-25 at 8 29 11 pm" src="https://cloud.githubusercontent.com/assets/673794/24328274/dfe59a52-1199-11e7-89c4-68640156c29a.png">


---

**Menu showing addition to 'Member Pages' section (en):**

<img width="286" alt="menu-member-pages-en" src="https://cloud.githubusercontent.com/assets/673794/24328181/0d008634-1198-11e7-96e4-7f6c31c5bc72.png">

---

**New  'Member Pages' main page (used to be the `HighVoltage pages index` page) (sv):**

<img width="621" alt="meeting-minutes-and-static-sv" src="https://cloud.githubusercontent.com/assets/673794/24328183/0d01544c-1198-11e7-9998-0229bab9424b.png">

---

**New  'Member Pages' main page (used to be the `HighVoltage pages index` page) (en):**

<img width="588" alt="meeting-minutes-and-static-en" src="https://cloud.githubusercontent.com/assets/673794/24328184/0d0307ce-1198-11e7-92b8-5c8addf00b8b.png">


Ready for review:
@thesuss @patmbolger 
