### PR TITLE
sort_link now executes XHR request

### DIFF
--- a/app/views/companies/_companies_list.html.haml
+++ b/app/views/companies/_companies_list.html.haml
@@ -6,18 +6,22 @@
           = t('activerecord.models.business_category.one')
         %th
           = sort_link(@search_params, :name,
-                      t('activerecord.attributes.company.name'))
+                      t('activerecord.attributes.company.name'), {},
+                      { class: 'companies_pagination', remote: true })
         %th
           = sort_link(@search_params, :addresses_region_name,
-                      t('activerecord.attributes.address.region'))
+                      t('activerecord.attributes.address.region'), {},
+                      { class: 'companies_pagination', remote: true })
         %th
           = sort_link(@search_params, :addresses_kommun_id,
-                      t('activerecord.attributes.address.kommun'))
+                      t('activerecord.attributes.address.kommun'), {},
+                      { class: 'companies_pagination', remote: true })
 
         - if current_user.admin?
           %th
             = sort_link(@search_params, :company_number,
-                      t('activerecord.attributes.company.company_number'))
+                      t('activerecord.attributes.company.company_number'), {},
+                      { class: 'companies_pagination', remote: true })
           %th
           %th
 

--- a/app/views/membership_applications/_membership_applications_list.html.haml
+++ b/app/views/membership_applications/_membership_applications_list.html.haml
@@ -4,13 +4,16 @@
       %tr
         %th
           = sort_link(@search_params, :last_name,
-                      t('membership_applications.index.name'))
+                      t('membership_applications.index.name'), {},
+                      { class: 'applications_pagination', remote: true })
         %th
           = sort_link(@search_params, :company_number,
-                      t('membership_applications.index.org_nr'))
+                      t('membership_applications.index.org_nr'), {},
+                      { class: 'applications_pagination', remote: true })
         %th
           = sort_link(@search_params, :state,
-                      t('membership_applications.index.state'))
+                      t('membership_applications.index.state'), {},
+                      { class: 'applications_pagination', remote: true })
         %th
     %tbody
       - @membership_applications.each do |membership_application|


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/140635833

Changes proposed in this pull request:
1.  Changed sort links (for paginated tables - companies and membership_applications) to use data-remote attribute.  This sends an XHR request to the controller action, which renders HTML which is used (in application.js) to replace the current div containing the table with the newly-sorted table.

Column sorting now results in a DOM element replacement, rather than a full page load.  This is much faster, and prevents the sorting from repositioning at the top of the page.

(the application.js stuff was already in place - just leveraging it again for this.)

Also, I updated the wiki page regarding adding pagination for a table.

Screenshots (Optional):


Ready for review:
@weedySeaDragon @RobertCram @thesuss 