### PR TITLE
Fix bug where ckeditor cannot load assets in production #143384491

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,13 @@ gem 'i18n-js', '>= 3.0.0.rc11'
 gem 'will_paginate'
 gem 'will_paginate-bootstrap'
 
-gem 'ckeditor'
+# Loading `ckeditor` directly from github due to problem in production
+# environment where assets cannot be found.
+# See: https://github.com/galetahub/ckeditor/issues/719
+# According to above link, this issue has been fixed but not yet released
+# (writing this on April 14, 2017).
+# Once release, remove reference to github for loading.
+gem 'ckeditor', github: 'galetahub/ckeditor'
 
 gem 'aasm', '~> 4.11.1'  # state machine ()acts as state machine)
 
@@ -81,4 +87,8 @@ end
 
 group :test do
   gem 'poltergeist'
+end
+
+group :production do
+  gem 'rails_12factor'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: git://github.com/galetahub/ckeditor.git
+  revision: 11d3a5b905646c6fd397f7710f95fb9eb29f0865
+  specs:
+    ckeditor (4.2.2)
+      cocaine
+      orm_adapter (~> 0.5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -92,9 +100,6 @@ GEM
     chronic (0.10.2)
     city-state (0.0.13)
       rubyzip (~> 1.1)
-    ckeditor (4.2.2)
-      cocaine
-      orm_adapter (~> 0.5.0)
     climate_control (0.1.0)
     cliver (0.3.2)
     cocaine (0.5.8)
@@ -263,6 +268,11 @@ GEM
       nokogiri (~> 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (5.0.1)
       actionpack (= 5.0.1)
       activesupport (= 5.0.1)
@@ -390,7 +400,7 @@ DEPENDENCIES
   capistrano-rbenv (~> 2.0)
   capistrano-ssh-doctor (~> 1.0)
   city-state
-  ckeditor
+  ckeditor!
   coveralls
   cucumber-rails
   cucumber-timecop
@@ -420,6 +430,7 @@ DEPENDENCIES
   pundit-matchers
   railroady
   rails (~> 5.0.0, >= 5.0.0.1)
+  rails_12factor
   rake
   ransack
   routing-filter
@@ -442,4 +453,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.3
+   1.14.6

--- a/app/assets/javascripts/ckeditor/basepath.js.erb
+++ b/app/assets/javascripts/ckeditor/basepath.js.erb
@@ -1,9 +1,0 @@
-<%
-  base_path = ''
-  if ENV['PROJECT'] =~ /editor/i
-    base_path << "/#{Rails.root.basename.to_s}/"
-  end
-  base_path << Rails.application.config.assets.prefix
-  base_path << '/javascripts/ckeditor/'
-%>
-var CKEDITOR_BASEPATH = '<%= base_path %>';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,5 @@
 @import "pagination";
 @import "companies";
 @import "maps";
-// @import "../javascripts/ckeditor/contents";
 @import "shf-documents";
 @import "membership-applications";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,6 @@
 @import "pagination";
 @import "companies";
 @import "maps";
-@import "../javascripts/ckeditor/contents";
+// @import "../javascripts/ckeditor/contents";
 @import "shf-documents";
 @import "membership-applications";

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -16,5 +16,6 @@ Rails.application.config.assets.precompile += %w( users.scss )
 Rails.application.config.assets.precompile += %w{ maps.scss }
 Rails.application.config.assets.precompile += %w{ companies.scss }
 Rails.application.config.assets.precompile += %w( ckeditor/config.js )
+Rails.application.config.assets.precompile += %w( ckeditor/contents.css )
 Rails.application.config.assets.precompile += %w{ shf-documents.scss }
 Rails.application.config.assets.precompile += %w( membership-applications.scss )


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/143384491

I tried many approaches to this until I found this recent posting that talks a about a bug in the latest _released_ version of the ckeditor gem: https://github.com/galetahub/ckeditor/issues/719

Based upon that, I changed the Gemfile reference to pull in the latest code directly from GitHub and the problem went away.  When the fix is released we can change this back to accessing the gem from rubygems as normal.


Changes proposed in this pull request:
1. Changed reference to gem as described above.
2. Removed `assets/javascripts/ckeditor/basepath.js.erb` as that is not needed for CDN deployment
3. Added the ckeditor file `contents.css` to the asset pipeline (`config/initializers/assets.rb`)
4. Added gem `rails_12factor` to Gemfile (prod env) as suggested by Heroku (https://devcenter.heroku.com/articles/getting-started-with-rails4#write-your-app)


Ready for review:
@weedySeaDragon 