### PR TITLE
Turn Turbolinks off #144778233

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,11 +13,10 @@
 //= require jquery
 //= require jquery_ujs
 //= require bootstrap-sprockets
-//= require turbolinks
 //= require i18n/translations
 //= require_tree .
 
-document.addEventListener('turbolinks:load', function() {
+$(function() {
     'use strict';
 
     $.each($('.search_field'), function (index, ele) {
@@ -121,7 +120,6 @@ document.addEventListener('turbolinks:load', function() {
             jQuery('#site-navigation.fixed-nav ~ .search-toggle-container').removeClass('nav-shadow-sub');
         }
     });
-
 });
 //Set timeout for flashes
 setTimeout("$('.flashes').fadeOut('slow');", 5000);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,8 +15,13 @@
 @import "bootstrap";
 @import "font-awesome-sprockets";
 @import "font-awesome";
-@import "pagination";
 @import "companies";
+@import "custom-membership-application-state";
+@import "custom";
 @import "maps";
-@import "shf-documents";
 @import "membership-applications";
+@import "pagination";
+@import "shf-documents";
+@import "shf-documents";
+@import "style";
+@import "users";

--- a/app/views/companies/_map_companies.haml
+++ b/app/views/companies/_map_companies.haml
@@ -3,7 +3,7 @@
 
 :javascript
 
-  document.addEventListener('turbolinks:load', function() {
+  $(function() {
 
       var markers = #{markers.to_json}
       mapCenter = {lat: 59.3293235, lng: 18.0685808}; // default center: Stockholm: [59.32932349999999, 18.0685808]

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,14 +5,12 @@
     %meta{ content: 'text/html; charset=UTF-8', 'http-equiv' => 'Content-Type' }/
     %title Medlemmar i Sveriges Hundföretagare
     = csrf_meta_tags
+    
     = stylesheet_link_tag 'https://cdnjs.cloudflare.com/ajax/libs/' + |
                           'select2/4.0.2/css/select2.min.css'         |
-    = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = stylesheet_link_tag 'style.css', media: 'all'
-    = stylesheet_link_tag 'custom.css', media: 'all'
-    = stylesheet_link_tag 'custom-membership-application-state', media: 'all'
-    = stylesheet_link_tag 'users', media: 'all'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag 'application', media: 'all'
+
+    = javascript_include_tag 'application'
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.2/js/select2.full.min.js'
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/i18n/sv.js'
     = javascript_include_tag Ckeditor.cdn_url


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/144778233

Changes proposed in this pull request:
1. Remove turbo links from JS manifest file (so turbo links is not loaded)
2. Converted callbacks from triggering on `turbolinks:load` event to page loaded event.
3. Added files to CSS manifest (application.scss) file
4. Removed references to above file in `application.html.haml`

Screenshots (Optional):


Ready for review:
@weedySeaDragon 