### PR TITLE
Admin can select or enter the reason they are waiting for an applicant

### DIFF
--- a/app/assets/stylesheets/custom-membership-application-state.scss
+++ b/app/assets/stylesheets/custom-membership-application-state.scss
@@ -25,6 +25,7 @@ html input:disabled {
   input {
     @extend .btn;
     margin-left: 1em;
+    margin-bottom: 1rem;
     text-transform: none;
   }
 

--- a/app/assets/stylesheets/membership-applications.scss
+++ b/app/assets/stylesheets/membership-applications.scss
@@ -129,7 +129,7 @@ $files-table-background: #ffffff;
 
   #application-status {
 
-    border: 1pt solid gray;
+    border: 1pt solid rgb(142, 173, 206);
     margin-left: 1rem;
     padding-left: 1rem;
 

--- a/app/assets/stylesheets/membership-applications.scss
+++ b/app/assets/stylesheets/membership-applications.scss
@@ -148,6 +148,12 @@ $files-table-background: #ffffff;
       margin-bottom: 1rem;
     }
 
+    #admin-change-status-buttons #other_text_field  input {
+      text-align: left;
+    }
+
+
+
   }
 
 

--- a/app/assets/stylesheets/membership-applications.scss
+++ b/app/assets/stylesheets/membership-applications.scss
@@ -126,6 +126,32 @@ $files-table-background: #ffffff;
 
   }
 
+
+  #application-status {
+
+    border: 1pt solid gray;
+    margin-left: 1rem;
+    padding-left: 1rem;
+
+    .button_to {
+      margin-bottom: 0.5rem;
+    }
+
+    .waiting_reason_title {
+      font-weight: bold;
+      text-align: right;
+    }
+
+
+    .row {
+      margin-top: 1rem;
+      margin-bottom: 1rem;
+    }
+
+  }
+
+
+
   .btn-file {
 
     border: 0;
@@ -163,4 +189,8 @@ $files-table-background: #ffffff;
   #uploaded-files h4.files-uploaded-list-title {
     font-weight: bold;
   }
+}
+
+.action-buttons {
+  margin-top: 2rem;
 }

--- a/app/helpers/membership_applications_helper.rb
+++ b/app/helpers/membership_applications_helper.rb
@@ -8,4 +8,14 @@ module MembershipApplicationsHelper
     @membership_application ? "#{@membership_application.first_name} #{@membership_application.last_name}" : '..'
 
   end
+
+
+  # For now, we are assuming this list won't change a whole lot or be large.
+  #  So we'll just get the few itmes from the locale file. If this assumption
+  #  proves to be wrong, the data for the list can be moved to the db (and then get the actual translations
+  # either from the locale files or store the translations in the db somehow.)
+  def reasons_for_waiting
+      t('membership_applications.need_info.reason').invert.to_a
+  end
+  
 end

--- a/app/policies/membership_application_policy.rb
+++ b/app/policies/membership_application_policy.rb
@@ -97,7 +97,7 @@ class MembershipApplicationPolicy < ApplicationPolicy
 
 
   def all_attributes
-    owner_attributes + [:membership_number]
+    owner_attributes + [:membership_number, :reason_waiting, :reason_waiting_custom_text]
   end
 
 

--- a/app/views/membership_applications/_application_status_form.html.haml
+++ b/app/views/membership_applications/_application_status_form.html.haml
@@ -1,18 +1,80 @@
-#admin-change-status-buttons
-  %p.header
-    = "#{t('membership_applications.show.change_status')}:"
+#application-status
+
+  #admin-change-status-buttons
+    .row
+      %h3.header
+        = "#{t('membership_applications.show.change_status')}:"
+
+    .row
+      = button_to t('membership_applications.start_review_btn'), start_review_membership_application_path(@membership_application), {class: 'btn start-review', disabled: !(@membership_application.may_start_review?)}
+
+      = button_to t('membership_applications.accept_btn'), accept_membership_application_path(@membership_application), {class: 'btn accept', disabled: !(@membership_application.may_accept?)}
+
+      = button_to t('membership_applications.reject_btn'), reject_membership_application_path(@membership_application), {class: 'btn reject', disabled: !(@membership_application.may_reject?)}
+
+      = button_to t('membership_applications.ask_applicant_for_info_btn'), need_info_membership_application_path(@membership_application), {class: 'btn need-info', disabled: !(@membership_application.may_ask_applicant_for_info?)}
+
+      - if @membership_application.waiting_for_applicant?
+
+        = form_for @membership_application, html: {multipart: true}, url: membership_application_path do |f|
+
+          .row
+            .col-sm-2.col-med-2.col-lg-2
+              .waiting_reason_title= t('membership_applications.need_info.reason_title')
+
+            .reason_waiting_information
+              .col-sm-4
+                = f.select( :reason_waiting, reasons_for_waiting )
 
 
-  = button_to t('membership_applications.start_review_btn'), start_review_membership_application_path(@membership_application), {class: 'btn start-review', disabled: !(@membership_application.may_start_review?)}
+              .col-sm-6
+                %div#other_text_field
+                  = f.label( :reason_waiting_custom_text, t('membership_applications.need_info.other_reason_label') )
+                  = f.text_field :reason_waiting_custom_text
 
-  = button_to t('membership_applications.accept_btn'), accept_membership_application_path(@membership_application), {class: 'btn accept', disabled: !(@membership_application.may_accept?)}
+          .row
+            .col-sm-offset-2.col-md-offset-2.col-lg-offset-2
+              = f.submit t('membership_applications.need_info.submit_button_label')
 
-  = button_to t('membership_applications.reject_btn'), reject_membership_application_path(@membership_application), {class: 'btn reject', disabled: !(@membership_application.may_reject?)}
 
-  = button_to t('membership_applications.ask_applicant_for_info_btn'), need_info_membership_application_path(@membership_application), {class: 'btn need-info', disabled: !(@membership_application.may_ask_applicant_for_info?)}
+    .row
+      = button_to t('membership_applications.cancel_waiting_for_applicant_btn'), cancel_need_info_membership_application_path(@membership_application), {class: 'btn cancel-need-info', disabled: !(@membership_application.may_cancel_waiting_for_applicant?)}
 
-  = button_to t('membership_applications.cancel_waiting_for_applicant_btn'), cancel_need_info_membership_application_path(@membership_application), {class: 'btn cancel-need-info', disabled: !(@membership_application.may_cancel_waiting_for_applicant?)}
 
-%br
-  - if !@membership_application.paid?
-    %p= t('membership_applications.show.waiting_for_payment')
+  %br
+    - if !@membership_application.paid?
+      %p= t('membership_applications.show.waiting_for_payment')
+
+
+:javascript
+
+  // hide or show the info based on the current values
+  let hideOrShow = function() {
+
+    let showEm;
+    let selected_reason = $('#membership_application_reason_waiting').find('option:selected').val();
+
+    showEm = 'custom_reason' == selected_reason;
+
+    if (!showEm) {
+        // clear out any custom reason if the selected reason is not the custom reason
+        document.getElementById("membership_application_reason_waiting_custom_text").value = "";
+    }
+
+    $('#other_text_field').toggle(showEm);
+  };
+
+
+  let set_up_depends = (function() {
+
+    $('#other_text_field').hide(); // start with this hidden.
+
+    $('#membership_application_reason_waiting').change(hideOrShow);
+
+    hideOrShow();
+  });
+
+
+  $(document).ready(set_up_depends);
+
+

--- a/app/views/membership_applications/_membership_application_fields.html.haml
+++ b/app/views/membership_applications/_membership_application_fields.html.haml
@@ -13,7 +13,7 @@
 
     = f.label :company_number, t('membership_applications.show.company_number'), class: 'required'
     = f.number_field :company_number, class: 'wpcf7-form-control'
-    %p.field-instruction= t('companies.org_nr_no_hyphens')
+    %p.field-instruction= t('membership_applications.show.org_nr_no_hyphens')
 
 
     = f.label :contact_email, t('membership_applications.show.contact_email'), class: 'required'

--- a/app/views/membership_applications/show.html.haml
+++ b/app/views/membership_applications/show.html.haml
@@ -38,5 +38,6 @@
 
 
     - if current_user && current_user.admin?
-      = link_to "#{t('membership_applications.edit_membership_application')}", edit_membership_application_path(@membership_application), class:'btn btn-warning'
-      = link_to "#{t('.delete')}", @membership_application, method: :delete, class:'btn btn-danger', data: { confirm: "#{t('.confirm_are_you_sure')}" }
+      .action-buttons
+        = link_to "#{t('membership_applications.edit_membership_application')}", edit_membership_application_path(@membership_application), class:'btn btn-warning'
+        = link_to "#{t('.delete')}", @membership_application, method: :delete, class:'btn btn-danger', data: { confirm: "#{t('.confirm_are_you_sure')}" }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -205,6 +205,7 @@ en:
       last_name: *last_name
       phone_number: Phone number
       company_number: *company_number
+      org_nr_no_hyphens: &orgnr_no_hyphen "Numbers only (no hyphens)"
       contact_email: *contact_email
 
       can_be_same_email: Can be the same that you logged in with, but need not be.
@@ -228,6 +229,7 @@ en:
       title: Edit Membership Application
       is_ready_for_review: Is Ready for Review
       submit_button_label: *save
+      org_nr_no_hyphens: &orgnr_no_hyphen
 
     update:
       success: The application was updated.
@@ -240,6 +242,7 @@ en:
       last_name: *last_name
       phone_number: Phone number
       company_number: *company_number
+      org_nr_no_hyphens: &orgnr_no_hyphen
       contact_email: *contact_email
       app_status: Application status
       change_status: Change the status
@@ -298,6 +301,13 @@ en:
       error: There was an error when trying to reject the application.
 
     need_info:
+      reason_title: Reason
+      reason:
+        need_documentation: Need documentation
+        waiting_for_payment: "Waiting for payment"
+        custom_reason: "Other (type in the reason)"
+
+
       success: 'The application has been marked as needing info. (Send email to the applicant.)'
       error: "There was an error when trying to set the application to 'needing information.'"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,7 +230,7 @@ en:
       title: Edit Membership Application
       is_ready_for_review: Is Ready for Review
       submit_button_label: *save
-      org_nr_no_hyphens: &orgnr_no_hyphen
+      org_nr_no_hyphens: *orgnr_no_hyphen
 
     update:
       success: The application was updated.
@@ -243,10 +243,10 @@ en:
       last_name: *last_name
       phone_number: Phone number
       company_number: *company_number
-      org_nr_no_hyphens: &orgnr_no_hyphen
+      org_nr_no_hyphens: *orgnr_no_hyphen
       contact_email: *contact_email
       app_status: Application status
-      change_status: Change the status
+      change_status: Change the application status
       membership_number: Membership number
       with_categories: Categories
       delete: *delete
@@ -307,6 +307,9 @@ en:
         need_documentation: Need documentation
         waiting_for_payment: "Waiting for payment"
         custom_reason: "Other (type in the reason)"
+
+      other_reason_label: "other reason:"
+      submit_button_label: "Save the reason"
 
 
       success: 'The application has been marked as needing info. (Send email to the applicant.)'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -232,7 +232,7 @@ sv:
       title: Redigera ansökan om medlemskap
       is_ready_for_review: Redo för granskning
       submit_button_label: *save
-      org_nr_no_hyphens: &orgnr_no_hyphen
+      org_nr_no_hyphens: *orgnr_no_hyphen
 
     update:
       success: Ansökan har uppdaterats.
@@ -245,10 +245,10 @@ sv:
       last_name: *last_name
       phone_number: *phone_number
       company_number: *company_number
-      org_nr_no_hyphens: &orgnr_no_hyphen
+      org_nr_no_hyphens: *orgnr_no_hyphen
       contact_email: *contact_email
       app_status: Ansökans status
-      change_status: Ändra status
+      change_status: Ändra status för medlemskapsansökan
       membership_number: *membership_number
       with_categories: Ansöker som
       delete: *delete
@@ -308,6 +308,9 @@ sv:
         need_documentation: "Behöver du dokumentation"
         waiting_for_payment: "Väntar på betalning"
         custom_reason: "Annat (skriv in orsaken)"
+
+      other_reason_label: "Annan orsak"
+      submit_button_label: "Spara orsaken"
 
       success: 'Ansökan har markerats som: "Behöver kompletteras". (Skicka e-post till den sökande.)'
       error: 'Det uppstod ett fel när systemet försökte sätta status: "Behöver kompletteras".'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -207,6 +207,7 @@ sv:
       last_name: *last_name
       phone_number: &phone_number Telefonnummer
       company_number: *company_number
+      org_nr_no_hyphens: &orgnr_no_hyphen "Endast siffror (ej bindestreck)"
       contact_email: *contact_email
 
       can_be_same_email: Kan vara samma som du loggar in med, men behöver inte vara det.
@@ -230,6 +231,7 @@ sv:
       title: Redigera ansökan om medlemskap
       is_ready_for_review: Redo för granskning
       submit_button_label: *save
+      org_nr_no_hyphens: &orgnr_no_hyphen
 
     update:
       success: Ansökan har uppdaterats.
@@ -242,6 +244,7 @@ sv:
       last_name: *last_name
       phone_number: *phone_number
       company_number: *company_number
+      org_nr_no_hyphens: &orgnr_no_hyphen
       contact_email: *contact_email
       app_status: Ansökans status
       change_status: Ändra status
@@ -299,6 +302,12 @@ sv:
       error: Det uppstod ett fel vid avslag av medlemskap.
 
     need_info:
+      reason_title: Anledning
+      reason:
+        need_documentation: "Behöver du dokumentation"
+        waiting_for_payment: "Väntar på betalning"
+        custom_reason: "Annat (skriv in orsaken)"
+
       success: 'Ansökan har markerats som: "Behöver kompletteras". (Skicka e-post till den sökande.)'
       error: 'Det uppstod ett fel när systemet försökte sätta status: "Behöver kompletteras".'
 

--- a/db/migrate/20170511002334_add_reason_waiting_to_membership_application.rb
+++ b/db/migrate/20170511002334_add_reason_waiting_to_membership_application.rb
@@ -1,0 +1,7 @@
+class AddReasonWaitingToMembershipApplication < ActiveRecord::Migration[5.0]
+
+  def change
+    add_column :membership_applications, :reason_waiting, :string
+  end
+
+end

--- a/db/migrate/20170512201756_add_reason_waiting_custom_text_to_membership_application.rb
+++ b/db/migrate/20170512201756_add_reason_waiting_custom_text_to_membership_application.rb
@@ -1,0 +1,7 @@
+class AddReasonWaitingCustomTextToMembershipApplication < ActiveRecord::Migration[5.0]
+
+  def change
+    add_column :membership_applications, :reason_waiting_custom_text, :string
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170507103334) do
+ActiveRecord::Schema.define(version: 20170512201756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,15 +90,17 @@ ActiveRecord::Schema.define(version: 20170507103334) do
   create_table "membership_applications", force: :cascade do |t|
     t.string   "company_number"
     t.string   "phone_number"
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
     t.integer  "user_id"
     t.string   "first_name"
     t.string   "last_name"
     t.string   "contact_email"
     t.integer  "company_id"
     t.string   "membership_number"
-    t.string   "state",             default: "new"
+    t.string   "state",                      default: "new"
+    t.string   "reason_waiting"
+    t.string   "reason_waiting_custom_text"
     t.index ["company_id"], name: "index_membership_applications_on_company_id", using: :btree
     t.index ["user_id"], name: "index_membership_applications_on_user_id", using: :btree
   end

--- a/features/membership-application-status/admin-enters-reason-waiting-for-info.feature
+++ b/features/membership-application-status/admin-enters-reason-waiting-for-info.feature
@@ -11,14 +11,10 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     Given the following users exists
       | email                 | admin |
       | emma@happymutts.se    |       |
-      | hans@happymutts.se    |       |
-      | anna@nosnarkybarky.se |       |
       | admin@shf.com         | true  |
 
     Given the following business categories exist
       | name         | description                     |
-      | dog grooming | grooming dogs from head to tail |
-      | dog crooning | crooning to dogs                |
       | rehab        | physcial rehabitation           |
 
     Given the following regions exist:
@@ -33,19 +29,35 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     And the following applications exist:
       | first_name | user_email            | company_number | category_name | state   |
       | Emma       | emma@happymutts.se    | 5562252998     | rehab         | waiting_for_applicant |
-      | Hans       | hans@happymutts.se    | 5562252998     | dog grooming  | waiting_for_applicant |
-      | Anna       | anna@nosnarkybarky.se | 5560360793     | rehab         | waiting_for_applicant |
 
     And I am logged in as "admin@shf.com"
 
 
   Scenario: Admin selects 'need more documentation' as the reason SHF is waiting_for_applicant
     Given I am on "Emma" application page
-    When I set t("<string>") to t("<string>")
+    When I set "reason_list" to t("membership_applications.need_info.reason.need_documentation")
     And I click on t("membership_applications.edit.submit_button_label")
     Then I should see t("membership_applications.update.success")
-    And I should see t("membership_applications.accepted")
+    And I should see t("membership_applications.need_documentation")
 
+
+
+  Scenario: Admin selects 'waiting for payment' as the reason SHF is waiting_for_applicant
+    Given I am on "Emma" application page
+    When I set "reason_list" to t("membership_applications.need_info.reason.waiting_for_payment")
+    And I click on t("membership_applications.edit.submit_button_label")
+    Then I should see t("membership_applications.update.success")
+    And I should see t("membership_applications.waiting_for_payment")
+
+
+  Scenario: Admin selects 'other' and enters text as the reason SHF is waiting_for_applicant
+    Given I am on "Emma" application page
+    When I set "reason_list" to t("membership_applications.need_info.reason.other")
+    And I fill in "custom_reason" with "This is my reason"
+    And I click on t("membership_applications.edit.submit_button_label")
+    Then I should see t("membership_applications.update.success")
+    And I should see t("membership_applications.need_info.reason.other")
+    And I should see "This is my reason"
 
 
   Scenario: things go wrong

--- a/features/membership-application-status/admin-enters-reason-waiting-for-info.feature
+++ b/features/membership-application-status/admin-enters-reason-waiting-for-info.feature
@@ -9,17 +9,17 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
 
   Background:
     Given the following users exists
-      | email                 | admin |
-      | emma@happymutts.se    |       |
-      | admin@shf.com         | true  |
+      | email                                  | admin |
+      | anna_waiting_for_info@nosnarkybarky.se |       |
+      | admin@shf.com                          | true  |
 
     Given the following business categories exist
-      | name         | description                     |
-      | rehab        | physcial rehabitation           |
+      | name  | description           |
+      | rehab | physcial rehabitation |
 
     Given the following regions exist:
-      | name         |
-      | Stockholm    |
+      | name      |
+      | Stockholm |
 
     Given the following companies exist:
       | name                 | company_number | email                 | region    |
@@ -27,37 +27,70 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
 
 
     And the following applications exist:
-      | first_name | user_email            | company_number | category_name | state   |
-      | Emma       | emma@happymutts.se    | 5562252998     | rehab         | waiting_for_applicant |
+      | first_name  | user_email                             | company_number | category_name | state                 |
+      | AnnaWaiting | anna_waiting_for_info@nosnarkybarky.se | 5560360793     | rehab         | waiting_for_applicant |
+
 
     And I am logged in as "admin@shf.com"
 
 
+  @javascript
   Scenario: Admin selects 'need more documentation' as the reason SHF is waiting_for_applicant
-    Given I am on "Emma" application page
-    When I set "reason_list" to t("membership_applications.need_info.reason.need_documentation")
-    And I click on t("membership_applications.edit.submit_button_label")
+    Given I am on "AnnaWaiting" application page
+    When I set "membership_application_reason_waiting" to t("membership_applications.need_info.reason.need_documentation")
+    And I click on t("membership_applications.need_info.submit_button_label")
     Then I should see t("membership_applications.update.success")
-    And I should see t("membership_applications.need_documentation")
+    And "membership_application_reason_waiting" should have t("membership_applications.need_info.reason.need_documentation") selected
+    And item "membership_application_reason_waiting_custom_text" should not be visible
 
 
-
+  @javascript
   Scenario: Admin selects 'waiting for payment' as the reason SHF is waiting_for_applicant
-    Given I am on "Emma" application page
-    When I set "reason_list" to t("membership_applications.need_info.reason.waiting_for_payment")
-    And I click on t("membership_applications.edit.submit_button_label")
+    Given I am on "AnnaWaiting" application page
+    When I set "membership_application_reason_waiting" to t("membership_applications.need_info.reason.waiting_for_payment")
+    And I click on t("membership_applications.need_info.submit_button_label")
     Then I should see t("membership_applications.update.success")
-    And I should see t("membership_applications.waiting_for_payment")
+    And "membership_application_reason_waiting" should have t("membership_applications.need_info.reason.waiting_for_payment") selected
+    And item "membership_application_reason_waiting_custom_text" should not be visible
 
 
+  @javascript
   Scenario: Admin selects 'other' and enters text as the reason SHF is waiting_for_applicant
-    Given I am on "Emma" application page
-    When I set "reason_list" to t("membership_applications.need_info.reason.other")
-    And I fill in "custom_reason" with "This is my reason"
-    And I click on t("membership_applications.edit.submit_button_label")
+    Given I am on "AnnaWaiting" application page
+    When I set "membership_application_reason_waiting" to t("membership_applications.need_info.reason.custom_reason")
+    And I fill in "membership_application_reason_waiting_custom_text" with "This is my reason"
+    And I click on t("membership_applications.need_info.submit_button_label")
     Then I should see t("membership_applications.update.success")
-    And I should see t("membership_applications.need_info.reason.other")
-    And I should see "This is my reason"
+    And item "membership_application_reason_waiting_custom_text" should be visible
+    And the "membership_application_reason_waiting_custom_text" field should be set to "This is my reason"
+    And "membership_application_reason_waiting" should have t("membership_applications.need_info.reason.custom_reason") selected
 
 
-  Scenario: things go wrong
+  @javascript
+  Scenario: Admin selects 'other' and fills in custom text but then changes reason to something else
+    Given I am on "AnnaWaiting" application page
+    When I set "membership_application_reason_waiting" to t("membership_applications.need_info.reason.custom_reason")
+    And I fill in "membership_application_reason_waiting_custom_text" with "This is my reason"
+    And I set "membership_application_reason_waiting" to t("membership_applications.need_info.reason.waiting_for_payment")
+    And I click on t("membership_applications.need_info.submit_button_label")
+    Then I should see t("membership_applications.update.success")
+    And "membership_application_reason_waiting" should have t("membership_applications.need_info.reason.waiting_for_payment") selected
+    And item "membership_application_reason_waiting_custom_text" should not be visible
+
+
+  @javascript
+  Scenario: When selected reason is not 'custom other,' the custom text is saved as blank (empty string)
+    Given I am on "AnnaWaiting" application page
+    When I set "membership_application_reason_waiting" to t("membership_applications.need_info.reason.custom_reason")
+    And I fill in "membership_application_reason_waiting_custom_text" with "This is my reason"
+    And I set "membership_application_reason_waiting" to t("membership_applications.need_info.reason.waiting_for_payment")
+    # change back so the custom reason field shows. it should be blank
+    And I set "membership_application_reason_waiting" to t("membership_applications.need_info.reason.custom_reason")
+    Then I should not see "This is my reason"
+
+  @javascript
+  Scenario: owner cannot see the fields for changing the reason
+    Given I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
+    And I am on the application page for "AnnaWaiting"
+    Then I should not see t("membership_applications.need_info.reason_title")
+    And I should not see t("membership_applications.need_info.submit_button_label")

--- a/features/membership-application-status/admin-enters-reason-waiting-for-info.feature
+++ b/features/membership-application-status/admin-enters-reason-waiting-for-info.feature
@@ -1,0 +1,51 @@
+Feature: Admin sets or enters the reason they are waiting for info from a user
+  As an admin
+  so that SHF can talk with the user specifically about why they are waiting and know how long they might need to wait,
+  I need to set the reason why SHF is waiting
+  and if the reason is not available from a list,
+  I need to be able to type in text that describes the situation
+
+  PT: https://www.pivotaltracker.com/story/show/143810729
+
+  Background:
+    Given the following users exists
+      | email                 | admin |
+      | emma@happymutts.se    |       |
+      | hans@happymutts.se    |       |
+      | anna@nosnarkybarky.se |       |
+      | admin@shf.com         | true  |
+
+    Given the following business categories exist
+      | name         | description                     |
+      | dog grooming | grooming dogs from head to tail |
+      | dog crooning | crooning to dogs                |
+      | rehab        | physcial rehabitation           |
+
+    Given the following regions exist:
+      | name         |
+      | Stockholm    |
+
+    Given the following companies exist:
+      | name                 | company_number | email                 | region    |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.se | Stockholm |
+
+
+    And the following applications exist:
+      | first_name | user_email            | company_number | category_name | state   |
+      | Emma       | emma@happymutts.se    | 5562252998     | rehab         | waiting_for_applicant |
+      | Hans       | hans@happymutts.se    | 5562252998     | dog grooming  | waiting_for_applicant |
+      | Anna       | anna@nosnarkybarky.se | 5560360793     | rehab         | waiting_for_applicant |
+
+    And I am logged in as "admin@shf.com"
+
+
+  Scenario: Admin selects 'need more documentation' as the reason SHF is waiting_for_applicant
+    Given I am on "Emma" application page
+    When I set t("<string>") to t("<string>")
+    And I click on t("membership_applications.edit.submit_button_label")
+    Then I should see t("membership_applications.update.success")
+    And I should see t("membership_applications.accepted")
+
+
+
+  Scenario: things go wrong

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -247,6 +247,14 @@ And(/^I should see (\d+) t\("([^"]*)"\)$/) do |n, content |
   expect(page).not_to have_text("#{i18n_content(content)}", count: n+1)
 end
 
+Then(/^t\("([^"]*)"\) should( not)? be visible$/) do |string, not_see|
+  unless not_see
+    expect(has_text?(:visible, "#{i18n_content(string)}")).to be true
+  else
+    expect(has_text?(:visible, "#{i18n_content(string)}")).to be false
+  end
+end
+
 
 # Have to be sure to wait for any javascript to execute since it may hide or show an item
 Then(/^item "([^"]*)" should( not)? be visible$/) do | item, negate|

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -112,3 +112,9 @@ end
 Then(/^I wait(?: for)? (\d+) second(?:s)?$/) do |seconds|
   sleep seconds.to_i.seconds
 end
+
+
+When(/^(?:I|they) select t\("([^"]*)"\) in select list "([^"]*)"$/) do |item, lst|
+  selected = i18n_content("#{item}")
+  find(:select, lst).find(:option, selected).select_option
+end

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -55,8 +55,10 @@ Feature: As an Admin
   Scenario: Admin requests more info from user (from under_review to 'waiting for applicant')
     Given I am on "EmmaUnderReview" application page
     Then I should see "rehab"
+    And I should not see t("membership_applications.need_info.reason_title")
     When I click on t("membership_applications.ask_applicant_for_info_btn")
     Then I should see t("membership_applications.need_info.success")
+    And I should see t("membership_applications.need_info.reason_title")
     And I should see status line with status t("membership_applications.waiting_for_applicant")
     And I should not see t("membership_applications.update.enter_member_number")
     And I should see "rehab"
@@ -183,8 +185,10 @@ Feature: As an Admin
   Scenario: Admin changed from 'waiting for applicant' to 'under review'
     Given I am on "AnnaWaiting" application page
     And I should see "rehab"
+    And I should see t("membership_applications.need_info.reason_title")
     When I click on t("membership_applications.cancel_waiting_for_applicant_btn")
     Then I should see t("membership_applications.cancel_need_info.success")
+    And I should not see t("membership_applications.need_info.reason_title")
     And I should see status line with status t("membership_applications.under_review")
     And I should not see t("membership_applications.waiting_for_applicant")
     And I should not see t("membership_applications.update.enter_member_number")
@@ -217,6 +221,7 @@ Feature: As an Admin
     And I fill in t("membership_applications.show.last_name") with "AdminUpdated"
     And I click on t("membership_applications.edit.submit_button_label")
     Then I should see t("membership_applications.update.success")
+    And I should see t("membership_applications.need_info.reason_title")
     And I should see status line with status t("membership_applications.waiting_for_applicant")
     And I should not see status line with status t("membership_applications.under_review")
 


### PR DESCRIPTION
PT Story:  https://www.pivotaltracker.com/story/show/143810729

_Closing this PR and will replace it with 1 or more other PRs._

This generated excellent discussion about what information SHF admins need.  Discussions led to the discovery that `waiting_for_payment` is important enough and causes actions specific and different enough that it needs to be it's own state.  (See PT  )
Discussions also led to the design decision that the reasons need to be stored in their own db table; they are their own (simple) model.
Will create a new PR (or 2) so that we can cleanly implement and review what has developed and been decided.



### Changes proposed in this pull request:
1. UX:  When the admin changes the application status to 'needs more info' then a drop-down (select) list appears. If the admin chooses "other" then a text field appears where they can type in their 'custom' reason. 
  - I'm not totally happy with how the UI works.  Right now, simply selecting an application status button will immediately POST and save the status change.  (Each button is really it's own form.)  But when a reason must be selected (and/or text entered), we must have some sort of "Save" button.  
   I'll be interested in user (and reviewer!) feedback. 

2. Added 2 attributes to `MembershipApplication` to store the info: 1 for the choice from the list of reasons, 1 to store the 'custom reason' if the admin chose "other"
3. I added a border around the section for changing the membership application status.  When the additional  elements appear (for choosing a reason), this area becomes more visually complex. We need a way to clearly set them off.  I put a border around it because that's the easiest thing to do, but I'm totally open to other ways.


### List of reasons (choices) _now_ comes from the db

The special entry  for  the other/custom_reason: ("Annat (skriv in orsaken)" / "Other (enter the reason)") comes from the locale file.
  - This is effectively a _constant_ that we are checking to see if the user is going to enter a custom reason.  Is the locale file the best source for the constant?   (Specifically, the `sv.yml` locale file)

---

## Screenshots:


<img width="702" alt="sv-before-info-status" src="https://cloud.githubusercontent.com/assets/673794/26038444/4b0ef126-38bd-11e7-8e1c-c9d3969e5ecc.png">

<img width="693" alt="en-before-info-status" src="https://cloud.githubusercontent.com/assets/673794/26038445/4b0f6ef8-38bd-11e7-9535-5fa87e97a4a4.png">

---

### Admin clicks on 'Behöver kompletteras / Ask Applicant for Info' and the new fields appear:

<img width="699" alt="sv-need-info-reason-list" src="https://cloud.githubusercontent.com/assets/673794/26038443/4b055d8c-38bd-11e7-93de-42c00e320220.png">


<img width="622" alt="en-need-info-reason-list" src="https://cloud.githubusercontent.com/assets/673794/26038438/4aff91fe-38bd-11e7-908b-0d98cc5274db.png">

---


<img width="646" alt="sv-custom-reason-blank" src="https://cloud.githubusercontent.com/assets/673794/26038440/4b008186-38bd-11e7-8a96-16188ecdb3b5.png">
---

<img width="771" alt="sv-enter-custom-reason" src="https://cloud.githubusercontent.com/assets/673794/26038442/4b015dea-38bd-11e7-80ba-061c80a834c1.png">

<img width="617" alt="en-entered-custom-reason" src="https://cloud.githubusercontent.com/assets/673794/26038439/4affe0e6-38bd-11e7-9a03-57ebc59b0256.png">



## Ready for review:
@thesuss @patmbolger 
