### PR TITLE
Fix AdminPolicy spec: set the roles correctly before testing the policy

### DIFF
--- a/spec/policies/admin_policy_spec.rb
+++ b/spec/policies/admin_policy_spec.rb
@@ -13,15 +13,8 @@ RSpec.describe AdminPolicy do
 
   end
 
-  describe 'For a member that is a part of a company' do
-    let(:members_company) { Company.find_by_company_number('5562728336')}
-    subject { described_class.new(members_company).authorized? }
 
-    it { is_expected.to be_falsey }
-
-  end
-
-  describe 'For a member that is not part of a company' do
+  describe 'For a member' do
     subject { described_class.new(member).authorized? }
 
     it { is_expected.to be_falsey }

--- a/spec/policies/admin_policy_spec.rb
+++ b/spec/policies/admin_policy_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe AdminPolicy do
 
   describe 'For a member that is a part of a company' do
     let(:members_company) { Company.find_by_company_number('5562728336')}
-    subject { described_class.new(member).authorized? }
+    subject { described_class.new(members_company).authorized? }
 
     it { is_expected.to be_falsey }
 

--- a/spec/policies/admin_policy_spec.rb
+++ b/spec/policies/admin_policy_spec.rb
@@ -15,30 +15,30 @@ RSpec.describe AdminPolicy do
 
   describe 'For a member that is a part of a company' do
     let(:members_company) { Company.find_by_company_number('5562728336')}
-    subject { described_class.new(admin).authorized? }
+    subject { described_class.new(member).authorized? }
 
-    it { is_expected.to be_truthy }
+    it { is_expected.to be_falsey }
 
   end
 
   describe 'For a member that is not part of a company' do
-    subject { described_class.new(admin).authorized? }
+    subject { described_class.new(member).authorized? }
 
-    it { is_expected.to be_truthy }
+    it { is_expected.to be_falsey }
 
   end
 
   describe 'For a user (logged in)' do
-    subject { described_class.new(admin).authorized? }
+    subject { described_class.new(user_1).authorized? }
 
-    it { is_expected.to be_truthy }
+    it { is_expected.to be_falsey }
 
   end
 
   describe 'For a visitor (not logged in)' do
-    subject { described_class.new(admin).authorized? }
+    subject { described_class.new(nil).authorized? }
 
-    it { is_expected.to be_truthy }
+    it { is_expected.to be_falsey }
 
   end
 end


### PR DESCRIPTION
PT Story:  https://www.pivotaltracker.com/story/show/146118515


Changes proposed in this pull request:
1.  fix the spec so that the correct roles are actually tested

Ready for review:
@patmbolger  @RobertCram
