### PR TITLE
Improve error handling when creating admin account in "production" env (Heroku staging)

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -223,8 +223,8 @@ if Rails.env.production?
     User.create!(email: email, password: pwd, admin: true)
   rescue => e
     puts e.inspect
-    raise SeedAdminENVError, SEED_ERROR_MSG
-    return false
+    # raise SeedAdminENVError, SEED_ERROR_MSG
+    # return false
   end
 else
   email = 'admin@sverigeshundforetagare.se'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -220,7 +220,7 @@ if Rails.env.production?
     email = env_invalid_blank('SHF_ADMIN_EMAIL')
     pwd = env_invalid_blank('SHF_ADMIN_PWD')
 
-    User.create(email: email, password: pwd, admin: true)
+    User.create!(email: email, password: pwd, admin: true)
   rescue
     raise SeedAdminENVError, SEED_ERROR_MSG
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -224,6 +224,7 @@ if Rails.env.production?
   rescue => e
     puts e.inspect
     raise SeedAdminENVError, SEED_ERROR_MSG
+    return false
   end
 else
   email = 'admin@sverigeshundforetagare.se'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -223,6 +223,7 @@ if Rails.env.production?
     User.create!(email: email, password: pwd, admin: true)
   rescue
     raise SeedAdminENVError, SEED_ERROR_MSG
+    raise
   end
 else
   email = 'admin@sverigeshundforetagare.se'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -224,7 +224,7 @@ if Rails.env.production?
   rescue => e
     puts e.inspect
     # raise SeedAdminENVError, SEED_ERROR_MSG
-    # return false
+    return
   end
 else
   email = 'admin@sverigeshundforetagare.se'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -221,9 +221,9 @@ if Rails.env.production?
     pwd = env_invalid_blank('SHF_ADMIN_PWD')
 
     User.create!(email: email, password: pwd, admin: true)
-  rescue
+  rescue => e
+    puts e.inspect
     raise SeedAdminENVError, SEED_ERROR_MSG
-    raise
   end
 else
   email = 'admin@sverigeshundforetagare.se'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -223,8 +223,7 @@ if Rails.env.production?
     User.create!(email: email, password: pwd, admin: true)
   rescue => e
     puts e.inspect
-    # raise SeedAdminENVError, SEED_ERROR_MSG
-    return
+    abort SEED_ERROR_MSG
   end
 else
   email = 'admin@sverigeshundforetagare.se'


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/143759579

We have a clause in seeds.rb that allows us to create an admin account in Heroku (even though Heroku env is set to "production".  This was failing if the admin user record failed validation(s).

Changes proposed in this pull request:
1.  Use `create!` in order to raise an exception on model validation failure
2. In rescue clause, print the error message (via `inspect`) and abort the program with seed-failed message.

(our project staging in Heroic - `shf-project` - does not seem to be a problem as the admin credentials (email, password) do not cause model validate errors .... this is more for our personal Heroku environments used to test before producing a PR, for instance)

Screenshots (Optional):
---
<img width="800" alt="screen shot 2017-04-26 at 6 38 16 am" src="https://cloud.githubusercontent.com/assets/9968213/25431424/83d3bb86-2a4e-11e7-9f75-51b01bc06b9a.png">

Ready for review:
@weedySeaDragon 