### PR TITLE
Undo PR 217 (increase Geocoder timeout, use ENV for google api key)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 ruby '2.3.1'
-gem 'dotenv-rails'
+gem 'dotenv-rails', groups: [:development, :test]
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.0'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,7 +16,7 @@
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.2/js/select2.full.min.js'
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/i18n/sv.js'
     = javascript_include_tag Ckeditor.cdn_url
-    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{Geocoder.config[:api_key]}"
+    = javascript_include_tag "#{Rails.configuration.x.shf['google_maps_js_api']}?key=AIzaSyAhSCR7wvLZnInHGJu7XQ5PrPCyt3VDnU0"
 
 
     - if Rails.env.test?

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,6 +1,6 @@
 Geocoder.configure(
     # Geocoding options
-     timeout: 9,                  # geocoding service timeout (secs)
+    # timeout: 3,                 # geocoding service timeout (secs)
     # lookup: :google,            # name of geocoding service (symbol)
 
     language: :sv,              # ISO-639 language code
@@ -20,11 +20,8 @@ Geocoder.configure(
     # supports SocketError and Timeout::Error
     # always_raise: [],
 
-
     # Calculation options
     units: :km,                 # :km for kilometers or :mi for miles
 
     # distances: :linear          # :spherical or :linear
 )
-
-Geocoder.configure(always_raise: :all) unless Rails.env.production?

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -98,10 +98,6 @@ RSpec.describe Address, type: :model do
       "#{expected_msg}; addr: #{addr.entire_address}, lat: #{addr.latitude}, long: #{addr.longitude}"
     end
 
-    it 'Geocoder is configured to raise all errors in test environment' do
-      expect(Geocoder.config[:always_raise]).to eq(:all)
-    end
-
     it 'geocode from address' do
       addr = Address.new(street_address: expected_streetaddress,
                          city: expected_city,


### PR DESCRIPTION
This **undoes** (reverts) #217.  The PR was done to see if errors appeared on Heroku (none do!).
This reverts #217 so that a *real* PR can be submitted and reviewed.
