### PR TITLE
CSV export: business categories can be output in any order (change spec)

### DIFF
--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe AdminController, type: :controller do
 
           # get the categories from the (.*) group -- if there are any
           #   get rid of extra quotes and whitespace
-          match.to_a.count > 1 ? categories = match[1].gsub('"','').split(',').map(&:strip) : categories = []
+          match.to_a.size > 1 ? categories = match[1].delete('"').split(',').map(&:strip) : categories = []
 
           # expect all categories to be there, but could be in any order
           expect(categories).to match_array(['Category1', 'Category 2', 'Category the third'])

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -226,19 +226,28 @@ RSpec.describe AdminController, type: :controller do
 
           member1.save
 
-          result_str = csv_header
+          result_str_start = csv_header
+          result_str_start << member1_info
 
-          result_str << member1_info + ','
+          result_str_end = '"' + c1.name + '"' +','
+          result_str_end << c1.se_mailing_csv_str + "\n"
 
-          result_str << '"Category1, Category 2, Category the third",'
+          result_regexp = Regexp.new(/^#{result_str_start},(.*),#{result_str_end}$/)
 
-          result_str << '"' + c1.name + '"' +','
+          # results without the categories:
+          expect(csv_response).to match result_regexp
 
-          result_str << c1.se_mailing_csv_str + "\n"
 
-          expect(csv_response).to match result_str
+          # Check that the categories are as expected:
+          match = csv_response.match result_regexp
+
+          # get the categories from the (.*) group -- if there are any
+          #   get rid of extra quotes and whitespace
+          match.to_a.count > 1 ? categories = match[1].gsub('"','').split(',').map(&:strip) : categories = []
+
+          # expect all categories to be there, but could be in any order
+          expect(categories).to match_array(['Category1', 'Category 2', 'Category the third'])
         end
-
 
       end
 


### PR DESCRIPTION
**Change the RSpec to allow `business categories` to be output in any order when exporting info to a CSV file.**

PT Story:  https://www.pivotaltracker.com/story/show/146177407

Changes proposed in this pull request:
1.  Changed the spec:  checked the expected result for everything before and after the business categories, then checked that all of the expected business categories were output -- allowing for them to be in any order


Ready for review:
@patmbolger @RobertCram @thesuss 
