### PR TITLE
Companies index view - only one category shown for each company #146879127

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 # Ignore Byebug command history file.
 .byebug_history
 
+# Ignore prior ruby version files (RVM)
+.ruby-version.*
+
 # Ignore Coveralls report results
 coverage/
 

--- a/app/views/companies/_companies_list.html.haml
+++ b/app/views/companies/_companies_list.html.haml
@@ -26,7 +26,7 @@
         %tr.company
           %td{ style: 'white-space: nowrap;' }
             - first = true
-            - company.business_categories.sort_by(&:name).uniq.each do | bc |
+            - company.business_categories.order(:name).distinct.each do | bc |
               - if first
                 - first = false
                 = bc.name

--- a/features/search_companies.feature
+++ b/features/search_companies.feature
@@ -41,11 +41,11 @@ Background:
     | We Luv Dogs | 5569467466     | alpha@weluvdogs.com  | Sweden       | Laxå      |
 
   And the following applications exist:
-    | first_name | user_email          | company_number | state    | categories   |
-    | Fred       | fred@barkyboys.com  | 5560360793     | accepted | Groomer      |
-    | John       | john@happymutts.com | 2120000142     | accepted | Psychologist |
-    | Anna       | anna@dogsrus.com    | 5562252998     | accepted | Trainer      |
-    | Emma       | emma@weluvdogs.com  | 5569467466     | accepted | Groomer      |
+    | first_name | user_email          | company_number | state    | categories      |
+    | Fred       | fred@barkyboys.com  | 5560360793     | accepted | Groomer, Trainer|
+    | John       | john@happymutts.com | 2120000142     | accepted | Psychologist    |
+    | Anna       | anna@dogsrus.com    | 5562252998     | accepted | Trainer         |
+    | Emma       | emma@weluvdogs.com  | 5569467466     | accepted | Groomer, Walker |
 
 @javascript
 Scenario: View all companies, sort by columns
@@ -82,6 +82,9 @@ Scenario: Search by category
   And I should see "We Luv Dogs"
   And I should not see "HappyMutts"
   And I should not see "Dogs R Us"
+  And I should see "Trainer"
+  And I should see "Walker"
+  And I should not see "Psychologist"
 
 @javascript
 Scenario: Search by region


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/146879127


Changes proposed in this pull request:
1. Perform order (sorting) and distinct selection in DB instead of in array
2. Added a rule to .gitignore to ignore ruby-version files created by RVM.

In the view, changed business categories prep to use in-DB ordering and unique selection.

The prior statement produced a single BC even with a company that had multiple BC's.

This is also probably a bit faster, as the BC collection has not yet been fetched from the DB.  That is, at the time of the statement, `company.business_categories` is still of Class `BusinessCategory::ActiveRecord_Associations_CollectionProxy`.


Screenshots (Optional):

Ready for review:
@weedySeaDragon @RobertCram 