### PR TITLE
Show current status only#144954863

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -3,7 +3,7 @@ class AdminController < ApplicationController
 
 
   def index
-    @membership_applications = MembershipApplication.all
+    @membership_applications = MembershipApplication.current
   end
 
 

--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -17,6 +17,7 @@ class MembershipApplicationsController < ApplicationController
 
     @membership_applications = @search_params
                                    .result
+                                   .current
                                    .includes(:business_categories)
                                    .page(params[:page]).per_page(10)
 

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -36,6 +36,7 @@ class MembershipApplication < ApplicationRecord
   accepts_nested_attributes_for :uploaded_files, allow_destroy: true
 
   scope :open, -> { where.not(state: [:accepted, :rejected]) }
+  scope :current, -> { where(['id IN (?)', select('MAX(id) as id').group(:company_number).map { |application| application.id }]) }
 
   include AASM
 

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -36,7 +36,7 @@ class MembershipApplication < ApplicationRecord
   accepts_nested_attributes_for :uploaded_files, allow_destroy: true
 
   scope :open, -> { where.not(state: [:accepted, :rejected]) }
-  scope :current, -> { where(['id IN (?)', select('MAX(id) as id').group(:company_number).map { |application| application.id }]) }
+  scope :current, -> { where('id IN (?)', unscoped.select('MAX(id) as id').group(:company_number).map { |application| application.id }) }
 
   include AASM
 

--- a/features/delete-company.feature
+++ b/features/delete-company.feature
@@ -136,7 +136,7 @@ Feature: As an admin
     When I am on the "business categories" page
     Then I should see "8" business categories
     When I am on the "landing" page
-    Then I should see "11" applications
+    Then I should see "5" applications
     When I am on the "all companies" page
     Then I should see "8" companies
     When I click the t("delete") action for the row with "Kats"
@@ -147,7 +147,7 @@ Feature: As an admin
     When I am on the "business categories" page
     Then I should see "8" business categories
     When I am on the "landing" page
-    Then I should see "11" applications
+    Then I should see "5" applications
 
   @poltergeist
   Scenario: Admin cannot delete a company with 2 (accepted) membership applications
@@ -155,7 +155,7 @@ Feature: As an admin
     When I am on the "business categories" page
     Then I should see "8" business categories
     When I am on the "landing" page
-    Then I should see "11" applications
+    Then I should see "5" applications
     When I am on the "all companies" page
     Then I should see "8" companies
     When I am on the page for company number "2120000142"
@@ -170,7 +170,7 @@ Feature: As an admin
     When I am on the "business categories" page
     Then I should see "8" business categories
     When I am on the "landing" page
-    Then I should see "11" applications
+    Then I should see "5" applications
 
 
   @poltergeist
@@ -183,7 +183,7 @@ Feature: As an admin
     When I am on the "business categories" page
     Then I should see "8" business categories
     When I am on the "landing" page
-    Then I should see "11" applications
+    Then I should see "5" applications
     When I am on the "all companies" page
     Then I should see "8" companies
     When I click the t("delete") action for the row with "Kitties"
@@ -194,7 +194,7 @@ Feature: As an admin
     When I am on the "business categories" page
     Then I should see "8" business categories
     When I am on the "landing" page
-    Then I should see "9" applications
+    Then I should see "4" applications
 
 
   @poltergeist
@@ -203,7 +203,7 @@ Feature: As an admin
     When I am on the "business categories" page
     Then I should see "8" business categories
     When I am on the "landing" page
-    Then I should see "11" applications
+    Then I should see "5" applications
     When I am on the "all companies" page
     Then I should see "8" companies
     When I click the t("delete") action for the row with "No More Snarky Barky"
@@ -214,7 +214,7 @@ Feature: As an admin
     When I am on the "business categories" page
     Then I should see "8" business categories
     When I am on the "landing" page
-    Then I should see "9" applications
+    Then I should see "4" applications
 
 
   @poltergeist @focus
@@ -223,7 +223,7 @@ Feature: As an admin
     When I am on the "business categories" page
     Then I should see "8" business categories
     When I am on the "landing" page
-    Then I should see "11" applications
+    Then I should see "5" applications
     When I am on the "all companies" page
     Then I should see "8" companies
     When I click the t("delete") action for the row with "WOOF"
@@ -234,4 +234,4 @@ Feature: As an admin
     When I am on the "business categories" page
     Then I should see "8" business categories
     When I am on the "landing" page
-    Then I should see "10" applications
+    Then I should see "4" applications

--- a/features/show_membership_application.feature
+++ b/features/show_membership_application.feature
@@ -1,7 +1,8 @@
 Feature: As an Admin
   So that we can accept or reject new Memberships,
   I need to review a Membership Application that has been submitted
-  PT: https://www.pivotaltracker.com/story/show/133950343
+  PT: https://www.pivotaltracker.com/story/show/133950343 (original)
+  PT: https://www.pivotaltracker.com/story/show/144954863 (refined)
 
   Secondary feature:
   As an admin
@@ -38,29 +39,30 @@ Feature: As an Admin
 
     And the following applications exist:
       | first_name         | user_email                          | company_number | state                 | category_name |
-      | Emma               | emma@random.com                     | 5562252998     | waiting_for_applicant | Psychologist  |
+      | EmmaWaiting        | emma@random.com                     | 5562252998     | waiting_for_applicant | Psychologist  |
       | Hans               | hans@random.com                     | 5560360793     | waiting_for_applicant | Psychologist  |
       | Anna               | anna_needs_info@random.com          | 2120000142     | waiting_for_applicant | Psychologist  |
       | LarsRejected       | lars_rejected@snarkybark.se         | 0000000000     | rejected              | dog crooning  |
       | NilsApproved       | nils_member@bowwowwow.se            | 0000000000     | accepted              | Groomer       |
       | EmmaUnderReview    | emma_under_review@happymutts.se     | 5562252998     | under_review          | rehab         |
-      | HansReadyForReview | hans_ready_for_review@happymutts.se | 5562252998     | ready_for_review      | dog grooming  |
+      | Emma               | hans_ready_for_review@happymutts.se | 5562252998     | ready_for_review      | dog grooming  |
+      | Anna               | anna_needs_info@random.com          | 2120000142     | rejected              | Psychologist  |
 
 
   @admin
   Scenario: Listing incoming Applications open for Admin
     Given I am logged in as "admin@shf.com"
     And I am on the list applications page
-    Then I should see "7" applications
-    And I should see 1 t("membership_applications.under_review")
+    Then I should see "4" applications
+    And I should see 1 t("membership_applications.ready_for_review")
     And I should see 1 t("membership_applications.accepted")
-    And I should see 3 t("membership_applications.waiting_for_applicant")
+    And I should see 1 t("membership_applications.waiting_for_applicant")
     And I should see 1 t("membership_applications.rejected")
     And I click on "Lastname, Emma"
     Then I should be on the application page for "Emma"
     And I should see "Emma Lastname"
     And I should see "5562252998"
-    And I should see status line with status t("membership_applications.waiting_for_applicant")
+    And I should see status line with status t("membership_applications.ready_for_review")
 
 
   @admin
@@ -73,7 +75,7 @@ Feature: As an Admin
   #  And I am Logged out
     Given I am logged in as "admin@shf.com"
     And I am on the list applications page
-    Then I should see "7" applications
+    Then I should see "4" applications
     And I click on "Lastname, Hans"
     Then I should be on the application page for "Hans"
     And I should see "Hans Lastname"
@@ -85,7 +87,7 @@ Feature: As an Admin
 
   @admin
   Scenario: Admin can see an application with multiple business categories given
-    Given I am logged in as "emma@random.com"
+    Given I am logged in as "hans_ready_for_review@happymutts.se"
     And I am on the "landing" page
     And I click on t("menus.nav.members.my_application")
     And I select "Trainer" Category
@@ -94,7 +96,7 @@ Feature: As an Admin
     And I am Logged out
     And I am logged in as "admin@shf.com"
     And I am on the list applications page
-    Then I should see "7" applications
+    Then I should see "4" applications
     And I click on "Lastname, Emma"
     Then I should be on the application page for "Emma"
     And I should see "Emma Lastname"
@@ -141,15 +143,16 @@ Feature: As an Admin
   @admin
   Scenario: Admin sees business categories for user that is ready_for_review
     Given I am logged in as "admin@shf.se"
-    When I am on the application page for "HansReadyForReview"
+    When I am on the application page for "Emma"
     Then I should see "dog grooming"
+    And I should see "rehab"
+    And I should see "Psychologist"
 
   @admin
   Scenario: Admin sees business categories for user that is waiting_for_applicant
     Given I am logged in as "admin@shf.se"
-    When I am on the application page for "Emma"
+    When I am on the application page for "Hans"
     Then I should see "Psychologist"
-
 
   @admin
   Scenario: Admin sees business categories for user that is accepted

--- a/features/show_status_of_application.feature
+++ b/features/show_status_of_application.feature
@@ -16,7 +16,7 @@ Feature: As an Admin
       | company_number | user_email                    | state                 |
       | 5562252998     | under_review@mail.se          | under_review          |
       | 2120000142     | accepted@mail.se              | accepted              |
-      | 0000000000     | rejected@mail.se              | rejected              |
+      | 5560360793     | rejected@mail.se              | rejected              |
       | 0000000000     | waiting_for_applicant@mail.se | waiting_for_applicant |
 
     And I am logged in as "admin@sgf.com"

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -30,10 +30,10 @@ Feature: As an Admin
     And the following applications exist:
       | first_name      | user_email                             | company_number | category_name | state                 |
       | EmmaUnderReview | emma_under_review@happymutts.se        | 5562252998     | rehab         | under_review          |
-      | HansUnderReview | hans_under_review@happymutts.se        | 5562252998     | dog grooming  | under_review          |
+      | HansUnderReview | hans_under_review@happymutts.se        | 2120000142     | dog grooming  | under_review          |
       | AnnaWaiting     | anna_waiting_for_info@nosnarkybarky.se | 5560360793     | rehab         | waiting_for_applicant |
       | LarsRejected    | lars_rejected@snarkybark.se            | 0000000000     | rehab         | rejected              |
-      | NilsAccepted    | nils_member@bowwowwow.se               | 0000000000     | dog crooning  | accepted              |
+      | NilsAccepted    | nils_member@bowwowwow.se               | 2120000142     | dog crooning  | accepted              |
 
     And I am logged in as "admin@shf.se"
     And time is frozen at 2016-12-16
@@ -62,7 +62,7 @@ Feature: As an Admin
     And I should see "rehab"
     When I am on the "landing" page
     Then I should see 2 t("membership_applications.waiting_for_applicant")
-    And I should see 1 t("membership_applications.under_review")
+    And I should see 0 t("membership_applications.under_review")
     And I should see 1 t("membership_applications.accepted")
     And I should see 1 t("membership_applications.rejected")
     And I am Logged out
@@ -80,7 +80,7 @@ Feature: As an Admin
     And I should see "rehab"
     When I am on the "landing" page
     Then I should see 1 t("membership_applications.waiting_for_applicant")
-    And I should see 1 t("membership_applications.under_review")
+    And I should see 0 t("membership_applications.under_review")
     And I should see 2 t("membership_applications.accepted")
     And I should see 1 t("membership_applications.rejected")
 
@@ -95,7 +95,7 @@ Feature: As an Admin
     And I should see "rehab"
     When I am on the "landing" page
     Then I should see 1 t("membership_applications.waiting_for_applicant")
-    And I should see 1 t("membership_applications.under_review")
+    And I should see 0 t("membership_applications.under_review")
     And I should see 2 t("membership_applications.rejected")
     And I should see 1 t("membership_applications.accepted")
 
@@ -115,7 +115,7 @@ Feature: As an Admin
     And I should see "rehab"
     When I am on the "landing" page
     Then I should see 2 t("membership_applications.rejected")
-    And I should see 1 t("membership_applications.under_review")
+    And I should see 0 t("membership_applications.under_review")
     And I should see 1 t("membership_applications.waiting_for_applicant")
     And I should see 1 t("membership_applications.accepted")
 
@@ -176,7 +176,7 @@ Feature: As an Admin
     And I am on the "landing" page
     And I should see 1 t("membership_applications.ready_for_review")
     And I should see 1 t("membership_applications.accepted")
-    And I should see 2 t("membership_applications.under_review")
+    And I should see 1 t("membership_applications.under_review")
     And I should see 1 t("membership_applications.rejected")
 
   @admin
@@ -190,7 +190,7 @@ Feature: As an Admin
     And I should not see t("membership_applications.update.enter_member_number")
     And I should see "rehab"
     When I am on the "landing" page
-    And I should see 3 t("membership_applications.under_review")
+    And I should see 2 t("membership_applications.under_review")
     And I should not see t("membership_applications.waiting_for_applicant")
     And I should see 1 t("membership_applications.accepted")
     And I should see 1 t("membership_applications.rejected")
@@ -231,7 +231,7 @@ Feature: As an Admin
     And I should see status line with status t("membership_applications.rejected")
     And I should see "dog crooning"
     When I am on the "landing" page
-    And I should see 2 t("membership_applications.under_review")
+    And I should see 1 t("membership_applications.under_review")
     And I should see 1 t("membership_applications.waiting_for_applicant")
     And I should see 0 t("membership_applications.accepted")
     And I should see 2 t("membership_applications.rejected")
@@ -276,7 +276,7 @@ Feature: As an Admin
     And I should see status line with status t("membership_applications.rejected")
     And I should see "rehab"
     When I am on the "landing" page
-    And I should see 2 t("membership_applications.under_review")
+    And I should see 1 t("membership_applications.under_review")
     And I should see 1 t("membership_applications.waiting_for_applicant")
     And I should see 1 t("membership_applications.accepted")
     And I should see 1 t("membership_applications.rejected")
@@ -296,7 +296,7 @@ Feature: As an Admin
     And I should see "rehab"
     When I am on the "landing" page
     Then I should see 1 t("membership_applications.waiting_for_applicant")
-    And I should see 2 t("membership_applications.under_review")
+    And I should see 1 t("membership_applications.under_review")
     And I should see 2 t("membership_applications.accepted")
     And I should see 0 t("membership_applications.rejected")
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/144954863

### Changes proposed in this pull request:

The admin just needs to be able to click on a user to edit/manage the application status.  There's no real need to see _every past state_ for a user's application.

Show just 1 entry (record/item) in the list for each user, and have it be the current (= most recent) status for their application.

### Discussion point

There seems to be  a deeper issue here. I think "MembershipApplication" should HAVE a state, not BE a state. The way it is set up now can give rise to inconsistent data. That is especially apparent in the cucumber tests. I have tweaked the relevant tests (and sometimes background data) to account for the fact that only the current membership application is shown, but for some tests the background data should probably be changed to be valid / easier to understand.

Ready for review:
@thesuss @weedySeaDragon @patmbolger 