### PR TITLE
HOTFIX show the map on company index view page (undo-comments)

### DIFF
--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -8,8 +8,8 @@
 
   .entry-content
 
-    -#.row
-    -#  = render 'map_companies',  markers: location_and_markers_for(@all_companies)
+    .row
+      = render 'map_companies',  markers: location_and_markers_for(@all_companies)
 
 
     - unless current_user.try(:admin)


### PR DESCRIPTION
This 'undoes' the previous hotfix PR #199.  This removes the comments so that the map shows again on the landing page.

Ready for review:
@thesuss 
