### PR TITLE
Add Bullet gem #144555485

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ group :development do
   gem 'capistrano-ssh-doctor', '~> 1.0'
   gem 'capistrano-env-config'
   gem 'railroady'
+  gem 'bullet'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,9 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     builder (3.2.3)
+    bullet (5.5.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.10.0)
     byebug (9.0.6)
     capistrano (3.6.1)
       airbrussh (>= 1.0.0)
@@ -365,6 +368,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
+    uniform_notifier (1.10.0)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.4.0)
@@ -393,6 +397,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap-sass (~> 3.3.6)
+  bullet
   capistrano (~> 3.6.0)
   capistrano-bundler (~> 1.1.2)
   capistrano-env-config

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,7 @@ class UsersController < ApplicationController
 
   def index
     @users = User.all.order(last_sign_in_at: :asc)
+      .includes(:membership_applications)
   end
 
 

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -1,0 +1,17 @@
+if defined? Bullet
+  Bullet.enable = true
+  Bullet.alert = true
+  Bullet.bullet_logger = true
+
+  Bullet.add_whitelist type: :unused_eager_loading,
+                 class_name: 'Company',
+                association: :membership_applications
+
+  Bullet.add_whitelist type: :unused_eager_loading,
+                 class_name: 'MembershipApplication',
+                association: :business_categories
+
+  Bullet.add_whitelist type: :unused_eager_loading,
+                 class_name: 'MembershipApplication',
+                association: :membershipapplications_business_categories
+end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/144555485

Bullet gem alerts us to badly-formed queries (especially "N+1" queries, which are very inefficient).

Changes proposed in this pull request:
1. Add bullet gem to `development`
2. Add an `includes` statement to users_controller `index` method
3. Add whitelisted items to bullet initializer in order to prevent bullet complaining about fetching business categories via a `through` association with member applications.

Screenshots (Optional):


Ready for review:
@weedySeaDragon @thesuss 