### PR TITLE
rake missing translations check: add 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,8 @@ group :development, :test do
   gem 'better_errors'
   gem 'binding_of_caller'  # needed to make better_errors work well
 
+  gem 'i18n-tasks'
+
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
     airbrussh (1.1.2)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (7.1.4)
+    ast (2.3.0)
     autoprefixer-rails (6.7.2)
       execjs
     backup (3.4.0)
@@ -151,6 +152,10 @@ GEM
     dotenv-rails (2.2.0)
       dotenv (= 2.2.0)
       railties (>= 3.2, < 5.1)
+    easy_translate (0.5.0)
+      json
+      thread
+      thread_safe
     erb2haml (0.1.5)
       html2haml
     erubis (2.7.0)
@@ -177,6 +182,7 @@ GEM
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
     high_voltage (3.0.0)
+    highline (1.7.8)
     html2haml (2.1.0)
       erubis (~> 2.7.0)
       haml (~> 4.0)
@@ -185,6 +191,16 @@ GEM
     i18n (0.8.0)
     i18n-js (3.0.0.rc15)
       i18n (~> 0.6, >= 0.6.6)
+    i18n-tasks (0.9.9)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      easy_translate (>= 0.5.0)
+      erubis
+      highline (>= 1.7.3)
+      i18n
+      parser (>= 2.2.3.0)
+      term-ansicolor (>= 1.3.2)
+      terminal-table (>= 1.5.1)
     jbuilder (2.6.1)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -229,6 +245,8 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (~> 0.3.0)
+    parser (2.3.3.1)
+      ast (~> 2.2)
     pg (0.19.0)
     poltergeist (1.13.0)
       capybara (~> 2.1)
@@ -357,7 +375,10 @@ GEM
       net-ssh (>= 2.8.0)
     term-ansicolor (1.4.0)
       tins (~> 1.0)
+    terminal-table (1.7.3)
+      unicode-display_width (~> 1.1.1)
     thor (0.19.4)
+    thread (0.2.2)
     thread_safe (0.3.5)
     tilt (2.0.6)
     timecop (0.8.1)
@@ -369,6 +390,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.1.3)
     uniform_notifier (1.10.0)
     warden (1.2.7)
       rack (>= 1.0)
@@ -422,6 +444,7 @@ DEPENDENCIES
   haml-rails
   high_voltage (~> 3.0.0)
   i18n-js (>= 3.0.0.rc11)
+  i18n-tasks
   jbuilder (~> 2.5)
   jquery-rails
   launchy

--- a/app/views/membership_applications/_membership_application_fields.html.haml
+++ b/app/views/membership_applications/_membership_application_fields.html.haml
@@ -13,7 +13,7 @@
 
     = f.label :company_number, t('membership_applications.show.company_number'), class: 'required'
     = f.number_field :company_number, class: 'wpcf7-form-control'
-    %p.field-instruction= t('companies.org_nr_no_hyphens')
+    %p.field-instruction= t('membership_applications.show.org_nr_no_hyphens')
 
 
     = f.label :contact_email, t('membership_applications.show.contact_email'), class: 'required'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -17,9 +17,10 @@ data:
   # Locale files or `File.find` patterns where translations are read from:
   read:
     ## Default:
-    # - config/locales/%{locale}.yml
+    - config/locales/%{locale}.yml
+    - config/locales/devise.%{locale}.yml
     ## More files:
-    # - config/locales/**/*.%{locale}.yml
+    # - config/locales/*.%{locale}.yml
     ## Another gem (replace %#= with %=):
     # - "<%#= %x[bundle show vagrant].chomp %>/templates/locales/%{locale}.yml"
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,138 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+base_locale: sv
+
+## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
+# locales: [es, fr]
+## Reporting locale, default: en. Available: en, ru.
+# internal_locale: en
+
+# Read and write translations.
+data:
+  ## Translations are read from the file system. Supported format: YAML, JSON.
+  ## Provide a custom adapter:
+  # adapter: I18n::Tasks::Data::FileSystem
+
+  # Locale files or `File.find` patterns where translations are read from:
+  read:
+    ## Default:
+    # - config/locales/%{locale}.yml
+    ## More files:
+    # - config/locales/**/*.%{locale}.yml
+    ## Another gem (replace %#= with %=):
+    # - "<%#= %x[bundle show vagrant].chomp %>/templates/locales/%{locale}.yml"
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+    ## For example, write devise and simple form keys to their respective files:
+    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
+    ## Catch-all default:
+    # - config/locales/%{locale}.yml
+
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
+  # router: convervative_router
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+  ## Pretty-print JSON:
+  # json:
+  #   write:
+  #     indent: '  '
+  #     space: ' '
+  #     object_nl: "\n"
+  #     array_nl: "\n"
+
+# Find translate calls
+search:
+  ## Paths or `File.find` patterns to search in:
+  paths:
+    - app/
+    - "app/controllers"
+    - "app/helpers"
+    - "app/presenters"
+    - "app/views"
+
+
+  ## Root directories for relative keys resolution.
+  # relative_roots:
+  #   - app/controllers
+  #   - app/helpers
+  #   - app/mailers
+  #   - app/presenters
+  #   - app/views
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  ##   %w(*.jpg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less *.yml *.json)
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+    - app/assets/videos
+
+  ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
+  ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
+  # only: ["*.rb", "*.html.slim"]
+
+  ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
+  # strict: true
+
+  ## Multiple scanners can be used. Their results are merged.
+  ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
+  ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example
+
+## Google Translate
+# translation:
+#   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
+#   api_key: "AbC-dEf5"
+
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+
+
+## Consider these keys used:
+ignore_unused:
+# - '{devise,kaminari,will_paginate}.*'
+# - 'simple_form.{yes,no}'
+# - 'simple_form.{placeholders,hints,labels}.*'
+# - 'simple_form.{error_notification,required}.:'
+  - activerecord.*
+  - date.*
+  - simple_form.*
+  - time.*
+  - errors.*
+  - datetime.*
+  - number.*
+  - support.*
+  - ckeditor.*
+
+
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*
+
+## Sometimes, it isn't possible for i18n-tasks to match the key correctly,
+## e.g. in case of a relative key defined in a helper method.
+## In these cases you can use the built-in PatternMapper to map patterns to keys, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       only: %w(*.html.haml *.html.slim),
+#       patterns: [['= title\b', '.page_title']] %>
+#
+# The PatternMapper can also match key literals via a special %{key} interpolation, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -56,6 +56,7 @@ search:
     - "app/helpers"
     - "app/presenters"
     - "app/views"
+    - features
 
 
   ## Root directories for relative keys resolution.

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -18,13 +18,13 @@ en:
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: "SHF Confirmation instructions"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "SHF Reset password instructions"
       unlock_instructions:
-        subject: "Unlock instructions"
+        subject: "SHF Unlock instructions"
       password_change:
-        subject: "Password Changed"
+        subject: "SHF Password Changed"
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."

--- a/config/locales/devise.sv.yml
+++ b/config/locales/devise.sv.yml
@@ -16,11 +16,13 @@ sv:
       unconfirmed: "Du måste bekräfta ditt konto innan du kan fortsätta."
     mailer:
       confirmation_instructions:
-        subject: "Instruktioner för att bekräfta konto"
+        subject: "SHF Instruktioner för att bekräfta konto"
       reset_password_instructions:
-        subject: "Instrukionter för att återställa lösenord"
+        subject: "SHF Instrukionter för att återställa lösenord"
       unlock_instructions:
         subject: "Instruktioner för att låsa up konto"
+      password_change:
+        subject: "SHF Lösenordet ändrat"
     omniauth_callbacks:
       failure: "Kunde inte autentisera dig med %{kind} för \"%{reason}\"."
       success: "Autentiserat med %{kind}-konto."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,6 +206,7 @@ en:
       last_name: *last_name
       phone_number: Phone number
       company_number: *company_number
+      org_nr_no_hyphens: &orgnr_no_hyphen  "Numbers only (no hyphens)"
       contact_email: *contact_email
 
       can_be_same_email: Can be the same that you logged in with, but need not be.
@@ -229,6 +230,7 @@ en:
       title: Edit Membership Application
       is_ready_for_review: Is Ready for Review
       submit_button_label: *save
+      org_nr_no_hyphens: *orgnr_no_hyphen
 
     update:
       success: The application was updated.
@@ -241,6 +243,7 @@ en:
       last_name: *last_name
       phone_number: Phone number
       company_number: *company_number
+      org_nr_no_hyphens: *orgnr_no_hyphen
       contact_email: *contact_email
       app_status: Application status
       change_status: Change the status

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -208,6 +208,7 @@ sv:
       last_name: *last_name
       phone_number: &phone_number Telefonnummer
       company_number: *company_number
+      org_nr_no_hyphens: &orgnr_no_hyphen "Endast siffror (ej bindestreck)"
       contact_email: *contact_email
 
       can_be_same_email: Kan vara samma som du loggar in med, men behöver inte vara det.
@@ -231,6 +232,7 @@ sv:
       title: Redigera ansökan om medlemskap
       is_ready_for_review: Redo för granskning
       submit_button_label: *save
+      org_nr_no_hyphens: *orgnr_no_hyphen
 
     update:
       success: Ansökan har uppdaterats.
@@ -243,6 +245,7 @@ sv:
       last_name: *last_name
       phone_number: *phone_number
       company_number: *company_number
+      org_nr_no_hyphens: *orgnr_no_hyphen
       contact_email: *contact_email
       app_status: Ansökans status
       change_status: Ändra status

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -208,7 +208,8 @@ Feature: As an Admin
   @admin
   Scenario: Admin cannot change from 'waiting for applicant' to 'waiting for applicant'
     Given I am on "AnnaWaiting" application page
-    Then I should not see button t("membership_applications.ask_applicant_for_info_btn")
+    Then I should not see t("membership_applications.ask_applicant_for_info_btn")
+
 
   @admin
   Scenario: 'Waiting for applicant' status is not changed if admin edits the application

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -203,12 +203,12 @@ Feature: As an Admin
   @admin
   Scenario: Admin cannot change from 'waiting for applicant' to accepted
     Given I am on "AnnaWaiting" application page
-    Then I should not see button t("membership_applications.accepted_btn")
+    Then I should not see button t("membership_applications.accept_btn")
 
   @admin
   Scenario: Admin cannot change from 'waiting for applicant' to 'waiting for applicant'
     Given I am on "AnnaWaiting" application page
-    Then I should not see button t("membership_applications.waiting_for_applicant_btn")
+    Then I should not see button t("membership_applications.ask_applicant_for_info_btn")
 
   @admin
   Scenario: 'Waiting for applicant' status is not changed if admin edits the application
@@ -244,7 +244,7 @@ Feature: As an Admin
   @admin
   Scenario: Admin cannot change from accepted to 'waiting for applicant'
     Given I am on "NilsAccepted" application page
-    Then I should not see button t("membership_applications.waiting_for_applicant_btn")
+    Then I should not see button t("membership_applications.ask_applicant_for_info_btn")
     Then I should not see button t("membership_applications.accept_btn")
     And I should not see button t("membership_applications.ask_applicant_for_info_btn")
     And I should not see button t("membership_applications.cancel_waiting_for_applicant_btn")
@@ -284,7 +284,7 @@ Feature: As an Admin
   @admin
   Scenario: Admin cannot change from rejected to 'waiting for applicant'
     Given I am on "LarsRejected" application page
-    Then I should not see button t("membership_applications.waiting_for_applicant_btn")
+    Then I should not see button t("membership_applications.ask_applicant_for_info_btn")
 
   @admin
   Scenario: Admin changed from rejected to accepted

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'i18n/tasks'
+
+RSpec.describe 'I18n' do
+  let(:i18n) { I18n::Tasks::BaseTask.new }
+  let(:missing_keys) { i18n.missing_keys }
+  #let(:unused_keys) { i18n.unused_keys }
+
+  it 'does not have missing keys' do
+    expect(missing_keys).to be_empty,
+                            "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+  end
+
+  #it 'does not have unused keys' do
+  #  expect(unused_keys).to be_empty,
+  #                         "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+  #end
+end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/136536743

[Per a  thoughtbot blog post](https://robots.thoughtbot.com/how-to-find-missing-or-unused-i18n-translations) adding a spec test that will run `i18n-tasks` is a good and easy way to add it to the default rake task (which runs /spec tests).


Changes proposed in this pull request:
1.  added the `i18n-tasks` gem
2. added the config file for i18n-tasks
3. added a spec that will runs the i18n-task to check for missing translations (copied from the template provided by the gem)

Ready for review:
@patmbolger @RobertCram @thesuss 
