### PR TITLE
dotenv gem always loaded; get the Google API key from .env file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 ruby '2.3.1'
-gem 'dotenv-rails', groups: [:development, :test]
+gem 'dotenv-rails'
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.0'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,7 +16,7 @@
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.2/js/select2.full.min.js'
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/i18n/sv.js'
     = javascript_include_tag Ckeditor.cdn_url
-    = javascript_include_tag "#{Rails.configuration.x.shf['google_maps_js_api']}?key=AIzaSyAhSCR7wvLZnInHGJu7XQ5PrPCyt3VDnU0"
+    = javascript_include_tag "https://maps.googleapis.com/maps/api/j?key=#{Rails.configuration.x.google_key}"
 
 
     - if Rails.env.test?


### PR DESCRIPTION
closing this.  #215 supercedes it.