### PR TITLE
Page title disclaimer #145646809

### DIFF
--- a/app/controllers/shf_documents_controller.rb
+++ b/app/controllers/shf_documents_controller.rb
@@ -81,6 +81,9 @@ class ShfDocumentsController < ApplicationController
       file.write(contents)
     end
 
+    member_page = MemberPage.find_by filename: page
+    member_page.update_attribute(:title, params[:title])
+
     redirect_to contents_show_path(page),
                 notice: t('.success', document_title: page.capitalize)
 

--- a/app/controllers/shf_documents_controller.rb
+++ b/app/controllers/shf_documents_controller.rb
@@ -85,7 +85,7 @@ class ShfDocumentsController < ApplicationController
     member_page.update_attribute(:title, params[:title])
 
     redirect_to contents_show_path(page),
-                notice: t('.success', document_title: page.capitalize)
+                notice: t('.success', document_title: member_page.title)
 
   rescue => e
     helpers.flash_message(:alert,

--- a/app/controllers/shf_documents_controller.rb
+++ b/app/controllers/shf_documents_controller.rb
@@ -107,6 +107,7 @@ class ShfDocumentsController < ApplicationController
   def page_and_page_contents
     @page, file_path = page_and_file_path
     @contents = File.new(file_path).read
+    @title = MemberPage.title(@page)
   rescue => e
     helpers.flash_message(:alert,
                           t('shf_documents.contents_access_error',

--- a/app/models/member_page.rb
+++ b/app/models/member_page.rb
@@ -1,7 +1,7 @@
 class MemberPage < ApplicationRecord
   validates_presence_of :filename
   # Note that we are not checking for uniqueness of filename - this is because
-  # all of the member page files are maintaind in a single directory (accessed
+  # all of the member page files are maintained in a single directory (accessed
   # by HighVoltage) and hence the OS will ensure unique filenames
 
   def self.title(file_name)

--- a/app/models/member_page.rb
+++ b/app/models/member_page.rb
@@ -12,9 +12,7 @@ class MemberPage < ApplicationRecord
     member_page.title
   end
 
-  private
-
-  def self.find_or_create(file_name)
+  private_class_method def self.find_or_create(file_name)
     member_page = find_by filename: file_name
 
     return member_page if member_page

--- a/app/models/member_page.rb
+++ b/app/models/member_page.rb
@@ -1,0 +1,23 @@
+class MemberPage < ApplicationRecord
+  validates_presence_of :filename
+  # Note that we are not checking for uniqueness of filename - this is because
+  # all of the member page files are maintaind in a single directory (accessed
+  # by HighVoltage) and hence the OS will ensure unique filenames
+
+  def self.title(file_name)
+    member_page = find_or_create(file_name)
+
+    return file_name.capitalize unless member_page.title
+
+    member_page.title
+  end
+
+  private
+
+  def self.find_or_create(file_name)
+    member_page = find_by filename: file_name
+
+    return member_page if member_page
+    return MemberPage.create(filename: file_name)
+  end
+end

--- a/app/views/application/_navigation.html.haml
+++ b/app/views/application/_navigation.html.haml
@@ -30,13 +30,17 @@
                 = render 'navigation_member_pages'
 
                 - if current_user.has_company?
+                  - member_company = current_user.membership_applications.accepted.last.company
                   %li.menu-item.menu-item-has-children
-                    = link_to t('menus.nav.members.manage_company.submenu_title'), company_path(current_user.membership_applications.last.company)
+                    = link_to t('menus.nav.members.manage_company.submenu_title'),
+                              company_path(member_company)
                     %ul.sub-menu
                       %li.menu-item
-                        = link_to t('menus.nav.members.manage_company.view_company'), company_path(current_user.membership_applications.last.company)
+                        = link_to t('menus.nav.members.manage_company.view_company'),
+                                  company_path(member_company)
                       %li.menu-item
-                        = link_to t('menus.nav.members.manage_company.edit_company'), edit_company_path(current_user.membership_applications.last.company)
+                        = link_to t('menus.nav.members.manage_company.edit_company'),
+                                  edit_company_path(company_path(member_company))
 
                 = render 'navigation_edit_my_application', membership_app: current_user.membership_applications.last
 

--- a/app/views/pages/historiska-dokument.html
+++ b/app/views/pages/historiska-dokument.html
@@ -1,6 +1,3 @@
-<h2 style="text-align: center;">Historiska Dokument (PDF/DOCX)</h2>
-
-<hr />
 <h1>Styrelseprotokoll</h1>
 
 <p><strong>2016</strong></p>

--- a/app/views/pages/nyhetsbrev.html
+++ b/app/views/pages/nyhetsbrev.html
@@ -1,6 +1,3 @@
-<h2 style="text-align: center;">V&aring;rt Nyhetsbrev</h2>
-
-<hr />
 <p>Ungef&auml;r en g&aring;ng per m&aring;nad skickar styrelsen, via mail, ut ett nyhetsbrev till alla medlemmar. Detta g&ouml;rs f&ouml;r att f&aring; en n&auml;ra och snabb kontakt mellan styrelsen och er medlemmar och f&ouml;r att medlemmarna kontinuerligt h&aring;lls uppdaterade om styrelsens arbete f&ouml;r att g&ouml;ra IMMI och dess medlemmar mer synliga och andra projekt som vi driver.</p>
 
 <p>I nyhetsbrevet har vi ocks&aring; reserverat plats f&ouml;r dig som medlem att bidra med material, tips och fotgrafier. Vill du g&ouml;ra reklam f&ouml;r vidareutbildningar, event eller f&ouml;rel&auml;sningar som du arrangerar passar det ocks&aring; utm&auml;rkt i nyhetsbrevet, liksom i den slutna facebookgruppen. Vill du g&ouml;ra reklam f&ouml;r dina kurser som v&auml;nder sig till hund&auml;gare passar detta b&auml;ttre p&aring; v&aring;r &ouml;ppna facebooksida.</p>

--- a/app/views/pages/olycksfallsforsakring.html
+++ b/app/views/pages/olycksfallsforsakring.html
@@ -1,6 +1,3 @@
-<h2 style="text-align: center;">Olycksfallsf&ouml;rs&auml;kring</h2>
-
-<hr />
 <p>I din medlemsavgift ing&aring;r en kollektiv f&ouml;rs&auml;kring genom If. F&ouml;rs&auml;kringen g&auml;ller f&ouml;r olycksfall eller skada %em under ditt arbete som instrukt&ouml;r eller hundpsykolog men ocks&aring; %em under tiden du f&auml;rdas till eller fr&aring;n kurs eller privat konsultation.</p>
 
 <p>F&ouml;rs&auml;kringen utfaller vid anm&auml;ld skada eller olycksfall i arbetet och ers&auml;tter d&aring; utlagda n&ouml;dv&auml;ndiga kostnader f&ouml;r l&auml;ke-, tandskade- och resekostnader.</p>

--- a/app/views/pages/styrelse.html
+++ b/app/views/pages/styrelse.html
@@ -1,6 +1,3 @@
-<h2 style="text-align: center;">Styelse Och Kontaktinformation</h2>
-
-<hr />
 <p>SHF:s nuvarande styrelse fick f&ouml;rtroendet &aring;rsm&ouml;tet 2015. Styrelsen best&aring;r av en grupp engagerade hundf&ouml;retagare som tillsammans besitter bred kompetens och ser behovet av en samlande organisation. Alla har en given roll och kvaliteter vi inte klarat oss utan. Det &auml;r ett sant n&ouml;je att tillsammans arbeta mot gemensamma m&aring;l som vi alla brinner f&ouml;r.</p>
 
 <p><strong>Plusgiro nummer 46 96 49-8</strong></p>

--- a/app/views/pages/traffa-dina-kollegor.html
+++ b/app/views/pages/traffa-dina-kollegor.html
@@ -1,6 +1,3 @@
-<h2 style="text-align: center;">Tr&auml;ffa Dina Kollegor</h2>
-
-<hr />
 <p>Vi anser att n&auml;ra kontakt och samarbete &auml;r av stor vikt f&ouml;r v&aring;r sammanh&aring;llning, gemenskap och kollektiva utveckling. Samtidigt bor vi ju i ett avl&aring;ngt land med stora geografiska avst&aring;nd. D&auml;r har vi stor gl&auml;dje av den moderna tekniken och kan f&ouml;ra diskussioner exempelvis i f&ouml;reningens Facebookgrupp. P&aring; Facebook finns &auml;ven en sida som &auml;r &ouml;ppen f&ouml;r alla intresserade. H&auml;r kan era kunder ta del av givande &ndash; eller &rdquo;bara&rdquo; trevliga &ndash; inl&auml;gg fr&aring;n dagens Hundsverige. Sj&auml;lvklart &auml;r du ocks&aring; v&auml;lkommen att kontakta styrelsen direkt. Kanske vill du ha ett bollplank f&ouml;r dina fr&aring;gor? Delge tips och komma med nya id&eacute;er? F&aring; r&aring;d om var du skulle kunna f&ouml;rmedla en kund vidare? Eller helt andra funderingar?!</p>
 
 <h2>Facebookgrupp:</h2>

--- a/app/views/pages/yrkesrad.html
+++ b/app/views/pages/yrkesrad.html
@@ -1,6 +1,3 @@
-<h2 style="text-align: center;">Yrkesr&aring;d</h2>
-
-<hr />
 <p>Skulle du kunna t&auml;nka dig att ing&aring; i ett yrkesr&aring;d i SHF d&auml;r du kan g&ouml;ra punktinsatser och driva en speciell fr&aring;ga och hj&auml;rtesak? Kontakta oss g&auml;rna, vi uppskattar allt engagemang stort som litet.</p>
 
 <p>Kontakta oss p&aring; <a href="mailto:info@sverigshundforetagare.se">info@sverigshundforetagare.se</a></p>

--- a/app/views/shf_documents/_contents_form.html.haml
+++ b/app/views/shf_documents/_contents_form.html.haml
@@ -1,10 +1,10 @@
 = form_tag({ controller: 'shf_documents', action: 'contents_update' },
            { method: 'patch' }) do
 
-  = label_tag :title, 'Page Title'
+  = label_tag :title, t('.member_page_title')
   = text_field_tag :title, @title
 
-  = label_tag :contents, 'Page Contents'
+  = label_tag :contents, t('.member_page_contents')
   = cktext_area_tag :contents, @contents
 
   .actions

--- a/app/views/shf_documents/_contents_form.html.haml
+++ b/app/views/shf_documents/_contents_form.html.haml
@@ -1,6 +1,10 @@
 = form_tag({ controller: 'shf_documents', action: 'contents_update' },
            { method: 'patch' }) do
 
+  = label_tag :title, 'Page Title'
+  = text_field_tag :title, @title
+
+  = label_tag :contents, 'Page Contents'
   = cktext_area_tag :contents, @contents
 
   .actions

--- a/app/views/shf_documents/_documents_list.html.haml
+++ b/app/views/shf_documents/_documents_list.html.haml
@@ -5,4 +5,4 @@
 
   - HighVoltage.page_ids.each do |page|
     %li{ class: li_class }
-      = link_to page.capitalize, contents_show_path(page: page)
+      = link_to MemberPage.title(page), contents_show_path(page: page)

--- a/app/views/shf_documents/contents_show.html.haml
+++ b/app/views/shf_documents/contents_show.html.haml
@@ -7,4 +7,9 @@
                 class: 'btn btn-default edit-shf-document'
 
   .entry-content
+    %hr
+    .center{ style: 'font-size: 150%;' }
+      = @title
+    %hr
+
     != @contents

--- a/app/views/shf_documents/contents_show.html.haml
+++ b/app/views/shf_documents/contents_show.html.haml
@@ -1,15 +1,16 @@
 .shf-document.show#shf-document
 
-  .item-nav-buttons.pull-right#item-nav-buttons
-    - if policy(ShfDocument).contents_update?
-      = link_to "#{t('shf_documents.edit_shf_document_contents')}",
+  - if policy(ShfDocument).contents_update?
+    .item-nav-buttons.pull-right#item-nav-buttons
+      = link_to "#{t('shf_documents.edit_member_page')}",
                 contents_edit_path(page: @page),
-                class: 'btn btn-default edit-shf-document'
+                class: 'btn btn-default edit-member-page'
 
   .entry-content
-    %hr
+    .clearfix
     .center{ style: 'font-size: 150%;' }
       = @title
+
     %hr
 
     != @contents

--- a/app/views/shf_documents/contents_show.html.haml
+++ b/app/views/shf_documents/contents_show.html.haml
@@ -2,7 +2,7 @@
 
   - if policy(ShfDocument).contents_update?
     .item-nav-buttons.pull-right#item-nav-buttons
-      = link_to "#{t('shf_documents.edit_member_page')}",
+      = link_to "#{t('.edit_member_page')}",
                 contents_edit_path(page: @page),
                 class: 'btn btn-default edit-member-page'
 

--- a/app/views/shf_documents/minutes_and_static_pages.html.haml
+++ b/app/views/shf_documents/minutes_and_static_pages.html.haml
@@ -6,6 +6,3 @@
 
 .entry-content
   = render partial: 'documents_list', locals: { ul_class: '', li_class: '' }
-
-  %br
-  (#{t('shf_documents.missing_special_letters')})

--- a/app/views/shf_documents/show.html.haml
+++ b/app/views/shf_documents/show.html.haml
@@ -23,7 +23,7 @@
 
     .row.center.item-nav-buttons#item-nav-buttons
       - if policy(@shf_document).update?
-        = link_to "#{t('shf_documents.edit_shf_document')}", edit_shf_document_path(@shf_document), class: 'btn btn-default edit-shf-document'
+        = link_to "#{t('shf_documents.edit_shf_document')}", edit_shf_document_path(@shf_document), class: 'btn btn-default edit-member-page'
 
       -if policy(@shf_document).index?
         = link_to "#{t('shf_documents.all_shf_documents')}", shf_documents_path, class: 'btn btn-default all-shf-documents'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -539,7 +539,7 @@ en:
     view_shf_document: View the SHF document details
     all_shf_documents: All SHF Documents
     all_shf_minutes: All Meeting Minutes
-    edit_shf_document_contents: Edit the document contents
+    edit_member_page: Edit page
 
     invalid_upload_type: Sorry, this is not a file type you can upload.
     file_too_large: *file_too_large_5MB

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -539,7 +539,6 @@ en:
     view_shf_document: View the SHF document details
     all_shf_documents: All SHF Documents
     all_shf_minutes: All Meeting Minutes
-    edit_member_page: Edit page
 
     invalid_upload_type: Sorry, this is not a file type you can upload.
     file_too_large: *file_too_large_5MB
@@ -596,10 +595,14 @@ en:
       shf_meeting_minutes: &member_pages_board_meetings SHF Board Meeting Minutes
 
     contents_show:
-      page_title: '%{document_title}'
+      edit_member_page: Edit page
 
     contents_edit:
-      page_title: 'Edit Content for SHF Document: %{document_title}'
+      page_title: 'Edit Member Page: %{document_title}'
+
+    contents_form:
+      member_page_title: Member Page Title
+      member_page_contents: Member Page Contents
 
     contents_update:
       success: '%{document_title} was updated successfully.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -545,8 +545,6 @@ en:
 
     contents_access_error: 'There was an error accessing the file: %{message}'
 
-    missing_special_letters: 'In the document titles above, letters å, ä and ö are shown as a, a and o, respectively.'
-
     index:
       page_title: 'Historical Documents: Board Meeting Minutes'
       instructions: 'These are SHF Board meeting minutes.  Click on the title of a document to view it.  Depending on your browser settings, it might open in a new window or it might download.'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -539,7 +539,6 @@ sv:
     view_shf_document: Information om dokument
     all_shf_documents: Alla uppladdade dokument
     all_shf_minutes: Alla mötesprotokoll
-    edit_member_page: Redigera sida
 
     invalid_upload_type: *invalid_upload_type
     file_too_large: *file_too_large_5MB
@@ -596,10 +595,14 @@ sv:
       shf_meeting_minutes: &member_pages_board_meetings Styrelseprotokoll
 
     contents_show:
-      page_title: '%{document_title}'
+      edit_member_page: Redigera sida
 
     contents_edit:
-      page_title: 'Redigera innehåll för SHF Document: %{document_title}'
+      page_title: 'Redigera medlemssida: %{document_title}'
+
+    contents_form:
+      member_page_title: Medlemssida Titel
+      member_page_contents: MInnehållsförteckning
 
     contents_update:
       success: '%{document_title} uppdaterades utan problem.'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -601,8 +601,8 @@ sv:
       page_title: 'Redigera medlemssida: %{document_title}'
 
     contents_form:
-      member_page_title: Medlemssida Titel
-      member_page_contents: MInnehållsförteckning
+      member_page_title: Titel
+      member_page_contents: Innehåll
 
     contents_update:
       success: '%{document_title} uppdaterades utan problem.'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -539,7 +539,7 @@ sv:
     view_shf_document: Information om dokument
     all_shf_documents: Alla uppladdade dokument
     all_shf_minutes: Alla mötesprotokoll
-    edit_shf_document_contents: Redigera dokumentinnehållet
+    edit_member_page: Redigera sida
 
     invalid_upload_type: *invalid_upload_type
     file_too_large: *file_too_large_5MB

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -545,8 +545,6 @@ sv:
 
     contents_access_error: 'Det uppstod ett fel att komma åt filen: %{message}'
 
-    missing_special_letters: 'Vi beklagar, men för tillfället kan systemet inte visa åäö i undersidornas titlar.'
-
     index:
       page_title: 'Styrelseprotokoll'
       instructions: 'Här hittar du våra senaste styrelsemötesprotokoll. Klicka på titeln på ett dokument för att visa det. Beroende på dina webbläsarinställningar kan det öppnas i ett nytt fönster eller så laddas det ner.'

--- a/db/migrate/20170507103334_create_member_pages.rb
+++ b/db/migrate/20170507103334_create_member_pages.rb
@@ -1,0 +1,10 @@
+class CreateMemberPages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :member_pages do |t|
+      t.string :filename, null: false
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/features/edit_member_page.feature
+++ b/features/edit_member_page.feature
@@ -13,6 +13,16 @@ Feature: Edit a member page
     Given I am logged in as "admin@shf.se"
     And I am on the test member page
     And I click on t("shf_documents.edit_member_page")
-    And I fill in "contents" with "This is content in the member pages testfile."
+    And I fill in "contents" with "This is content in the member pages test file."
     And I click on t("submit")
-    And I should see "This is content in the member pages testfile."
+    And I should see "This is content in the member pages test file."
+
+  Scenario: Admin can edit title of member page
+    Given I am logged in as "admin@shf.se"
+    And I am on the test member page
+    And I should see "Testfile"
+    And I click on t("shf_documents.edit_member_page")
+    And I fill in "title" with "New Title for Member Page"
+    And I click on t("submit")
+    And I should see "New Title for Member Page"
+    And I should not see "Testfile"

--- a/features/edit_member_page.feature
+++ b/features/edit_member_page.feature
@@ -12,7 +12,7 @@ Feature: Edit a member page
   Scenario: Admin can edit contents of member page
     Given I am logged in as "admin@shf.se"
     And I am on the test member page
-    And I click on t("shf_documents.edit_member_page")
+    And I click on t("shf_documents.contents_show.edit_member_page")
     And I fill in "contents" with "This is content in the member pages test file."
     And I click on t("submit")
     And I should see "This is content in the member pages test file."
@@ -21,7 +21,7 @@ Feature: Edit a member page
     Given I am logged in as "admin@shf.se"
     And I am on the test member page
     And I should see "Testfile"
-    And I click on t("shf_documents.edit_member_page")
+    And I click on t("shf_documents.contents_show.edit_member_page")
     And I fill in "title" with "New Title for Member Page"
     And I click on t("submit")
     And I should see "New Title for Member Page"

--- a/features/edit_member_page.feature
+++ b/features/edit_member_page.feature
@@ -12,7 +12,7 @@ Feature: Edit a member page
   Scenario: Admin can edit contents of member page
     Given I am logged in as "admin@shf.se"
     And I am on the test member page
-    And I click on t("shf_documents.edit_shf_document_contents")
+    And I click on t("shf_documents.edit_member_page")
     And I fill in "contents" with "This is content in the member pages testfile."
     And I click on t("submit")
     And I should see "This is content in the member pages testfile."

--- a/features/view_hidden_pages.feature
+++ b/features/view_hidden_pages.feature
@@ -42,7 +42,7 @@ Feature: Only members and admins can see members only (hidden) pages
   Scenario: Member can see members only pages
     Given I am logged in as "emma@happymutts.com"
     And  I am on the static workgroups page
-    Then I should see "Yrkesråd"
+    Then I should see "Yrkesrad"
     Then I should not see t("errors.not_permitted")
 
   Scenario: Member can see members only menu
@@ -53,7 +53,7 @@ Feature: Only members and admins can see members only (hidden) pages
   Scenario: Admin can see members only pages
     Given I am logged in as "admin@shf.se"
     And  I am on the static workgroups page
-    Then I should see "Yrkesråd"
+    Then I should see "Yrkesrad"
     Then I should not see t("errors.not_permitted")
 
   Scenario: Admin can see members only menu

--- a/spec/factories/member_pages.rb
+++ b/spec/factories/member_pages.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :member_page do
-    filename "MyString"
-    title "MyString"
+    filename 'test_file_name'
+    title 'test_page_title'
   end
 end

--- a/spec/factories/member_pages.rb
+++ b/spec/factories/member_pages.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :member_page do
+    filename "MyString"
+    title "MyString"
+  end
+end

--- a/spec/fixtures/member_pages/testfile.html
+++ b/spec/fixtures/member_pages/testfile.html
@@ -1,1 +1,1 @@
-This is content in the member pages testfile.
+This is content in the member pages test file.

--- a/spec/models/member_page_spec.rb
+++ b/spec/models/member_page_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MemberPage, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/member_page_spec.rb
+++ b/spec/models/member_page_spec.rb
@@ -1,5 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe MemberPage, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:member_page) { create(:member_page) }
+
+  describe 'Factory' do
+    it 'has a valid factory' do
+      expect(create(:member_page)).to be_valid
+    end
+  end
+
+  describe 'DB Table' do
+    it { is_expected.to have_db_column :filename }
+    it { is_expected.to have_db_column :title }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of :filename }
+  end
+
+  describe '.title' do
+    it 'creates a new record if non-existant' do
+      expect { MemberPage.title('page_name') }.to change(MemberPage, :count).by(1)
+    end
+
+    it 'returns file name as default title' do
+      expect(MemberPage.title('page_name')).to eq 'Page_name'
+    end
+
+    it 'returns title if present' do
+      expect(MemberPage.title(member_page.filename)).to eq member_page.title
+    end
+  end
 end

--- a/spec/models/member_page_spec.rb
+++ b/spec/models/member_page_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe MemberPage, type: :model do
       expect { MemberPage.title('page_name') }.to change(MemberPage, :count).by(1)
     end
 
-    it 'returns file name as default title' do
+    it 'returns capitalized file name as default title' do
       expect(MemberPage.title('page_name')).to eq 'Page_name'
     end
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/145646809


Changes proposed in this pull request:
1. Removed message - on member pages index page - regarding missing Swedish letters å, ä, ö.

(this is no longer needed since now each page can be given a title using any characters)

Ready for review:
@weedySeaDragon @thesuss
