### PR TITLE
removed notice re special chararacters in member pages index view

### DIFF
--- a/app/views/shf_documents/minutes_and_static_pages.html.haml
+++ b/app/views/shf_documents/minutes_and_static_pages.html.haml
@@ -6,6 +6,3 @@
 
 .entry-content
   = render partial: 'documents_list', locals: { ul_class: '', li_class: '' }
-
-  %br
-  (#{t('shf_documents.missing_special_letters')})

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -546,8 +546,6 @@ en:
 
     contents_access_error: 'There was an error accessing the file: %{message}'
 
-    missing_special_letters: 'In the document titles above, letters å, ä and ö are shown as a, a and o, respectively.'
-
     index:
       page_title: 'Historical Documents: Board Meeting Minutes'
       instructions: 'These are SHF Board meeting minutes.  Click on the title of a document to view it.  Depending on your browser settings, it might open in a new window or it might download.'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -546,8 +546,6 @@ sv:
 
     contents_access_error: 'Det uppstod ett fel att komma åt filen: %{message}'
 
-    missing_special_letters: 'Vi beklagar, men för tillfället kan systemet inte visa åäö i undersidornas titlar.'
-
     index:
       page_title: 'Styrelseprotokoll'
       instructions: 'Här hittar du våra senaste styrelsemötesprotokoll. Klicka på titeln på ett dokument för att visa det. Beroende på dina webbläsarinställningar kan det öppnas i ett nytt fönster eller så laddas det ner.'


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/145646809


Changes proposed in this pull request:
1.  Remove the message about page titles not containing characters ä, å and ö (not needed since we can now edit page titles)


Ready for review:
@weedySeaDragon @thesuss