### PR TITLE
Get production logs working again (remove 'rails12_factor' gem)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,3 @@ end
 group :test do
   gem 'poltergeist'
 end
-
-group :production do
-  gem 'rails_12factor'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,11 +271,6 @@ GEM
       nokogiri (~> 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.0.1)
       actionpack (= 5.0.1)
       activesupport (= 5.0.1)
@@ -436,7 +431,6 @@ DEPENDENCIES
   pundit-matchers
   railroady
   rails (~> 5.0.0, >= 5.0.0.1)
-  rails_12factor
   rake
   ransack
   rb-readline


### PR DESCRIPTION
PT Story:  https://www.pivotaltracker.com/story/show/145940689


Changes proposed in this pull request:
1.  removed` rails12_factor gem`


Ready for review:
@patmbolger 
