### PR TITLE
Add waiting_for_payment state and possible transitions

### DIFF
--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -130,6 +130,17 @@ class MembershipApplicationsController < ApplicationController
     simple_state_change(:cancel_waiting_for_applicant!, t('.success'), t('.error'))
   end
 
+  def need_payment
+    simple_state_change(:ask_for_payment!, t('.success'), t('.error'))
+  end
+
+  def cancel_need_payment
+    simple_state_change(:cancel_waiting_for_payment!, t('.success'), t('.error'))
+  end
+
+  def received_payment
+    simple_state_change(:received_payment!, t('.success'), t('.error'))
+  end
 
   private
   def membership_application_params

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -46,6 +46,7 @@ class MembershipApplication < ApplicationRecord
     state :under_review
     state :waiting_for_applicant
     state :ready_for_review
+    state :waiting_for_payment
     state :accepted
     state :rejected
 
@@ -65,6 +66,18 @@ class MembershipApplication < ApplicationRecord
 
     event :is_ready_for_review do
       transitions from: :waiting_for_applicant, to: :ready_for_review
+    end
+
+    event :ask_for_payment do
+      transitions from: :under_review, to: :waiting_for_payment
+    end
+
+    event :cancel_waiting_for_payment do
+      transitions from: :waiting_for_payment, to: :under_review
+    end
+
+    event :received_payment do
+      transitions from: :waiting_for_payment, to: :accepted, after: :accept_membership
     end
 
     event :accept do

--- a/app/views/membership_applications/_application_status_form.html.haml
+++ b/app/views/membership_applications/_application_status_form.html.haml
@@ -13,6 +13,12 @@
 
   = button_to t('membership_applications.cancel_waiting_for_applicant_btn'), cancel_need_info_membership_application_path(@membership_application), {class: 'btn cancel-need-info', disabled: !(@membership_application.may_cancel_waiting_for_applicant?)}
 
+  = button_to t('membership_applications.ask_applicant_for_payment_btn'), need_payment_membership_application_path(@membership_application), {class: 'btn need-payment', disabled: !(@membership_application.may_ask_for_payment?)}
+
+  = button_to t('membership_applications.cancel_waiting_for_payment_btn'), cancel_need_payment_membership_application_path(@membership_application), {class: 'btn cancel_need-payment', disabled: !(@membership_application.may_cancel_waiting_for_payment?)}
+
+  = button_to t('membership_applications.received_payment_btn'), received_payment_membership_application_path(@membership_application), {class: 'btn received-payment', disabled: !(@membership_application.may_received_payment?)}
+
 %br
   - if !@membership_application.paid?
     %p= t('membership_applications.show.waiting_for_payment')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -306,6 +306,18 @@ en:
       success: The application has been changed to no longer needing information from the applicant.
       error: "There was an error when trying to set the application to 'no longer needing information from the applicant.'"
 
+    need_payment:
+      success: 'The application has been marked as waiting for payment. (Send email to the applicant.)'
+      error: "There was an error when trying to set the application to 'waiting for payment.'"
+
+    received_payment:
+      success: The membership has been approved.
+      error: There was an error when trying to approve the membership.
+
+    cancel_need_payment:
+      success: The application has been changed to no longer needing payment from the applicant.
+      error: "There was an error when trying to set the application to 'no longer needing payment from the applicant.'"
+
     is_ready_for_review:
       success: Your application has been submitted for another review.
       error: There was an error when trying to submit your application for another review.
@@ -313,7 +325,8 @@ en:
     state:
       new: &status_new New
       under_review: &status_under_review Under Review
-      waiting_for_applicant: &status_waiting_for_applicant  Waiting for applicant
+      waiting_for_applicant: &status_waiting_for_applicant Waiting for applicant
+      waiting_for_payment: &status_waiting_for_payment Waiting for payment
       ready_for_review: &status_ready_for_review Ready For Review
       accepted: &status_accepted Accepted
       rejected: &status_rejected Rejected
@@ -329,6 +342,10 @@ en:
     cancel_waiting_for_applicant_btn: Cancel Waiting for Applicant Info
     waiting_for_applicant: *status_waiting_for_applicant
     applicant_updated_info: &event_applicant_updated_info Applicant Updated Info
+    ask_applicant_for_payment_btn: Ask Applicant for Payment
+    cancel_waiting_for_payment_btn: Cancel Waiting for Payment
+    received_payment_btn: Received Payment
+    waiting_for_payment: *status_waiting_for_payment
     ready_for_review: *status_ready_for_review
     start_review_btn: Start Reviewing
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -307,6 +307,18 @@ sv:
       success: Ansökan har ändrats och behöver ej längre kompletteras av sökande.
       error: 'Det uppstod ett fel när systemet försökte ångra status: "Behöver kompletteras".'
 
+    need_payment:
+      success: 'Ansökan har markerats som: "Behöver betalning". (Skicka e-post till den sökande.)'
+      error: 'Det uppstod ett fel när systemet försökte sätta status: "Behöver betalning".'
+
+    received_payment:
+      success: Medlemsansökan har godkänts.
+      error: Det uppstod ett fel vid godkännande av medlemskap.
+
+    cancel_need_payment:
+      success: Ansökan har ändrats och behöver ej längre betalas av sökande.
+      error: 'Det uppstod ett fel när systemet försökte ångra status: "Behöver betalning".'
+
     is_ready_for_review:
       success: Din ansökan har lämnats in för omgranskning.
       error: Det uppstod ett fel när du försöker att skicka in din ansökan för omgranskning.
@@ -315,6 +327,7 @@ sv:
       new: &status_new Ny
       under_review: &status_under_review Behandlas
       waiting_for_applicant: &status_waiting_for_applicant  Väntar på sökande
+      waiting_for_payment: &status_waiting_for_payment Väntar på betalning
       ready_for_review: &status_ready_for_review Redo för granskning
       accepted: &status_accepted Godkänd
       rejected: &status_rejected Avböjd
@@ -330,6 +343,10 @@ sv:
     cancel_waiting_for_applicant_btn: Ångra Behöver kompletteras
     waiting_for_applicant: *status_waiting_for_applicant
     applicant_updated_info: &event_applicant_updated_info Sökanden har kompletterat sin ansökan
+    ask_applicant_for_payment_btn: Behöver betalning
+    cancel_waiting_for_payment_btn: Ångra Behöver betalning
+    received_payment_btn: Fick betalning
+    waiting_for_payment: *status_waiting_for_payment
     ready_for_review: *status_ready_for_review
     start_review_btn: Påbörja granskning
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -348,7 +348,7 @@ sv:
     applicant_updated_info: &event_applicant_updated_info Sökanden har kompletterat sin ansökan
     ask_applicant_for_payment_btn: Behöver betalning
     cancel_waiting_for_payment_btn: Ångra Behöver betalning
-    received_payment_btn: Fick betalning
+    received_payment_btn: Betalning inkommen
     waiting_for_payment: *status_waiting_for_payment
     ready_for_review: *status_ready_for_review
     start_review_btn: Påbörja granskning

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,12 @@ Rails.application.routes.draw do
         post 'need-info', to: 'membership_applications#need_info'
         get 'cancel-need-info', to: 'membership_applications#show'
         post 'cancel-need-info', to: 'membership_applications#cancel_need_info'
+        get 'need-payment', to: 'membership_applications#show'
+        post 'need-payment', to: 'membership_applications#need_payment'
+        get 'cancel-need-payment', to: 'membership_applications#show'
+        post 'cancel-need-payment', to: 'membership_applications#cancel_need_payment'
+        get 'received-payment', to: 'membership_applications#show'
+        post 'received-payment', to: 'membership_applications#received_payment'
 
       end
 

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -10,6 +10,7 @@ Feature: As an Admin
       | applicant_2@random.com                 |       |
       | emma_under_review@happymutts.se        |       |
       | hans_under_review@happymutts.se        |       |
+      | lars_waiting_for_payment@happymutts.se |       |
       | anna_waiting_for_info@nosnarkybarky.se |       |
       | nils_member@bowwowwow.se               |       |
       | lars_rejected@snarkybark.se            |       |
@@ -28,12 +29,13 @@ Feature: As an Admin
 
 
     And the following applications exist:
-      | first_name      | user_email                             | company_number | category_name | state                 |
-      | EmmaUnderReview | emma_under_review@happymutts.se        | 5562252998     | rehab         | under_review          |
-      | HansUnderReview | hans_under_review@happymutts.se        | 5562252998     | dog grooming  | under_review          |
-      | AnnaWaiting     | anna_waiting_for_info@nosnarkybarky.se | 5560360793     | rehab         | waiting_for_applicant |
-      | LarsRejected    | lars_rejected@snarkybark.se            | 0000000000     | rehab         | rejected              |
-      | NilsAccepted    | nils_member@bowwowwow.se               | 0000000000     | dog crooning  | accepted              |
+      | first_name            | user_email                             | company_number | category_name | state                 |
+      | EmmaUnderReview       | emma_under_review@happymutts.se        | 5562252998     | rehab         | under_review          |
+      | HansUnderReview       | hans_under_review@happymutts.se        | 5562252998     | dog grooming  | under_review          |
+      | AnnaWaiting           | anna_waiting_for_info@nosnarkybarky.se | 5560360793     | rehab         | waiting_for_applicant |
+      | LarsRejected          | lars_rejected@snarkybark.se            | 0000000000     | rehab         | rejected              |
+      | NilsAccepted          | nils_member@bowwowwow.se               | 0000000000     | dog crooning  | accepted              |
+      | LarsWaitingForPayment | lars_waiting_for_payment@happymutts.se | 0000000000     | dog crooning  | waiting_for_payment   |
 
     And I am logged in as "admin@shf.se"
     And time is frozen at 2016-12-16
@@ -145,6 +147,21 @@ Feature: As an Admin
     And I should not see "image.png"
     And I should see "rehab"
 
+  @admin
+  Scenario: Admin changed from under_review to waiting_for_payment
+    Given I am on "EmmaUnderReview" application page
+    Then I should see "rehab"
+    When I click on t("membership_applications.ask_applicant_for_payment_btn")
+    Then I should see t("membership_applications.need_payment.success")
+    And I should see status line with status t("membership_applications.waiting_for_payment")
+    And I should not see t("membership_applications.update.enter_member_number")
+    And I should see "rehab"
+    When I am on the "landing" page
+    Then I should see 1 t("membership_applications.waiting_for_applicant")
+    And I should see 2 t("membership_applications.waiting_for_payment")
+    And I should see 1 t("membership_applications.under_review")
+    And I should see 1 t("membership_applications.rejected")
+    And I should see 1 t("membership_applications.accepted")
 
   # From waiting for applicant to...
   @member
@@ -220,6 +237,30 @@ Feature: As an Admin
     And I should see status line with status t("membership_applications.waiting_for_applicant")
     And I should not see status line with status t("membership_applications.under_review")
 
+
+  # From waiting_for_payment to...
+  Scenario: Admin changed waiting_for_payment to under_review
+    Given I am on "LarsWaitingForPayment" application page
+    And I click on t("membership_applications.cancel_waiting_for_payment_btn")
+    Then I should see t("membership_applications.cancel_need_payment.success")
+    And I should see status line with status t("membership_applications.under_review")
+    When I am on the "landing" page
+    And I should see 3 t("membership_applications.under_review")
+    And I should see 0 t("membership_applications.waiting_for_payment")
+    And I should see 1 t("membership_applications.rejected")
+    And I should see 1 t("membership_applications.accepted")
+
+  Scenario: Admin changed waiting_for_payment to accepted
+    Given I am on "LarsWaitingForPayment" application page
+    And I click on t("membership_applications.received_payment_btn")
+    Then I should see t("membership_applications.received_payment.success")
+    And I should see status line with status t("membership_applications.accepted")
+    When I am on the "landing" page
+    And I should see 0 t("membership_applications.ready_for_review")
+    And I should see 2 t("membership_applications.under_review")
+    And I should see 0 t("membership_applications.waiting_for_payment")
+    And I should see 1 t("membership_applications.rejected")
+    And I should see 2 t("membership_applications.accepted")
 
   # From accepted to...
   @admin


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/146016481


**Changes proposed in this pull request:**

1. Add a waiting_for_payment state and its possible transitions to the MembershipApplication


** Discussion **

1. Implementing it this way is no problem if the payment phase always comes AFTER the review phase. If payment is also possible during the review phase we should rethink this.

2. In the pivotal tracker story, the "received_payment" event would effect a transition from "waiting_for_payment" to "ready_for_review". That opened up the possibility of entering the "waiting_for_payment" state twice. I think a better option would be to either a) transition to "accepted" immediately, or -if absolutely needed-  b) to introduce a new intermediate state "ready_for_acceptance". I've implemented a).

3. At the moment it is possible to transition from "rejected" to "accepted". I'm not sure what the use case is for this, and therefore not sure how to include the "waiting_for_payment" state there. But it probably should be.

4. I don't speak Swedish, so I would appreciate it if someone who does could check my "translations".


Ready for review:
@thesuss @weedySeaDragon @patmbolger 