### PR TITLE
deployment: ckeditor uploads must be shared across deployments/releases

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -10,12 +10,35 @@ set :branch, ENV['BRANCH']
 
 set :deploy_to, ENV['APP_PATH']
 
+# These files are shared among all deployments.  Every deployment has a
+# link to these files.  They are not recreated (new) for each deployment.
+# If any specific file for the system must remain the same from one
+# deployment to the next, it should be listed here.
+# These individual files are in the 'shared' directory on the production system: /var/www/shf/shared/
+# (That is the convention for Capistrano deployments.)
 set :linked_files, %w{config/database.yml config/secrets.yml .env}
 
+# These directories are shared among all deployments.  Every deployment has a
+# link to these directories.  They are not recreated (new) for each deployment.
+# If any information or data for the system must remain the same from one
+# deployment to the next, it should be listed here.
+# These directories are in the 'shared' directory on the production system: /var/www/shf/shared/
+# (That is the convention for Capistrano deployments.)
 set :linked_dirs, %w{
-  bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system
-  public/uploads public/.well-known public/storage
+  bin log tmp/pids tmp/cache tmp/sockets vendor/bundle
+  public/system
+  public/uploads
+  public/.well-known
+  public/storage
+  public/ckeditor_assets
 }
+
+# public/.well-known  created by diffouo (raoul) when this was set up. used for ??? (not used?)
+# public/system       created by diffouo (raoul) when this was set up. used for ??? (not used?)
+# public/uploads      created by diffouo (raoul) when this was set up. used for ??? (not used?)
+# public/storage  Files uploaded for  membership applications
+# public/ckeditor_assets Files uploaded by members, admins when using the ckeditor (ex: company page custom infor, SHF member documents)
+
 
 set :keep_releases, 5
 


### PR DESCRIPTION
PT Story:  **Capistrano deploy: add models/ckeditor assets to 'linked' (shared) dirs**
https://www.pivotaltracker.com/story/show/145697995

Changes proposed in this pull request:
1. added public/ckeditor_assets to linked_dirs ('shared' on production)
2. added comments explaining the linked_files and linked_dirs in the capistrano` deploy.rb` file
3. added comments describing the linked directories (those that weren't obviously rails related or -conventions)
4. copied the files that had been uploaded with ckeditor during different releases and put them into the `/var/www/shf/sharedckeditor_assets` directory on the production server.  So all of the files uploaded by members for their company pages are now 'recovered' and in that shared directory.

   Linked `public/ckeditor_assets` in the current release to the shared `... /ckeditor_assets` directory
   - There was an issue with the images in the membership documents: it seems like the current release referred to image file names that were older and different than the filenames for the images that had been uploaded.  I believe they are fixed and in sync, now, but @thesuss you should definitely check this page:
http://hitta.sverigeshundforetagare.se/en/shf_documents/contents/medlemsbeviset

Since we don't have a staging server, we can't actually test this change until we deploy again.  However, since this is a simple change and it is follows standard Capistrano conventions, it should be fine.  (We've had Raoul do this in the past for other directories where we do uploads.)

Ready for review:
@thesuss @patmbolger
