### PR TITLE
Company #index view: use .sort or .sort_by instead of .order  (.order causes a db query)

### DIFF
--- a/app/helpers/companies_helper.rb
+++ b/app/helpers/companies_helper.rb
@@ -7,7 +7,7 @@ module CompaniesHelper
 
   def list_categories company, separator=' '
     if company.business_categories.any?
-      company.business_categories.order(:name).map(&:name).join(separator)
+      company.business_categories.map(&:name).sort.join(separator)
     end
   end
 

--- a/app/views/companies/_companies_list.html.haml
+++ b/app/views/companies/_companies_list.html.haml
@@ -26,7 +26,7 @@
         %tr.company
           %td{ style: 'white-space: nowrap;' }
             - first = true
-            - company.business_categories.order(:name).distinct.each do |bc|
+            - company.business_categories.sort_by(&:name).uniq.each do | bc |
               - if first
                 - first = false
                 = bc.name


### PR DESCRIPTION
When displaying on the Companies #index page, 
additional db queries were happening when the business categories were being read for each company. (Was happening both when collecting information for the Google map, and for the list of companies.)

Should have been using `.sort` or `.sort_by` to use the business_categories already loaded into memory for each company, instead of using `.order` which forces a db query.

PT Story: https://www.pivotaltracker.com/story/show/144968843

This speeds up things a wee bit and makes looking at the logs a little more tolerable.

Changes proposed in this pull request:
1.  changed to `sort` in 2 places were `order` was used


Ready for review:
@patmbolger @thesuss 
