### PR TITLE
HOTFIX: hardcoding Google API key for Map; API key was not being read 

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,7 +16,7 @@
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.2/js/select2.full.min.js'
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/i18n/sv.js'
     = javascript_include_tag Ckeditor.cdn_url
-    = javascript_include_tag "#{Rails.configuration.x.shf['google_maps_js_api']}?key=#{Rails.configuration.x.google_key}"
+    = javascript_include_tag "#{Rails.configuration.x.shf['google_maps_js_api']}?key=AIzaSyAhSCR7wvLZnInHGJu7XQ5PrPCyt3VDnU0"
 
 
     - if Rails.env.test?


### PR DESCRIPTION
Once again, the Google API key is not showing up.  the interpolation was returning nothing, so the maps were not being displayed.  <sigh>

Hardcoding the API key.
