### PR TITLE
Sprint15 Ensure unique membershipapplications #145758349

### DIFF
--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -31,6 +31,7 @@ class MembershipApplication < ApplicationRecord
 
   validates_length_of :company_number, is: 10
   validates_format_of :contact_email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: [:create, :update]
+  validates_uniqueness_of :user_id, scope: :company_number
   validate :swedish_organisationsnummer
 
   accepts_nested_attributes_for :uploaded_files, allow_destroy: true

--- a/features/edit_link_on_company_page.feature
+++ b/features/edit_link_on_company_page.feature
@@ -12,14 +12,6 @@ Feature: As the owner of a company (or an admin)
       | bowser@snarkybarky.se |       | true      | 2120000142     |
       | admin@shf.se          | true  | false     |                |
 
-    And the following applications exist:
-      | first_name | user_email            | company_number | state    |
-      | Emma       | emma@happymutts.com   | 5562252998     | accepted |
-      | Lars       | lars@happymutts.com   | 5562252998     | accepted |
-      | Anna       | anna@happymutts.com   | 5562252998     | accepted |
-      | Bowser     | bowser@snarkybarky.se | 2120000142     | accepted |
-
-
   Scenario: Visitor does not see edit link for a company
     Given I am Logged out
     And I am the page for company number "5562252998"

--- a/features/show-company.feature
+++ b/features/show-company.feature
@@ -48,18 +48,14 @@ Feature: As a visitor,
       | JustForFun   |
 
     And the following applications exist:
-      | first_name | user_email          | company_number | category_name | state    |
-      | Emma       | emma@happymutts.com | 5560360793     | Groomer       | accepted |
-      | Emma       | emma@happymutts.com | 5560360793     | JustForFun    | accepted |
-      | Anna       | a@happymutts.com    | 2120000142     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 2120000142     | Trainer       | accepted |
-      | Anna       | a@happymutts.com    | 2120000142     | Rehab         | accepted |
-      | Emma       | emma@happymutts.com | 2120000142     | Psychologist  | accepted |
-      | Emma       | emma@happymutts.com | 2120000142     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 6613265393     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 6222279082     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 8025085252     | Groomer       | accepted |
-      | Anna       | member@cmpy6.com    | 6914762726     | Groomer       | accepted |
+      | first_name | user_email          | company_number | category_name           | state    |
+      | Emma       | emma@happymutts.com | 5560360793     | Groomer, JustForFun     | accepted |
+      | Anna       | a@happymutts.com    | 2120000142     | Groomer, Trainer, Rehab | accepted |
+      | Emma       | emma@happymutts.com | 2120000142     | Psychologist, Groomer   | accepted |
+      | Anna       | a@happymutts.com    | 6613265393     | Groomer                 | accepted |
+      | Anna       | a@happymutts.com    | 6222279082     | Groomer                 | accepted |
+      | Anna       | a@happymutts.com    | 8025085252     | Groomer                 | accepted |
+      | Anna       | member@cmpy6.com    | 6914762726     | Groomer                 | accepted |
 
   Scenario: Show company details to a visitor, but don't show the org nr.
     Given I am Logged out

--- a/features/show_only_complete_companies.feature
+++ b/features/show_only_complete_companies.feature
@@ -22,7 +22,6 @@ Feature: So that I do not get frustrated by trying to find out more
       | NoRegion                 | 8028973322     | hello@NoRegion.se      | ThisNameWillBeDeleted |
       |                          | 5906055081     | hello@noName.se        | Stockholm             |
 
-
     And the following users exists
       | email                        | admin |
       | admin@shf.se                 | true  |
@@ -30,24 +29,18 @@ Feature: So that I do not get frustrated by trying to find out more
       | annaTrainer@bowsers.com      |       |
       | larsGroomer@noRegionOrOld.se |       |
       | larsTrainer@noRegionOrOld.se |       |
-      | oleGroomer@noOldRegion.se    |       |
-      | oleTrainer@noOldRegion.se    |       |
-      | majaGroomer@onlyNoRegion.se  |       |
-      | majaTrainer@onlyNoRegion.se  |       |
-      | kikkiGroomer@noName.se       |       |
-      | kikkiTrainer@noName.se       |       |
+      | ole@noOldRegion.se           |       |
+      | maja@onlyNoRegion.se         |       |
+      | kikki@noName.se              |       |
 
 
     And the following applications exist:
-      | first_name   | user_email                   | company_number | category_name | state    |
-      | EmmaGroomer  | emmaGroomer@happymutts.com   | 5560360793     | Groomer       | accepted |
-      | AnnaTrainer  | annaTrainer@bowsers.com      | 2120000142     | Trainer       | accepted |
-      | OleGroomer   | oleGroomer@noOldRegion.se    | 5569467466     | Groomer       | accepted |
-      | OleTrainer   | oleTrainer@noOldRegion.se    | 5569467466     | Trainer       | accepted |
-      | MajaGroomer  | majaGroomer@onlyNoRegion.se  | 8028973322     | Groomer       | accepted |
-      | MajaTrainer  | majaTrainer@onlyNoRegion.se  | 8028973322     | Trainer       | accepted |
-      | KikkiGroomer | kikkiGroomer@noName.se       | 5906055081     | Groomer       | accepted |
-      | KikkiTrainer | kikkiTrainer@noName.se       | 5906055081     | Trainer       | accepted |
+      | first_name  | user_email                 | company_number | category_name    | state    |
+      | EmmaGroomer | emmaGroomer@happymutts.com | 5560360793     | Groomer          | accepted |
+      | AnnaTrainer | annaTrainer@bowsers.com    | 2120000142     | Trainer          | accepted |
+      | Ole         | ole@noOldRegion.se         | 5569467466     | Groomer, Trainer | accepted |
+      | Maja        | maja@onlyNoRegion.se       | 8028973322     | Groomer, Trainer | accepted |
+      | Kikki       | kikki@noName.se            | 5906055081     | Groomer, Trainer | accepted |
 
     And the region for company named "NoRegion" is set to nil
 

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -14,8 +14,11 @@ And(/^the following applications exist:$/) do |table|
                             contact_email: hash['user_email']))
     ma.state = hash['state'].to_sym if hash.has_key?('state')
    if hash['category_name']
-     category = BusinessCategory.find_by_name(hash['category_name'])
-     ma.business_categories = [category]
+     categories = []
+     for category_name in hash['category_name'].split(/\s*,\s*/)
+       categories << BusinessCategory.find_by_name(category_name)
+     end
+     ma.business_categories = categories
    end
  end
 end

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -40,25 +40,21 @@ Feature: As a visitor,
       | JustForFun   |
 
     And the following applications exist:
-      | first_name | user_email          | company_number | category_name | state    |
-      | Emma       | emma@happymutts.com | 5560360793     | Groomer       | accepted |
-      | Emma       | emma@happymutts.com | 5560360793     | JustForFun    | accepted |
-      | Anna       | a@happymutts.com    | 2120000142     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 2120000142     | Trainer       | accepted |
-      | Anna       | a@happymutts.com    | 2120000142     | Rehab         | accepted |
-      | Emma       | emma@happymutts.com | 2120000142     | Psychologist  | accepted |
-      | Emma       | emma@happymutts.com | 2120000142     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 6613265393     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 6222279082     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 8025085252     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 6914762726     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 7661057765     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 7736362901     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 6112107039     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 3609340140     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 2965790286     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 4268582063     | Groomer       | accepted |
-      | Anna       | a@happymutts.com    | 8028973322     | Groomer       | accepted |
+      | first_name | user_email          | company_number | category_name           | state    |
+      | Emma       | emma@happymutts.com | 5560360793     | Groomer, JustForFun     | accepted |
+      | Anna       | a@happymutts.com    | 2120000142     | Groomer, Trainer, Rehab | accepted |
+      | Emma       | emma@happymutts.com | 2120000142     | Psychologist, Groomer   | accepted |
+      | Anna       | a@happymutts.com    | 6613265393     | Groomer                 | accepted |
+      | Anna       | a@happymutts.com    | 6222279082     | Groomer                 | accepted |
+      | Anna       | a@happymutts.com    | 8025085252     | Groomer                 | accepted |
+      | Anna       | a@happymutts.com    | 6914762726     | Groomer                 | accepted |
+      | Anna       | a@happymutts.com    | 7661057765     | Groomer                 | accepted |
+      | Anna       | a@happymutts.com    | 7736362901     | Groomer                 | accepted |
+      | Anna       | a@happymutts.com    | 6112107039     | Groomer                 | accepted |
+      | Anna       | a@happymutts.com    | 3609340140     | Groomer                 | accepted |
+      | Anna       | a@happymutts.com    | 2965790286     | Groomer                 | accepted |
+      | Anna       | a@happymutts.com    | 4268582063     | Groomer                 | accepted |
+      | Anna       | a@happymutts.com    | 8028973322     | Groomer                 | accepted |
 
   @javascript
   Scenario: Visitor sees all companies

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,8 +18,15 @@ FactoryGirl.define do
     end
 
     factory :user_with_2_membership_apps do
+
+      transient do
+        company_number1 5712213304
+        company_number2 5562728336
+      end
+
       after(:create) do |user, evaluator|
-        create_list(:membership_application, 2, user: user, contact_email: evaluator.email, company_number: evaluator.company_number)
+        create(:membership_application, user: user, contact_email: evaluator.email, company_number: evaluator.company_number1)
+        create(:membership_application, user: user, contact_email: evaluator.email, company_number: evaluator.company_number2)
       end
 
     end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/145758349


**Changes proposed in this pull request:**
1.  Add a validation that enforces the business rule that a membership application (MA) is unique, and only one such MA record should exist (for a user and a company)

**Discussion**

1. I would like to rename the "category_name" header in the background data to "categories" to make it clear that there's a one to many relation between a MA and business categories, and we're not just setting an attribute. I haven't done so yet, because it would involve changing features that are not otherwise affected by the uniqueness validation, and I wanted to keep this PR clean.

2. The rails uniqueness validation doesn't guarantee keeping all duplicates out (because of a possible race condition). To absolutely prevent duplicates a unique index must be added to the table. I'm not sure that's necessary in this case where we only use the uniqueness validation te keep ourselves honest.

Ready for review:
@patmbolger @weedySeaDragon @thesuss 