### PR TITLE
remove map from landing (company#index) page

### DIFF
--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -8,8 +8,8 @@
 
   .entry-content
 
-    .row
-      = render 'map_companies',  markers: location_and_markers_for(@all_companies)
+    -#.row
+    -#  = render 'map_companies',  markers: location_and_markers_for(@all_companies)
 
 
     - unless current_user.try(:admin)


### PR DESCRIPTION
HOTFIX - the markers for companies were not being displayed on the company index page (= the landing page)

remove it until we have it working correctly.

Changes proposed in this pull request:
1.  commented out 2 lines from the view file

Ready for review:
@thesuss 
