### PR TITLE
BUG: Geocode all companies before showing #index

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -13,6 +13,8 @@ class CompaniesController < ApplicationController
                           .complete
                           .includes(:addresses, :business_categories)
 
+    @all_companies.each { | co | geocode_if_needed co  }
+
     @companies = @all_companies.page(params[:page]).per_page(10)
 
 
@@ -87,10 +89,14 @@ class CompaniesController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_company
     @company = Company.includes(:addresses).find(params[:id])
+    geocode_if_needed @company
+  end
 
-    needs_geocoding = @company.addresses.reject(&:geocoded?)
+
+  def geocode_if_needed(company)
+    needs_geocoding = company.addresses.reject(&:geocoded?)
     needs_geocoding.each(&:geocode_best_possible)
-    @company.save!  if needs_geocoding.count > 0
+    company.save!  if needs_geocoding.count > 0
   end
 
 

--- a/features/mapping_and_geocoding/companies_are_geocoded_when_viewing_all.feature
+++ b/features/mapping_and_geocoding/companies_are_geocoded_when_viewing_all.feature
@@ -1,0 +1,43 @@
+Feature: All companies are geocoded before being shown on the view all companies page
+  As a visitor,
+  so all companies are mapped when I look at the list of them,
+  geocode any companies that aren't yet geocoded before everything is displayed.
+
+  Background:
+    Given the following regions exist:
+      | name         |
+      | Stockholm    |
+      | Västerbotten |
+
+    Given the following companies exist:
+      | name                 | company_number | email                  | region       |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.com | Stockholm    |
+      | Bowsers              | 2120000142     | bowwow@bowsersy.com    | Västerbotten |
+
+
+    And the following users exists
+      | email               | admin |
+      | emma@happymutts.com |       |
+      | a@happymutts.com    |       |
+      | admin@shf.se        | true  |
+
+    And the following business categories exist
+      | name         |
+      | Groomer      |
+      | Trainer      |
+
+    And the following applications exist:
+      | first_name | user_email          | company_number | category_name | state    |
+      | Emma       | emma@happymutts.com | 5560360793     | Groomer       | accepted |
+      | Anna       | a@happymutts.com    | 2120000142     | Trainer       | accepted |
+
+
+
+  Scenario: A company that isn't geocoded is geocoded before all are viewed
+    Given all addresses for the company named "No More Snarky Barky" are not geocoded
+    And all addresses for the company named "Bowsers" are not geocoded
+    And I am Logged out
+    When I am on the "landing" page
+    Then all addresses for the company named "No More Snarky Barky" should be geocoded
+    And all addresses for the company named "Bowsers" should be geocoded
+

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -352,3 +352,11 @@ And(/^I should be on the SHF document page for "([^"]*)"$/)  do | doc_title |
     shf_doc = ShfDocument.find_by_title(doc_title)
   expect(current_path_without_locale(current_path)).to eq shf_document_path(shf_doc)
 end
+
+
+Then(/^all addresses for the company named "([^"]*)" should be geocoded$/) do | company_name |
+
+  co = Company.find_by_name(company_name)
+  expect( co.addresses.reject(&:geocoded? ).count).to be 0
+
+end

--- a/features/step_definitions/company_steps.rb
+++ b/features/step_definitions/company_steps.rb
@@ -57,3 +57,17 @@ And(/^the region for company named "([^"]*)" is set to nil$/) do | company_name 
   co.addresses.first.update(region: nil)
   co.save!  # do not do validations in case we're putting this into a bad state on purpose
 end
+
+
+Given(/^all addresses for the company named "([^"]*)" are not geocoded$/) do |company_name|
+  co = Company.find_by_name(company_name)
+
+  # Cannot do this through our Models, because it will be geocoded.
+  # Have to use SQL to set up this situation
+
+  addr_ids = co.addresses.map(&:id)
+
+  query = "UPDATE addresses SET latitude=NULL, longitude=NULL WHERE id in (#{addr_ids.join(', ')})"
+  result = Address.connection.exec_query(query)
+
+end

--- a/features/step_definitions/company_steps.rb
+++ b/features/step_definitions/company_steps.rb
@@ -68,6 +68,6 @@ Given(/^all addresses for the company named "([^"]*)" are not geocoded$/) do |co
   addr_ids = co.addresses.map(&:id)
 
   query = "UPDATE addresses SET latitude=NULL, longitude=NULL WHERE id in (#{addr_ids.join(', ')})"
-  result = Address.connection.exec_query(query)
+  Address.connection.exec_query(query)
 
 end

--- a/lib/tasks/shf.rake
+++ b/lib/tasks/shf.rake
@@ -140,6 +140,75 @@ namespace :shf do
     finish_and_close_log(log, start_time, Time.now, "Kommuns create")
   end
 
+
+  # Geocode all Addresses.
+  #   arguments:
+  #    sleep:     number of seconds to sleep between each geocode request so we
+  #                don't exceed the number of requests per <x> seconds
+  #                for Google (or any other service)
+  #                Note that 1 Address may require multiple geocode requests
+  #                to get a valid locataion if the Address is a 'fake' address.
+  #                See the note below about using :geocode_best_possible
+  #                 default = 0.5 seconds
+  #
+  #    batch_num: number of objects in each batch (also so we don't exceed
+  #               the number of requests per second)
+  #                 default = 40
+  #
+  # We don't use the geocode:all  rake task
+  # because we want to call the :geocode_best_possible method instead of
+  # just using the 'geocoded_by :entire_address' that the geocode:all task
+  # would use.  We do this because the fake data generated might not
+  # create a real address, so the :entire_address might not really give us
+  # the geolocation (latitude, longitude) info.
+  #
+  # This is based on the Geocoder gem geocode:all task.
+  # @see https://github.com/alexreisner/geocoder#bulk-geocoding for more info
+  #
+  # We don't want to exceed the limit of number of geocoding calls per second
+  #  (see the Google maps API limits).  We're using the free, standard plan
+  # as of 2017-03-29, which means 50 requests per second.
+  #
+  # Examples:
+  #  use the defaults:
+  #    rake shf:geolocate_all_addresses
+  #
+  #  set the number of seconds to sleep between geocoding requests to 3 seconds:
+  #    rake shf:geolocate_all_addresses[3]
+  #
+  #  set the number of records to request in each batch to 19, and number of seconds to sleep = 3:
+  #    rake shf:geolocate_all_addresses[3, 19]
+  #
+  # Note that there are NO SPACES after the commas (between the arguments)
+  #
+  desc "geocode all addresses args=[sleep_time=2,batch_num=40] (those without latitude, longitude info) NO SPACES between arguments"
+  task :geocode_all_addresses, [:sleep_time, :batch_num] => :environment do |task_name, args|
+
+    args.with_defaults(sleep_time: 0.5, batch_num: 40)
+
+    Geocoder.configure( timeout: 20)   # geocoding service timeout (secs)
+
+    logfile = 'log/shf-geocode.log'
+    start_time = Time.now
+    log = start_logging(start_time, logfile, "Geocode All Addresses (RAILS_ENV = #{Rails.env} arguments = #{args.each { |arg| arg.inspect} }  )")
+
+    no_location =  Address.not_geocoded
+
+    no_location.find_each(batch_size: args[:batch_num].to_i) do | addr |
+      addr.geocode_best_possible
+      addr.save
+      log_and_show log, Logger::INFO, "  Geocoded Address id: #{addr.id}  now latitude= #{addr.latitude}, longitude= #{addr.longitude}"
+      sleep(args[:sleep_time].to_f)
+    end
+
+    log_and_show log, Logger::INFO, "Information was logged to: #{logfile}"
+    finish_and_close_log(log, start_time, Time.now, "Geocode All Addresses")
+
+  end
+
+
+  # -------------------------------------------------
+
   def import_a_member_app_csv(row, log)
 
     log_and_show log, Logger::INFO, "Importing row: #{row.inspect}"
@@ -271,7 +340,7 @@ namespace :shf do
 
   def finish_and_close_log(log, start_time, end_time, action = "Import")
     duration = (start_time - end_time) / 1.minute
-    log_and_show log, Logger::INFO, "#{action} finished at #{start_time}."
+    log_and_show log, Logger::INFO, "=== #{action} finished at #{start_time}.\n"
     log.close
     log
   end

--- a/lib/tasks/shf.rake
+++ b/lib/tasks/shf.rake
@@ -182,7 +182,7 @@ namespace :shf do
   # Note that there are NO SPACES after the commas (between the arguments)
   #
   desc "geocode all addresses args=[sleep_time=2,batch_num=40] (those without latitude, longitude info) NO SPACES between arguments"
-  task :geocode_all_addresses, [:sleep_time, :batch_num] => :environment do |task_name, args|
+  task :geocode_all_addresses, [:sleep_time, :batch_num] => :environment do |_task_name, args|
 
     args.with_defaults(sleep_time: 0.2, batch_num: 50)
 

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe Address, type: :model do
            WHERE street_address = 'Matarengivägen 24'
         SQL
 
-        result = Address.connection.execute(query)
+        Address.connection.execute(query)
 
         need_geocoding = Address.not_geocoded
         needed_geocoding = need_geocoding.count
@@ -347,7 +347,7 @@ RSpec.describe Address, type: :model do
           UPDATE addresses SET latitude=NULL, longitude=NULL
         SQL
 
-        result =  Address.connection.execute(query)
+        Address.connection.execute(query)
 
         need_geocoding = Address.not_geocoded
         needed_geocoding = need_geocoding.count

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -253,5 +253,115 @@ RSpec.describe Address, type: :model do
 
     end
 
+
+    describe '#self.geocode_all_needed(sleep_between: 0.5, num_per_batch: 50)' do
+
+      let(:a_company) { create(:company, num_addresses: 0) }
+
+      let(:norbotten_region) { create(:region, name: 'Norrbotten') }
+      let(:overtornea_kommun) { create(:kommun, name: 'Övertorneå') }
+
+      # These are real addresses in  Övertorneå Municipality in Norrbotten County:
+
+      let(:valid_address1) { addr1 = create(:address,
+                                    street_address: 'Matarengivägen 24',
+                                    post_code: '957 31',
+                                    city: 'Övertorneå',
+                                    kommun: overtornea_kommun,
+                                    region: norbotten_region,
+                                    addressable: a_company )
+                            addr1.validate
+                            addr1
+       }
+
+      let(:valid_address2) { addr2 = create(:address,
+                                    street_address: 'Skolvägen 12',
+                                    post_code: '957 31',
+                                    city: 'Övertorneå',
+                                    kommun: overtornea_kommun,
+                                    region: norbotten_region,
+                                    addressable: a_company )
+                            addr2.validate
+                            addr2
+       }
+
+      let(:valid_address3) { addr3 = create(:address,
+                                            street_address: 'Matarengivägen 30',
+                                            post_code: '957 31',
+                                            city: 'Övertorneå',
+                                            kommun: overtornea_kommun,
+                                            region: norbotten_region,
+                                            addressable: a_company )
+                              addr3.validate
+                              addr3
+       }
+
+      it 'nothing geocoded if all have latitude and longitude' do
+        valid_address1
+        valid_address2
+        valid_address3
+
+        need_geocoding = Address.not_geocoded
+        needed_geocoding = need_geocoding.count
+
+        Address.geocode_all_needed
+
+        after_run_need_geocoding = Address.not_geocoded.count
+
+        expect(needed_geocoding).to eq 0
+        expect(after_run_need_geocoding).to eq 0
+      end
+
+
+      it 'will geocode 1 that needs it' do
+
+        valid_address1
+        valid_address2
+        valid_address3
+
+        query = <<-SQL
+          UPDATE addresses SET latitude=NULL, longitude=NULL  
+           WHERE street_address = 'Matarengivägen 24'
+        SQL
+
+        result = ActiveRecord::Base.connection.execute(query)
+
+        need_geocoding = Address.not_geocoded
+        needed_geocoding = need_geocoding.count
+
+        Address.geocode_all_needed
+
+        after_run_need_geocoding = Address.not_geocoded.count
+
+        expect(needed_geocoding).to eq 1
+        expect(after_run_need_geocoding).to eq 0
+      end
+
+
+      it 'will geocode 3 that need it' do
+        valid_address1
+        valid_address2
+        valid_address3
+
+        query = <<-SQL
+          UPDATE addresses SET latitude=NULL, longitude=NULL
+        SQL
+
+        result = ActiveRecord::Base.connection.execute(query)
+
+        need_geocoding = Address.not_geocoded
+        needed_geocoding = need_geocoding.count
+
+        Address.geocode_all_needed
+
+        after_run_need_geocoding = Address.not_geocoded.count
+
+        expect(needed_geocoding).to eq 3
+        expect(after_run_need_geocoding).to eq 0
+      end
+
+
+    end
+
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe Address, type: :model do
            WHERE street_address = 'Matarengivägen 24'
         SQL
 
-        result = ActiveRecord::Base.connection.execute(query)
+        result = Address.connection.execute(query)
 
         need_geocoding = Address.not_geocoded
         needed_geocoding = need_geocoding.count
@@ -347,7 +347,7 @@ RSpec.describe Address, type: :model do
           UPDATE addresses SET latitude=NULL, longitude=NULL
         SQL
 
-        result = ActiveRecord::Base.connection.execute(query)
+        result =  Address.connection.execute(query)
 
         need_geocoding = Address.not_geocoded
         needed_geocoding = need_geocoding.count


### PR DESCRIPTION
PT Story: **can't map list of companies if they're not geolocated**
https://www.pivotaltracker.com/story/show/142716667

Company and address data already existed in the production database but they had not yet been geocoded (= no latitude and longitude).  An individual company was geocoded when it was shown (via CompaniesController `.set_company`), but when the list of companies was shown (e.g. `.index`), the companies were not checked to see if they needed to be geocoded.

This meant that bad data was sent the javascript used to render the Google map with 'plupps' (marker pins) for the companies, and instead of showing the map, a big, ugly 'Something went wrong' message was shown.

Susanna figured it out, and she and I manually viewed each company individually so they'd be geocoded. Now that all companies in the production db are geocoded, this shouldn't be a problem again.  But this code will _ensure_ it will never happen again, and this code _should have been in place beforehand._

### Changes proposed in this pull request:
1.  added an Address class method that will geocode all addresses not yet geocoded `.geocode_all_needed`
2. a rake method to geocode all addresses that need it (calls the Address class method)
3. CompaniesController `index` will now call `geocode_if_needed` for each company in the list of all companies, so every company will be geocoded before they are all displayed on the #index view ( = the Google map!)
4. spec for the Address class method
5. feature (and new steps needed): "All companies are geocoded before being shown on the view all companies page"

Ready for review:
@patmbolger @thesuss 
