### PR TITLE
Add users with membershipapplications for two companies to seeding.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,7 +16,8 @@ SEED_COMPLETE_MSG = '<<< SEEDING COMPLETED' unless defined?(SEED_COMPLETE_MSG)
 
 NUM_USERS = 100 unless defined?(NUM_USERS)
 
-NUM_USERS_WITH_ONE_APPLICATION =  90 unless defined?(NUM_USERS_WITH_ONE_APPLICATION)
+NUM_USERS_WITH_SINGLE_APPLICATION =  80 unless defined?(NUM_USERS_WITH_SINGLE_APPLICATION)
+NUM_USERS_WITH_DOUBLE_APPLICATION = 10 unless defined?(NUM_USERS_WITH_DOUBLE_APPLICATION)
 
 DEFAULT_PASSWORD = 'whatever' unless defined?(DEFAULT_PASSWORD)
 
@@ -79,7 +80,7 @@ unless Rails.env.production? || Rails.env.test?
   puts "  As companies are created for accepted applications, their address has to be geocoded/located."
   puts "  This takes time to do. Be patient. (You can look at the /log/development.log to be sure that things are happening and this is not stuck.)"
 
-  make_applications(users.values, NUM_USERS_WITH_ONE_APPLICATION)
+  make_applications(users.values, NUM_USERS_WITH_SINGLE_APPLICATION, NUM_USERS_WITH_DOUBLE_APPLICATION)
 
   puts "\n  Membership applications created: #{MembershipApplication.count}"
   puts "  Membership Applications by state:"


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/147432613


**Changes proposed in this pull request:**

1. Extend the seeding to include the use case where one user has two membership applications (each one for a different company)

Ready for review:
@weedySeaDragon @patmbolger @thesuss 