### PR TITLE
HOTFIX: hardcode the google maps URL and API key

### DIFF
--- a/app/views/companies/_map_companies.haml
+++ b/app/views/companies/_map_companies.haml
@@ -1,4 +1,4 @@
-= javascript_include_tag "#{Rails.configuration.shf['google_maps_js_api']}?key=#{Rails.configuration.x.google_key}"
+= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=AIzaSyAhSCR7wvLZnInHGJu7XQ5PrPCyt3VDnU0"
 
 #map
 


### PR DESCRIPTION
HOTFIX:  the URL for Google Maps is not being formed correctly.
the API key is not being read from the `.env` file
The URL is `<script src="https://maps.googleapis.com/maps/api/js?key="></script>` (missing the key)

Changes proposed in this pull request:
1.  hardcoded the URL and API key in the 1 place it's used

Ready for review:
@thesuss 
