### PR TITLE
Sprint14 refactor logging #145819009

### DIFF
--- a/app/models/activity_logger.rb
+++ b/app/models/activity_logger.rb
@@ -41,7 +41,7 @@ class ActivityLogger
     end
   end
 
-  private def initialize(filename, facility, activity, show=true)
+  private def initialize(filename, facility, activity, show)
     @filename = filename
     @facility = facility
     @activity = activity

--- a/app/models/activity_logger.rb
+++ b/app/models/activity_logger.rb
@@ -9,20 +9,37 @@ class ActivityLogger
   # [facility] [activity] [severity] <message>
   # Example log contents:
   # [SHF_TASK] [Load Kommuns] [info] Started at 2017-05-20 17:25:39 -0400
-  # [SHF_TASK] [Load Kommuns] [info] 290 Regions created.
+  # [SHF_TASK] [Load Kommuns] [info] 290 Kommuns created.
   # [SHF_TASK] [Load Kommuns] [info] Finished at 2017-05-20 17:25:39 -0400.
   # [SHF_TASK] [Load Kommuns] [info] Duration: 0.67 seconds.
   #
-  # Here, the facility is an SHF task file, the activity is loading Kommuns
+  # Here, the facility is an SHF task, the activity is loading Kommuns
   # into the DB, and the messages are all of INFO severity.
   #
   # Usage:
-  # 1) call log = ActivityLogger.new(logfile, facility, activity)
+  # 1) call ActivityLogger.open(logfile, facility, activity)
+  #    -- assign the logger instance value to a local var (e.g., "log = ..."), OR
+  #    -- pass a block which takes an argument (which is the logger instance)
   # 2) for each logged message during the activity,
-  #    call log.record(severity, message),
+  #    call log.record(severity, message), (log == logger instance)
   #    where severity is one of 'debug', 'info, 'warn', 'error', 'fatal', 'unknown'
   # 3) when the activity is complete,
-  #    call log.close
+  #    -- the log file will be closed automatically if opened with a block, OR
+  #    -- call log.close
+
+  def self.open(filename, facility, activity, show=true)
+    log = new(filename, facility, activity, show=true)
+
+    if block_given?
+      begin
+        yield log
+      ensure
+        log.close
+      end
+    else
+      log
+    end
+  end
 
   def initialize(filename, facility, activity, show=true)
     @filename = filename

--- a/app/models/activity_logger.rb
+++ b/app/models/activity_logger.rb
@@ -1,0 +1,64 @@
+class ActivityLogger
+
+  # This supports simple logging of activity, such as loading data into the
+  # the DB with a rake task.
+  # This also allows for output to STDOUT of logged messages.
+  #
+  # The format of the logged messages are:
+  #
+  # [facility] [activity] [severity] <message>
+  # Example log contents:
+  # [SHF_TASK] [Load Kommuns] [info] Started at 2017-05-20 17:25:39 -0400
+  # [SHF_TASK] [Load Kommuns] [info] 290 Regions created.
+  # [SHF_TASK] [Load Kommuns] [info] Finished at 2017-05-20 17:25:39 -0400.
+  # [SHF_TASK] [Load Kommuns] [info] Duration: 0.67 seconds.
+  #
+  # Here, the facility is an SHF task file, the activity is loading Kommuns
+  # into the DB, and the messages are all of INFO severity.
+  #
+  # Usage:
+  # 1) call log = ActivityLogger.new(logfile, facility, activity)
+  # 2) for each logged message during the activity,
+  #    call log.record(severity, message),
+  #    where severity is one of 'debug', 'info, 'warn', 'error', 'fatal', 'unknown'
+  # 3) when the activity is complete,
+  #    call log.close
+
+  def initialize(filename, facility, activity, show=true)
+    @filename = filename
+    @facility = facility
+    @activity = activity
+    @facility_and_action = "[#{facility}] [#{activity}] "
+    @show = show
+    @start_time = Time.now
+
+    @log = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(filename))
+
+    record('info', "Started at #{@start_time}")
+  end
+
+  def record(log_level, message)
+    raise 'invalid log severity level' unless
+      ActiveSupport::Logger::Severity.constants.include?(log_level.upcase.to_sym)
+
+    @log.tagged(@facility, @activity, log_level) do
+      @log.send(log_level, message)
+    end
+
+    puts @facility_and_action + "[#{log_level}] " + message if @show
+  end
+
+  def close(duration: true)
+    finish_time = Time.now
+    record('info', "Finished at #{finish_time}.")
+    record('info',
+      "Duration: #{(finish_time - @start_time).round(2)} seconds.\n") if duration
+    @log.close
+    logged_to if @show
+  end
+
+  def logged_to
+    puts @facility_and_action + '[info] ' + "Information was logged to: #{@filename}"
+  end
+
+end

--- a/app/models/activity_logger.rb
+++ b/app/models/activity_logger.rb
@@ -28,7 +28,7 @@ class ActivityLogger
   #    -- call log.close
 
   def self.open(filename, facility, activity, show=true)
-    log = new(filename, facility, activity, show=true)
+    log = new(filename, facility, activity, show)
 
     if block_given?
       begin
@@ -41,7 +41,7 @@ class ActivityLogger
     end
   end
 
-  def initialize(filename, facility, activity, show=true)
+  private def initialize(filename, facility, activity, show=true)
     @filename = filename
     @facility = facility
     @activity = activity

--- a/lib/tasks/shf.rake
+++ b/lib/tasks/shf.rake
@@ -120,7 +120,7 @@ namespace :shf do
     require 'csv'
     require 'smarter_csv'
 
-    log = ActivityLogger.open(LOG_FILE, 'SHF_TASK', 'Load Kommuns') do |log|
+    ActivityLogger.open(LOG_FILE, 'SHF_TASK', 'Load Kommuns') do |log|
 
       if Kommun.exists?
         log.record('warn', 'Kommuns table not empty.')

--- a/lib/tasks/shf.rake
+++ b/lib/tasks/shf.rake
@@ -3,7 +3,8 @@ require 'active_support/logger'
 
 namespace :shf do
 
-  ACCEPTED_STATE = 'accepted' unless defined?(ACCEPTED_STATE)
+  ACCEPTED_STATE = 'accepted'
+  LOG_FILE = 'log/shf_tasks'
 
   desc 'recreate db (current env): drop, setup, migrate, seed the db.'
   task :db_recreate => [:environment] do
@@ -48,9 +49,7 @@ namespace :shf do
         key_mapping: headers_to_columns_mapping
     }
 
-    logfile = 'log/import.log'
-    start_time = Time.now
-    log = start_logging(start_time, logfile)
+    log = ActivityLogger.new(LOG_FILE, 'SHF_TASK', 'Import CSV')
 
     if args.has_key? :csv_filename
 
@@ -67,33 +66,35 @@ namespace :shf do
             num_read += 1
           rescue ActiveRecord::RecordInvalid => invalid_info
             error_rows += 1
-            log_and_show(log, Logger::ERROR, "#{invalid_info.record.errors.full_messages.join(", ")}")
+            log.record('error', "#{invalid_info.record.errors.full_messages.join(", ")}")
           end
         end
 
-        log_and_show log, Logger::INFO, "\nFinished.  Read #{num_read + error_rows} rows.\n  #{num_read} were valid and their information was imported.\n  #{error_rows} had errors."
+        msg = "\nRead #{num_read + error_rows} rows.\n" +
+              "#{num_read} were valid and their information was imported.\n" +
+              "#{error_rows} had errors."
+        log.record('info', msg)
 
       else
-        log_file_doesnt_exist_and_close(log, args[:csv_filename], start_time)
-        finish_and_close_log(log, start_time, Time.now)
+        log.record('error', "#{args[:csv_filename]} does not exist. Nothing imported")
+        log.close
         raise LoadError
       end
 
     else
-      log_must_provide_filename_and_close(log, usage, start_time)
+      msg = "You must specify a .csv filename to import.\n  Ex: #{usage}"
+      log.record('error', msg)
+      log.close
       raise "ERROR: You must specify a .csv filename to import. Ex: #{usage}"
     end
 
-    log_and_show log, Logger::INFO, "Information was logged to: #{logfile}"
-    finish_and_close_log(log, start_time, Time.now)
+    log.close
   end
 
   desc "load regions data (counties plus 'Sverige' and 'Online')"
   task :load_regions => [:environment] do
 
-    logfile = 'log/shf-regions.log'
-    start_time = Time.now
-    log = start_logging(start_time, logfile, "Regions create")
+    log = ActivityLogger.new(LOG_FILE, 'SHF_TASK', 'Load Regions')
 
     # Populate the 'regions' table for Swedish regions (aka counties),
     # as well as 'Sverige' (Sweden) and 'Online'.  This is used to specify
@@ -102,17 +103,16 @@ namespace :shf do
     # This uses the 'city-state' gem for a list of regions (name and ISO code).
 
     if Region.exists?
-      log_and_show log, Logger::WARN, "Regions table not empty"
+      log.record('warn', 'Regions table not empty.')
     else
       CS.states(:se).each_pair { |k, v| Region.create(name: v, code: k.to_s) }
       Region.create(name: 'Sverige', code: nil)
       Region.create(name: 'Online', code: nil)
 
-      log_and_show log, Logger::INFO, "#{Region.count} Regions created"
+      log.record('info', "#{Region.count} Regions created.")
     end
 
-    log_and_show log, Logger::INFO, "Information was logged to: #{logfile}"
-    finish_and_close_log(log, start_time, Time.now, "Regions create")
+    log.close
   end
 
   desc "load kommuns data (290 Swedish municipalities)"
@@ -121,23 +121,19 @@ namespace :shf do
     require 'csv'
     require 'smarter_csv'
 
-    logfile = 'log/shf-kommuns.log'
-    start_time = Time.now
-    log = start_logging(Time.now, logfile, "Kommuns create")
+    log = ActivityLogger.new(LOG_FILE, 'SHF_TASK', 'Load Kommuns')
 
     if Kommun.exists?
-      log_and_show log, Logger::WARN, "Kommuns table not empty"
+      log.record('warn', 'Kommuns table not empty.')
     else
       SmarterCSV.process('lib/seeds/kommuner.csv').each do |kommun|
         Kommun.create(name: kommun[:name])
       end
 
-      log_and_show log, Logger::INFO, "#{Kommun.count} kommuns created"
+      log.record('info', "#{Kommun.count} Regions created.")
     end
 
-    log_and_show log, Logger::INFO, "Information was logged to: #{logfile}"
-
-    finish_and_close_log(log, start_time, Time.now, "Kommuns create")
+    log.close
   end
 
 
@@ -188,19 +184,21 @@ namespace :shf do
 
     Geocoder.configure( timeout: 20)   # geocoding service timeout (secs)
 
-    logfile = 'log/shf-geocode.log'
-    start_time = Time.now
-    log = start_logging(start_time, logfile, "Geocode All Addresses (RAILS_ENV = #{Rails.env} arguments = #{args.each { |arg| arg.inspect} }  )")
+    log = ActivityLogger.new(LOG_FILE, 'SHF_TASK', 'Geocode Addresses')
 
     not_geocoded = Address.not_geocoded
-    log_and_show log, Logger::INFO, "  #{not_geocoded.count} Addresses are not yet geocoded.  Will now geocode them..."
+
+    msg = " #{not_geocoded.count} Addresses are not yet geocoded.  Will geocode."
+    log.record('info', msg)
+
     Address.geocode_all_needed(sleep_between: args[:sleep_time].to_f, num_per_batch: args[:batch_num].to_i)
 
-    log_and_show log, Logger::INFO, "  After running Address.geocode_all_needed(sleep_between: #{args[:sleep_time].to_f}, num_per_batch: #{args[:batch_num].to_i}), #{Address.not_geocoded.count} Addresses are not geocoded."
+    msg = " After running Address.geocode_all_needed(sleep_between: " +
+          "#{args[:sleep_time].to_f}, num_per_batch: #{args[:batch_num].to_i})"+
+          ", #{Address.not_geocoded.count} Addresses are not geocoded."
+    log.record('info', msg)
 
-    log_and_show log, Logger::INFO, "Information was logged to: #{logfile}"
-    finish_and_close_log(log, start_time, Time.now, "Geocode All Addresses")
-
+    log.close
   end
 
 
@@ -208,7 +206,9 @@ namespace :shf do
 
   def import_a_member_app_csv(row, log)
 
-    log_and_show log, Logger::INFO, "Importing row: #{row.inspect}"
+    log.record('info', "Importing row: #{row.inspect}")
+
+    # log_and_show log, Logger::INFO, "Importing row: #{row.inspect}"
 
     if (user = User.find_by(email: row[:email]))
       puts_already_exists 'User', row[:email]
@@ -285,64 +285,20 @@ namespace :shf do
       Company.create!(company_number: company_num,
                       email: email,
                       name: name,
-                      street: street,
-                      post_code: post_code,
-                      city: city,
-                      region: region,
                       phone_number: phone_number,
                       website: website)
 
       company = Company.find_by_company_number(company_num)
+
+      company.addresses << Address.new(street_address: street,
+                                       post_code: post_code,
+                                       city: city,
+                                       region: region)
+
       puts_created 'Company', company.company_number
     end
     company
   end
-
-
-  def start_logging(start_time = Time.now,
-                    log_fn = 'log/import.log',
-                    action = "Import")
-    log = ActiveSupport::Logger.new(log_fn)
-    log_and_show log, Logger::INFO, "#{action} started at #{start_time}"
-    log
-  end
-
-
-# Severity label for logging (max 5 chars).
-  LOG_LEVEL_LABEL = %w(DEBUG INFO WARN ERROR FATAL ANY)
-    .each(&:freeze).freeze unless defined?(LOG_LEVEL_LABEL)
-
-
-  def log_level_text(log_level)
-    LOG_LEVEL_LABEL[log_level] || 'ANY'
-  end
-
-
-  def log_and_show(log, log_level, message)
-    log.add log_level, message
-    puts "#{log_level_text(log_level)}: #{message}"
-  end
-
-
-  def log_file_doesnt_exist_and_close(log, filename, start_time, end_time=Time.now)
-    log_and_show log, Logger::ERROR, "#{filename} does not exist. Nothing imported"
-    finish_and_close_log(log, start_time, end_time)
-  end
-
-
-  def log_must_provide_filename_and_close(log, usage_example, start_time, end_time=Time.now)
-    log_and_show(log, Logger::ERROR, "You must specify a .csv filename to import.\n  Ex: #{usage_example}")
-    finish_and_close_log(log, start_time, end_time)
-  end
-
-
-  def finish_and_close_log(log, start_time, end_time, action = "Import")
-    duration = (start_time - end_time) / 1.minute
-    log_and_show log, Logger::INFO, "=== #{action} finished at #{start_time}.\n"
-    log.close
-    log
-  end
-
 
   def puts_created(item_type, item_name)
     puts " #{item_type} created and saved: #{item_name}"

--- a/spec/models/activity_logger_spec.rb
+++ b/spec/models/activity_logger_spec.rb
@@ -6,15 +6,16 @@ RSpec.describe ActivityLogger do
   let(:log)      { ActivityLogger.open(filepath, 'TEST', 'open', false) }
 
   describe 'log file' do
+
+    before(:each) do
+      File.delete(filepath) if File.file?(filepath)
+    end
+
+    after(:all) do
+      File.delete(File.join(Rails.root, 'tmp', 'testfile'))
+    end
+
     context 'open without a block' do
-
-      before(:each) do
-        File.delete(filepath) if File.file?(filepath)
-      end
-
-      after(:all) do
-        File.delete(File.join(Rails.root, 'tmp', 'testfile'))
-      end
 
       it 'creates log file' do
         log
@@ -31,14 +32,6 @@ RSpec.describe ActivityLogger do
     end
 
     context 'open with a block' do
-
-      before(:each) do
-        File.delete(filepath) if File.file?(filepath)
-      end
-
-      after(:all) do
-        File.delete(File.join(Rails.root, 'tmp', 'testfile'))
-      end
 
       it 'creates log file' do
         ActivityLogger.open(filepath, 'TEST', 'open', false) do |log|

--- a/spec/models/activity_logger_spec.rb
+++ b/spec/models/activity_logger_spec.rb
@@ -44,9 +44,11 @@ RSpec.describe ActivityLogger do
         end
       end
       it 'records message to log file' do
-        log.record('info', 'this is another test message')
-        expect(File.read(filepath))
-          .to include '[TEST] [open] [info] this is another test message'
+        ActivityLogger.open(filepath, 'TEST', 'open', false) do |log|
+          log.record('info', 'this is another test message')
+          expect(File.read(filepath))
+            .to include '[TEST] [open] [info] this is another test message'
+        end
       end
     end
   end

--- a/spec/models/activity_logger_spec.rb
+++ b/spec/models/activity_logger_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe ActivityLogger do
   let(:filepath) { File.join(Rails.root, 'tmp', 'testfile') }
   let(:log)      { ActivityLogger.open(filepath, 'TEST', 'open', false) }
 
-  # open a log filename - without block
-  # assert existance of file at specific location
   describe 'log file' do
     context 'open without a block' do
 
@@ -59,8 +57,4 @@ RSpec.describe ActivityLogger do
       end
     end
   end
-
-  # open a log filename - with block
-  # assert existance of file at specific location
-
 end

--- a/spec/models/activity_logger_spec.rb
+++ b/spec/models/activity_logger_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe ActivityLogger do
+
+  let(:filepath) { File.join(Rails.root, 'tmp', 'testfile') }
+  let(:log)      { ActivityLogger.open(filepath, 'TEST', 'open', false) }
+
+  # open a log filename - without block
+  # assert existance of file at specific location
+  describe 'log file' do
+    context 'open without a block' do
+
+      before(:each) do
+        File.delete(filepath) if File.file?(filepath)
+      end
+
+      after(:all) do
+        File.delete(File.join(Rails.root, 'tmp', 'testfile'))
+      end
+
+      it 'creates log file' do
+        log
+        expect(File).to exist(filepath)
+      end
+      it 'returns instance of ActivityLogger' do
+        expect(log).to be_an_instance_of(ActivityLogger)
+      end
+      it 'records message to log file' do
+        log.record('info', 'this is a test message')
+        expect(File.read(filepath))
+          .to include '[TEST] [open] [info] this is a test message'
+      end
+    end
+
+    context 'open with a block' do
+
+      before(:each) do
+        File.delete(filepath) if File.file?(filepath)
+      end
+
+      after(:all) do
+        File.delete(File.join(Rails.root, 'tmp', 'testfile'))
+      end
+
+      it 'creates log file' do
+        ActivityLogger.open(filepath, 'TEST', 'open', false) do |log|
+          expect(File).to exist(filepath)
+        end
+      end
+      it 'returns instance of ActivityLogger' do
+        ActivityLogger.open(filepath, 'TEST', 'open', false) do |log|
+          expect(log).to be_an_instance_of(ActivityLogger)
+        end
+      end
+      it 'records message to log file' do
+        log.record('info', 'this is another test message')
+        expect(File.read(filepath))
+          .to include '[TEST] [open] [info] this is another test message'
+      end
+    end
+  end
+
+  # open a log filename - with block
+  # assert existance of file at specific location
+
+end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/145819009


Changes proposed in this pull request:
1. Refactor logging from rake tasks file to separate class
2. Fix rake task `import_membership_apps` (which had not been updated since we moved address fields from `Company` to its own model `Address`
3. Unit tests for logging class

The new class `ActivityLogger` greatly simplifies logging in the rake tasks file, and could also prove useful in other situations.

(I was going to start on story https://www.pivotaltracker.com/story/show/145192549 but realized that I wanted to finish this refactoring first).

Ready for review:
@weedySeaDragon @RobertCram