### PR TITLE
Clean up how current_user is used

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,4 +35,8 @@ class ApplicationController < ActionController::Base
     flash[:alert] = t('errors.not_permitted')
     redirect_back(fallback_location: root_path)
   end
+
+  def current_user
+    super || Visitor.new
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,12 @@ class ApplicationController < ActionController::Base
     redirect_back(fallback_location: root_path)
   end
 
-  def current_user
+  def current_user  # Override Devise helper method (controller instance method)
     super || Visitor.new
+  end
+
+  def user_signed_in?  # Override Devise helper method
+    return false if current_user.is_a? Visitor
+    true
   end
 end

--- a/app/helpers/companies_helper.rb
+++ b/app/helpers/companies_helper.rb
@@ -94,7 +94,7 @@ module CompaniesHelper
                    { name: 'kommun', label: 'kommun', method: 'name' },
                    { name: 'region', label: 'region', method: 'name' } ]
 
-    if user&.admin? || user&.is_in_company_numbered?(company.company_number)
+    if user.admin? || user.is_in_company_numbered?(company.company_number)
       return all_fields, true
     else
       start_index = all_fields.find_index do |field|

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -23,4 +23,8 @@ class Visitor
   def has_company?
     false
   end
+
+  def is_in_company_numbered?(_company_number_)
+    false
+  end
 end

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -1,9 +1,5 @@
 class Visitor
 
-  def is_admin?
-    false
-  end
-
   def admin?
     false
   end

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -1,0 +1,26 @@
+class Visitor
+
+  def is_admin?
+    false
+  end
+
+  def admin?
+    false
+  end
+
+  def is_member?
+    false
+  end
+
+  def is_member_or_admin?
+    false
+  end
+
+  def has_membership_application?
+    false
+  end
+
+  def has_company?
+    false
+  end
+end

--- a/app/policies/admin_only/admin_only_policy.rb
+++ b/app/policies/admin_only/admin_only_policy.rb
@@ -5,17 +5,17 @@ module AdminOnly
 
 
     def index?
-      is_admin?
+      @user.admin?
     end
 
 
     def update?
-      is_admin?
+      @user.admin?
     end
 
 
     def create?
-      is_admin?
+      @user.admin?
     end
 
 

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -1,13 +1,7 @@
 class AdminPolicy < Struct.new(:user)
 
   def authorized?
-    is_admin?
-  end
-
-
-  private
-  def is_admin?
-    user.admin? if user
+    user.admin?
   end
 
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -11,11 +11,11 @@ class ApplicationPolicy
   end
 
   def index?
-    @user.admin? if @user
+    @user.admin?
   end
 
   def update?
-    is_admin? ||  @record.user == @user
+    @user.admin? ||  @record.user == @user
   end
 
   def edit?
@@ -24,14 +24,7 @@ class ApplicationPolicy
 
 
   def destroy?
-    is_admin?
-  end
-
-
-  private
-
-  def is_admin?
-    @user.admin? if @user
+    @user.admin?
   end
 
 end

--- a/app/policies/business_category_policy.rb
+++ b/app/policies/business_category_policy.rb
@@ -1,7 +1,7 @@
 class BusinessCategoryPolicy < ApplicationPolicy
 
   def new?
-    is_admin?
+    user.admin?
   end
 
 
@@ -16,17 +16,17 @@ class BusinessCategoryPolicy < ApplicationPolicy
 
 
   def index?
-    is_admin?
+    user.admin?
   end
 
 
   def update?
-    is_admin?
+    user.admin?
   end
 
 
   def edit?
-    is_admin?
+    user.admin?
   end
 
 

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -10,7 +10,7 @@ class CompanyPolicy < ApplicationPolicy
   end
 
   def new?
-    is_admin?
+    user.admin?
   end
 
   def create?
@@ -18,17 +18,14 @@ class CompanyPolicy < ApplicationPolicy
   end
 
   def update?
-   is_admin? || is_in_company?
+   user.admin? || is_in_company?
   end
 
 
 
   private
-  def is_admin?
-    @user.admin? if @user
-  end
 
   def is_in_company?
-    @user && @user.is_in_company_numbered?(@record.company_number)
+    @user.is_in_company_numbered?(@record.company_number)
   end
 end

--- a/app/policies/membership_application_policy.rb
+++ b/app/policies/membership_application_policy.rb
@@ -38,7 +38,7 @@ class MembershipApplicationPolicy < ApplicationPolicy
 
 
   def new?
-    is_admin?
+    user.admin?
   end
 
 
@@ -48,27 +48,27 @@ class MembershipApplicationPolicy < ApplicationPolicy
 
 
   def information?
-    user
+    not_a_visitor
   end
 
 
   def accept?
-    is_admin?
+    user.admin?
   end
 
 
   def reject?
-    is_admin?
+    user.admin?
   end
 
 
   def need_info?
-    is_admin?
+    user.admin?
   end
 
 
   def cancel_need_info?
-    is_admin?
+    user.admin?
   end
 
 

--- a/app/policies/membership_application_policy.rb
+++ b/app/policies/membership_application_policy.rb
@@ -12,7 +12,7 @@ class MembershipApplicationPolicy < ApplicationPolicy
 
 
   def permitted_attributes_for_show
-    user ? all_attributes : []
+    not_a_visitor ? all_attributes : []
   end
 
 
@@ -107,18 +107,24 @@ class MembershipApplicationPolicy < ApplicationPolicy
 
 
   def allowed_attribs_for_current_user
-    if user && user.admin?
+    if user.admin?
       all_attributes
-    elsif user && owner?
+    elsif owner?
       owner_attributes
-    else
+    elsif not_a_visitor
       user_owner_attributes
+    else
+      []
     end
   end
 
 
   def owner?
-    user && @record.respond_to?(:user) && @record.user == user
+    @record.respond_to?(:user) && @record.user == user
+  end
+
+  def not_a_visitor
+    ! user.is_a? Visitor
   end
 
 end

--- a/app/policies/page_policy.rb
+++ b/app/policies/page_policy.rb
@@ -1,7 +1,7 @@
 class PagePolicy < Struct.new(:user, :record)
 
   def destroy?
-    is_admin?
+    user.admin?
   end
 
   def show?
@@ -15,7 +15,7 @@ class PagePolicy < Struct.new(:user, :record)
 
 
   def new?
-    is_admin?
+    user.admin?
   end
 
 
@@ -25,7 +25,7 @@ class PagePolicy < Struct.new(:user, :record)
 
 
   def update?
-    is_admin?
+    user.admin?
   end
 
 
@@ -36,10 +36,7 @@ class PagePolicy < Struct.new(:user, :record)
 
   private
   def user_is_member?
-    (user.is_member? || user.admin?) if user
+    (user.is_member? || user.admin?)
   end
 
-  def is_admin?
-    user.admin? if user
-  end
 end

--- a/app/policies/shf_document_policy.rb
+++ b/app/policies/shf_document_policy.rb
@@ -6,12 +6,12 @@ class ShfDocumentPolicy < ApplicationPolicy
   end
 
   def update?
-    is_admin?
+    user.admin?
   end
 
 
   def show?
-    is_admin?
+    user.admin?
   end
 
   def contents_show?
@@ -32,7 +32,7 @@ class ShfDocumentPolicy < ApplicationPolicy
 
 
   def create?
-    is_admin?
+    user.admin?
   end
 
   def minutes_and_static_pages?

--- a/app/views/application/_navigation.html.haml
+++ b/app/views/application/_navigation.html.haml
@@ -13,11 +13,11 @@
             %span.bar.bar-2
             %span.bar.bar-3
         -# Visitor navigation
-        - unless current_user
+        - unless current_user.is_member_or_admin?
           .menu#menu-menu-1-container
             = render 'navigation_visitor'
 
-        - if current_user && !current_user.try(:admin)
+        - if current_user.is_member? && ! current_user.admin?
           .menu#menu-menu-2-container
             %ul.menu#menu-menu-2
               %li.menu-item
@@ -26,32 +26,31 @@
               %li.menu-item
                 = link_to t('menus.nav.members.shf_companies'), root_path
 
-              - if current_user.is_member_or_admin?
-                = render 'navigation_member_pages'
+              = render 'navigation_member_pages'
 
-                - if current_user.has_company?
-                  - member_company = current_user.membership_applications.accepted.last.company
-                  %li.menu-item.menu-item-has-children
-                    = link_to t('menus.nav.members.manage_company.submenu_title'),
-                              company_path(member_company)
-                    %ul.sub-menu
-                      %li.menu-item
-                        = link_to t('menus.nav.members.manage_company.view_company'),
-                                  company_path(member_company)
-                      %li.menu-item
-                        = link_to t('menus.nav.members.manage_company.edit_company'),
-                                  edit_company_path(member_company)
+              - if current_user.has_company?
+                - member_company = current_user.membership_applications.accepted.last.company
+                %li.menu-item.menu-item-has-children
+                  = link_to t('menus.nav.members.manage_company.submenu_title'),
+                            company_path(member_company)
+                  %ul.sub-menu
+                    %li.menu-item
+                      = link_to t('menus.nav.members.manage_company.view_company'),
+                                company_path(member_company)
+                    %li.menu-item
+                      = link_to t('menus.nav.members.manage_company.edit_company'),
+                                edit_company_path(member_company)
 
-                = render 'navigation_edit_my_application', membership_app: current_user.membership_applications.last
+              = render 'navigation_edit_my_application', membership_app: current_user.membership_applications.last
 
-              - else
-                - if current_user.has_membership_application?
-                  = render 'navigation_edit_my_application', membership_app: current_user.membership_applications.last
-                - else
-                  %li.menu-item
-                    = link_to t('menus.nav.users.apply_for_membership'), new_membership_application_path
+        - else
+          - if current_user.has_membership_application?
+            = render 'navigation_edit_my_application', membership_app: current_user.membership_applications.last
+          - else
+            %li.menu-item
+              = link_to t('menus.nav.users.apply_for_membership'), new_membership_application_path
 
-        - if current_user && current_user.admin?
+        - if current_user.admin?
           .menu#menu-menu-3-container
             %ul.menu#menu-menu-3
               = render 'navigation_member_pages'

--- a/app/views/application/_top.html.haml
+++ b/app/views/application/_top.html.haml
@@ -1,5 +1,5 @@
 = render 'navigation'
 #site-logo
   %p.admin
-    - if current_user.try(:admin)
+    - if current_user.admin?
       = t('info.logged_in_as_admin')

--- a/app/views/business_categories/show.html.haml
+++ b/app/views/business_categories/show.html.haml
@@ -17,7 +17,7 @@
         %tr
           %th= t('companies.index.name')
           %th= t('companies.index.region_land')
-          - if current_user.try(:admin)
+          - if current_user.admin?
             %th= t('companies.index.company_number')
             %th
       %tbody
@@ -25,6 +25,6 @@
           %tr.company
             %td= link_to company.name, company
             %td= company.main_address.region ?  company.main_address.region.name  : ''
-            - if current_user.try(:admin)
+            - if current_user.admin?
               %td= company.company_number
               %td= link_to t('edit'), edit_company_path(company)

--- a/app/views/companies/_companies_list.html.haml
+++ b/app/views/companies/_companies_list.html.haml
@@ -14,7 +14,7 @@
           = sort_link(@search_params, :addresses_kommun_id,
                       t('activerecord.attributes.address.kommun'))
 
-        - if current_user.try(:admin)
+        - if current_user.admin?
           %th
             = sort_link(@search_params, :company_number,
                       t('activerecord.attributes.company.company_number'))
@@ -36,7 +36,7 @@
           %td= link_to company.name, company
           %td= company.main_address.region&.name
           %td= company.main_address.kommun&.name
-          - if current_user.try(:admin)
+          - if current_user.admin?
             %td= company.company_number
             %td= link_to "#{t('edit')}", edit_company_path(company)
             %td= link_to "#{t('delete')}", company, method: :delete,

--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -1,7 +1,7 @@
 %header.entry-header
-  - unless current_user.try(:admin)
+  - unless current_user.admin?
     %h1.entry-title= t('.title')
-  - if current_user.try(:admin)
+  - if current_user.admin?
     %h1.entry-title= t('.admin_title')
 
 .entry-content
@@ -11,7 +11,7 @@
              markers: location_and_markers_for(@all_visible_companies)
 
 
-  - unless current_user.try(:admin)
+  - unless current_user.admin?
 
     .search-instructions
       %h3

--- a/app/views/companies/show.html.haml
+++ b/app/views/companies/show.html.haml
@@ -18,7 +18,7 @@
       .col-md-5
         = field_or_none t('.name'), @company.name, tag_options: {class: 'hidden', id: 'location-text'}
 
-        - if current_user && current_user.admin?
+        - if current_user.admin?
           = field_or_none t('.org_nr'), @company.company_number, tag_options: {class: 'company-number'}
 
         = field_or_none t('.phone_number'), @company.phone_number, tag_options: {class: 'phone-number'}
@@ -71,7 +71,7 @@
         = link_to "#{t('companies.all_companies')}",
                   companies_path, class: 'btn btn-default all-companies'
 
-      - if current_user.try(:admin)
+      - if current_user.admin?
         = link_to "#{t('.delete')}", @company, method: :delete,
                   class:'btn btn-danger delete-company',
                   data: { confirm: "#{t('.confirm_are_you_sure')}" }

--- a/app/views/membership_applications/_membership_application_fields.html.haml
+++ b/app/views/membership_applications/_membership_application_fields.html.haml
@@ -1,7 +1,7 @@
 .app-section
   %h2.first= t('membership_applications.new.section_title_about_you')
   .answers
-    - if current_user && current_user.admin? && @membership_application.is_accepted?
+    - if current_user.admin? && @membership_application.is_accepted?
       = f.label :membership_number, t('membership_applications.show.membership_number'), class: 'required'
       = f.text_field :membership_number, class: 'wpcf7-form-control'
 

--- a/app/views/membership_applications/show.html.haml
+++ b/app/views/membership_applications/show.html.haml
@@ -36,7 +36,5 @@
     - if current_user.admin?
       = render partial: 'application_status_form'
 
-
-    - if current_user && current_user.admin?
       = link_to "#{t('membership_applications.edit_membership_application')}", edit_membership_application_path(@membership_application), class:'btn btn-warning'
       = link_to "#{t('.delete')}", @membership_application, method: :delete, class:'btn btn-danger', data: { confirm: "#{t('.confirm_are_you_sure')}" }

--- a/app/views/shf_documents/index.html.haml
+++ b/app/views/shf_documents/index.html.haml
@@ -15,7 +15,7 @@
 
         %th= sort_link(@ransack_query_results, :description, t('.description'))
 
-        - if current_user.try(:admin)
+        - if current_user.admin?
           %th
           %th
 
@@ -26,11 +26,11 @@
 
           %td.description= shf_document.description
 
-          - if current_user.try(:admin)
+          - if current_user.admin?
             %td= link_to t('.view_details'), shf_document
             %td= link_to t('delete'), shf_document, :method => :delete, :data => { :confirm => t('.delete_confirm', document_title: shf_document.title) }
 
-  - if current_user.try(:admin)
+  - if current_user.admin?
     %br
     .center
       = link_to t('shf_documents.new_shf_minutes'), new_shf_document_path, class: 'btn btn-default btn-shf-document-new'

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1,16 +1,6 @@
 require 'rails_helper'
 
-
-RSpec.configure do |config|
-  config.include Devise::Test::ControllerHelpers, :type => :controller
-end
-
-
 RSpec.describe AdminController, type: :controller do
-
-  include Warden::Test::Helpers
-
-  include Devise::Test::ControllerHelpers
 
   # this will bypass Pundit policy access checks so logging in is not necessary
   before(:each) { Warden.test_mode! }

--- a/spec/factories/visitors.rb
+++ b/spec/factories/visitors.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :visitor
+end

--- a/spec/helpers/companies_helper_spec.rb
+++ b/spec/helpers/companies_helper_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe CompaniesHelper, type: :helper do
   describe '#show_address_fields' do
     let(:admin)   { create(:user, admin: true) }
     let(:member)  { create(:member_with_membership_app) }
-    let(:visitor) { create(:user) }
+    let(:visitor) { build(:visitor) }
     let(:company) { create(:company) }
 
     let(:all_fields) do

--- a/spec/models/visitor_spec.rb
+++ b/spec/models/visitor_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Visitor, type: :model do
+
+  shared_examples_for 'a user' do
+    it { should respond_to(:admin?) }
+    it { should respond_to(:is_member?) }
+    it { should respond_to(:is_member_or_admin?) }
+    it { should respond_to(:has_membership_application?) }
+    it { should respond_to(:has_company?) }
+    it { should respond_to(:is_in_company_numbered?) }
+  end
+
+  describe Visitor do
+    subject { Visitor.new }
+    it_should_behave_like 'a user'
+  end
+
+  describe User do
+    subject { FactoryGirl.create(:user) }
+    it_should_behave_like 'a user'
+  end
+end

--- a/spec/models/visitor_spec.rb
+++ b/spec/models/visitor_spec.rb
@@ -2,6 +2,21 @@ require 'rails_helper'
 
 RSpec.describe Visitor, type: :model do
 
+  # Visitor class represents a "user" of the site who is not logged in.
+  # An instance of this class responds to certain methods which are typically
+  # called on the return value of Devise's "current_user" helper method.
+  # The Visitor class allows us to set the value of "current_user" to a
+  # Visitor instance when the user is not logged in.  Since this instance
+  # responds appropriately to the methods below, there is no need to check
+  # if "current_user" is nil before calling methods on the return value of
+  # "current_user" (which will either be an instance of User or of Visitor).
+
+  # The methods listed below are used to determine the type of user, and to
+  # execute different logic paths based upon that type.
+  # If any other such methods are added to the codebase, then that method should
+  # be 1) added as an instance method to Visitor, and 2) added to the
+  # shared_examples_for block below.
+
   shared_examples_for 'a user' do
     it { should respond_to(:admin?) }
     it { should respond_to(:is_member?) }

--- a/spec/policies/admin_only_policy_spec.rb
+++ b/spec/policies/admin_only_policy_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe AdminOnly::AdminOnlyPolicy do
   let(:user_1) { create(:user, email: 'user@random.com') }
   let(:member) { create(:member_with_membership_app, email: 'member@random.com', company_number: '5562728336')}
   let(:admin)  { create(:user, email: 'admin@shf.com', admin: true) }
+  let(:visitor) { build(:visitor) }
 
   let(:simple_record) { create(:business_category) }
 
@@ -52,7 +53,7 @@ RSpec.describe AdminOnly::AdminOnlyPolicy do
   end
 
   describe 'Visitor (not logged in) is forbidden everything' do
-    subject { described_class.new(nil, simple_record) }
+    subject { described_class.new(visitor, simple_record) }
 
     it { is_expected.to forbid_action :index }
     it { is_expected.to forbid_action :show }

--- a/spec/policies/admin_policy_spec.rb
+++ b/spec/policies/admin_policy_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe AdminPolicy do
   let(:user_1) { create(:user, email: 'user@random.com') }
   let(:member) { create(:member_with_membership_app, email: 'member@random.com', company_number: '5562728336')}
   let(:admin)  { create(:user, email: 'admin@shf.com', admin: true) }
+  let(:visitor) { build(:visitor) }
 
   describe 'For admin' do
     subject { described_class.new(admin).authorized? }
@@ -29,7 +30,7 @@ RSpec.describe AdminPolicy do
   end
 
   describe 'For a visitor (not logged in)' do
-    subject { described_class.new(nil).authorized? }
+    subject { described_class.new(visitor).authorized? }
 
     it { is_expected.to be_falsey }
 

--- a/spec/policies/business_category_policy_spec.rb
+++ b/spec/policies/business_category_policy_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe BusinessCategoryPolicy do
 
   let(:user_1) { create(:user, email: 'user_1@random.com') }
   let(:admin) { create(:user, email: 'admin@sgf.com', admin: true) }
+  let(:visitor) { build(:visitor) }
   let(:category) { create(:business_category) }
 
   describe 'For admin' do
@@ -31,7 +32,7 @@ RSpec.describe BusinessCategoryPolicy do
   end
 
   describe 'For a visitor (not logged in)' do
-    subject { described_class.new(nil, category) }
+    subject { described_class.new(visitor, category) }
 
     it { is_expected.to forbid_action :index }
     it { is_expected.to permit_action :show }

--- a/spec/policies/company_policy_spec.rb
+++ b/spec/policies/company_policy_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe CompanyPolicy do
   let(:user_1) { create(:user, email: 'user_1@random.com') }
   let(:member) { create(:member_with_membership_app, email: 'member@random.com', company_number: '5562728336')}
   let(:admin)  { create(:user, email: 'admin@sfh.com', admin: true) }
+  let(:visitor) { build(:visitor) }
   let(:company) { create(:company, company_number: '5712213304')}
 
   describe 'For admin' do
@@ -53,7 +54,7 @@ RSpec.describe CompanyPolicy do
   end
 
   describe 'For a visitor (not logged in)' do
-    subject { described_class.new(nil, company) }
+    subject { described_class.new(visitor, company) }
 
     it { is_expected.to permit_action :index }
     it { is_expected.to permit_action :show }

--- a/spec/policies/membership_application_policy_spec.rb
+++ b/spec/policies/membership_application_policy_spec.rb
@@ -67,7 +67,7 @@ describe MembershipApplicationPolicy do
 
 
     describe 'for a visitor' do
-      subject { described_class.new(nil, application) }
+      subject { described_class.new(Visitor.new, application) }
 
       it 'forbits create' do
         is_expected.to forbid_mass_assignment_of(:state).for_action(:create)

--- a/spec/policies/membership_application_policy_spec.rb
+++ b/spec/policies/membership_application_policy_spec.rb
@@ -123,12 +123,13 @@ describe MembershipApplicationPolicy do
 
     let(:user_1) { create(:user, email: 'user_1@random.com') }
     let(:user_2) { create(:user, email: 'user_2@random.com') }
-    let(:admin) { create(:user, email: 'admin@sgf.com', admin: true) }
+    let(:admin)  { create(:user, email: 'admin@sgf.com', admin: true) }
+    let(:visitor) { build(:visitor) }
     let(:application) { create(:membership_application,
                                user: user_1) }
 
     describe 'For visitors (not logged in)' do
-      subject { described_class.new(nil, application) }
+      subject { described_class.new(visitor, application) }
 
       it 'forbids new' do
         is_expected.to forbid_action :new

--- a/spec/policies/page_policy_spec.rb
+++ b/spec/policies/page_policy_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe PagePolicy do
   let(:user_1) { create(:user, email: 'user_1@random.com') }
   let(:member) { create(:member_with_membership_app, email: 'member@random.com')}
   let(:admin)  { create(:user, email: 'admin@sfh.com', admin: true) }
+  let(:visitor) { build(:visitor) }
   let (:page) {}
 
   describe 'For admin' do
@@ -44,7 +45,7 @@ RSpec.describe PagePolicy do
   end
 
   describe 'For a visitor (not logged in)' do
-    subject { described_class.new(nil, page) }
+    subject { described_class.new(visitor, page) }
 
     it { is_expected.to forbid_action :index }
     it { is_expected.to forbid_action :show }

--- a/spec/policies/shf_document_policy_spec.rb
+++ b/spec/policies/shf_document_policy_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ShfDocumentPolicy do
   let(:user_1) { create(:user, email: 'user@random.com') }
   let(:member) { create(:member_with_membership_app, email: 'member@random.com', company_number: '5562728336')}
   let(:admin)  { create(:user, email: 'admin@shf.se', admin: true) }
+  let(:visitor) { build(:visitor) }
   let(:shf_document) { create(:shf_document, uploader: (create(:user, email: 'admin2@shf.se', admin: true )) )}
 
   subject { described_class }
@@ -53,7 +54,7 @@ RSpec.describe ShfDocumentPolicy do
 
 
   describe 'For a visitor (not logged in)' do
-    subject { described_class.new(nil, shf_document) }
+    subject { described_class.new(visitor, shf_document) }
 
     it { is_expected.to forbid_action :index }
     it { is_expected.to forbid_action :show }
@@ -97,7 +98,7 @@ RSpec.describe ShfDocumentPolicy do
       it { is_expected.to forbid_action :contents_update }
     end
     context 'For a visitor (not logged in)' do
-      subject { described_class.new(nil, ShfDocument) }
+      subject { described_class.new(visitor, ShfDocument) }
 
       it { is_expected.to forbid_action :index }
       it { is_expected.to forbid_action :contents_show }

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe UserPolicy do
                         email: 'member@random.com',
                         company_number: '5562728336') }
   let(:admin)  { create(:user, email: 'admin@sfh.com', admin: true) }
+  let(:visitor) { build(:visitor) }
 
   permissions :index? do
     it 'allows access to admin' do
@@ -22,7 +23,7 @@ RSpec.describe UserPolicy do
     end
 
     it 'denies access to visitor' do
-      expect(UserPolicy).not_to permit(nil)
+      expect(UserPolicy).not_to permit(visitor)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,9 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
 
+  config.include Devise::TestHelpers, :type => :controller
+  config.include Devise::TestHelpers, :type => :view
+
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   config.infer_spec_type_from_file_location!

--- a/spec/views/application/_navigation.html.haml_spec.rb
+++ b/spec/views/application/_navigation.html.haml_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'companies/index' do
 
-  include Devise::Test::ControllerHelpers
-
   let(:member)  { FactoryGirl.create(:member_with_membership_app) }
 
   let(:admin)   { FactoryGirl.create(:user, admin: true) }
@@ -22,7 +20,7 @@ RSpec.describe 'companies/index' do
   describe 'member' do
 
     before(:each) do
-      sign_in member
+      allow(view).to receive(:current_user) { member }
 
       assign(:all_visible_companies, [])
       assign(:search_params, Company.ransack(nil))
@@ -85,7 +83,7 @@ RSpec.describe 'companies/index' do
   describe 'admin' do
 
     before(:each) do
-      sign_in admin
+      allow(view).to receive(:current_user) { admin }
 
       render 'application/navigation'
     end
@@ -179,18 +177,20 @@ RSpec.describe 'companies/index' do
 
   describe 'visitor' do
 
-    before(:each) { render 'application/navigation' }
+    before(:each) do
+      allow(view).to receive(:current_user) { Visitor.new }
+
+      render 'application/navigation'
+    end
 
     it 'renders link to main site' do
       text = t('menus.nav.home')
-      expect(rendered)
-        .to match %r{<a href=\"#{shf_site}\">#{text}}
+      expect(rendered).to match %r{<a href=\"#{shf_site}\">#{text}}
     end
 
     it 'renders brochure link' do
       text = t('menus.nav.visitor.brochure')
-      expect(rendered)
-        .to match %r{<a href=\"#{shf_site}broschyr\/\">#{text}}
+      expect(rendered).to match %r{<a href=\"#{shf_site}broschyr\/\">#{text}}
     end
 
     context 'for-dog-owners menu' do


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/142459295


Changes proposed in this pull request:

I added code that streamlines working with the `current_user` and `user_signed_in?` Devise methods.  That is, the new code allows us to assume that `current_user` is _never_ nil.  This makes for cleaner code where our logic checks for user type.  

1. Added class `Visitor`, which responds to the same methods that the code calls on the return value of `current_user`.

2. Overrode `current_user` to create a Visitor instance if the user is not logged in.

3. Overrode `user_signed_in?` to check for presence of a visitor user vs logged-in user.

4. Altered many statements in existing code consistent with above changes.

5. Added a unit test (Visitor model) that confirms that Visitor and User models each respond to the same set of methods that are used to drive application logic.

Screenshots (Optional):


Ready for review:
@weedySeaDragon @RobertCram @thesuss 