### PR TITLE
[TEST] Pulling in google maps in layout #142984999

### DIFF
--- a/app/views/companies/_map_companies.haml
+++ b/app/views/companies/_map_companies.haml
@@ -1,4 +1,3 @@
-= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=AIzaSyAhSCR7wvLZnInHGJu7XQ5PrPCyt3VDnU0"
 
 #map
 
@@ -16,4 +15,3 @@
       initCenteredMap(mapCenter, markers, null);
 
     });
-

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,6 +16,7 @@
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.2/js/select2.full.min.js'
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/i18n/sv.js'
     = javascript_include_tag Ckeditor.cdn_url
+    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=AIzaSyAhSCR7wvLZnInHGJu7XQ5PrPCyt3VDnU0"
 
     - if Rails.env.test?
       -#


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/142984999


Changes proposed in this pull request:
1. Moved javascript include from specific page view to application layout.

The page load function is triggering our custom javascript, but evidently before the google maps JS is downloaded.  Moving the latter to the layout should cause the maps JS to load once and be cached and available when needed.  (perhaps the page-specific downloading was causing the map JS to _not_ be cached?).

Ready for review:
@weedySeaDragon 