### PR TITLE
Reason waiting (incl. custom reason) UX

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -61,7 +61,7 @@ $(function() {
       $.each($('.ckeditor'), function (index, ele) {
         CKEDITOR.replace ($(ele).attr('id'));
       })
-    }
+    };
 
     // Slide mobile navigation from left
     jQuery('#site-navigation .menu-toggle').on('click', function () {

--- a/app/assets/stylesheets/member-app-waiting-reason.scss
+++ b/app/assets/stylesheets/member-app-waiting-reason.scss
@@ -1,7 +1,33 @@
-.member_app_waiting_reasons {
 
-  input.wpcf7-form-control.is-custom {
-    width: 3rem;
+$reason-border-color:  #ff7f50;  // coral; picked sort of at random
+
+
+#reason-waiting {
+
+  border-bottom: 1pt solid $reason-border-color;
+  margin-bottom: 1rem;
+
+  .row {
+
+    margin-bottom: 0;
+    margin-top: 0;
+    padding-bottom: 0.5rem;
+    padding-top: 0.5rem;
+
+  }
+
+
+  select {
+    height: 110%;
+  }
+
+  label {
+    font-weight: normal;
+  }
+
+  input[type="text"] {
+    padding: 0.3rem;
+    width: 35rem;
   }
 
 }

--- a/app/helpers/membership_applications_helper.rb
+++ b/app/helpers/membership_applications_helper.rb
@@ -4,8 +4,66 @@ module MembershipApplicationsHelper
     policy(@membership_application).permitted_attributes_for_edit.include? :state
   end
 
+
   def member_full_name
     @membership_application ? "#{@membership_application.first_name} #{@membership_application.last_name}" : '..'
 
   end
+
+
+  def reasons_collection(other_reason_value, other_reason_text)
+    collection = AdminOnly::MemberAppWaitingReason.all.to_a
+    collection << AdminOnly::MemberAppWaitingReason.new(id: other_reason_value, "name_#{I18n.locale}" => "#{other_reason_text}")
+    collection
+  end
+
+
+  def selected_reason_value(member_app, other_reason_value)
+    (!member_app.custom_reason_text.blank?) ? other_reason_value : member_app.member_app_waiting_reasons_id
+  end
+
+
+  # the method to use to get the name for a reason, given the locale
+  # If no locale is given, the current locale is used.
+  # If the locale given isn't found or defined, the default name method is used
+  def reason_name_method(locale = I18n.locale)
+    reason_method 'name', locale
+  end
+
+
+  # the method to use to get the description for a reason, given the locale
+  # If no locale is given, the current locale is used.
+  # If the locale given isn't found or defined, the default name method is used
+  def reason_desc_method(locale = I18n.locale)
+    reason_method 'description', locale
+  end
+
+
+  # a collection of arrays with [the name of the reasons for waiting, the reason (object)]
+  # in the locale
+  def reasons_for_waiting_names(use_locale = I18n.locale)
+    reasons_for_waiting_info('name', use_locale)
+  end
+
+
+  # a collection of arrays with [the descriptions of the reasons for waiting,  the reason (object)]
+  # in the locale
+  def reasons_for_waiting_descs(use_locale = I18n.locale)
+    reasons_for_waiting_info('description', use_locale)
+  end
+
+
+  private
+
+  def reason_method(method_prefix, locale)
+    possible_method = "#{method_prefix}_#{locale}".to_sym
+    (AdminOnly::MemberAppWaitingReason.new.respond_to?(possible_method) ? possible_method : AdminOnly::MemberAppWaitingReason.send("default_#{method_prefix}_method".to_sym))
+  end
+
+
+  def reasons_for_waiting_info(method_prefix, locale)
+    method_name = reason_method(method_prefix, locale)
+    AdminOnly::MemberAppWaitingReason.all.map { |r| [r.id, r.send(method_name)] }
+  end
+
 end

--- a/app/models/admin_only/member_app_waiting_reason.rb
+++ b/app/models/admin_only/member_app_waiting_reason.rb
@@ -12,13 +12,23 @@ module AdminOnly
 
 
     # This is effectively a CONSTANT that is used in the UI
-    def self.other_reason_name
-      I18n.t('admin_only.member_app_waiting_reasons.other_custom_reason')
+    def self.other_reason_name(locale = I18n.locale)
+      I18n.t('admin_only.member_app_waiting_reasons.other_custom_reason', locale)
     end
+
+
+    def self.other_reason_desc(locale = I18n.locale)
+      I18n.t('admin_only.member_app_waiting_reasons.other_custom_reason_desc', locale)
+    end
+
 
 
     def self.default_name_method
       :name_sv
+    end
+
+    def self.default_description_method
+      :description_sv
     end
 
   end

--- a/app/models/admin_only/member_app_waiting_reason.rb
+++ b/app/models/admin_only/member_app_waiting_reason.rb
@@ -5,24 +5,6 @@ module AdminOnly
     validates_presence_of :name_sv
 
 
-    # Is this the placeholder for "Other (enter a custom reason)" for the UI (true) or a custom reason entered (false)
-    def other_reason_placeholder?
-      name_sv == self.class.other_reason_name
-    end
-
-
-    # This is effectively a CONSTANT that is used in the UI
-    def self.other_reason_name(locale = I18n.locale)
-      I18n.t('admin_only.member_app_waiting_reasons.other_custom_reason', locale)
-    end
-
-
-    def self.other_reason_desc(locale = I18n.locale)
-      I18n.t('admin_only.member_app_waiting_reasons.other_custom_reason_desc', locale)
-    end
-
-
-
     def self.default_name_method
       :name_sv
     end

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -23,6 +23,11 @@ class MembershipApplication < ApplicationRecord
   has_and_belongs_to_many :business_categories
   has_many :uploaded_files
 
+  belongs_to :waiting_reason, optional: true,
+             foreign_key: "member_app_waiting_reasons_id",
+             class_name: 'AdminOnly::MemberAppWaitingReason'
+
+
   validates_presence_of :first_name,
                         :last_name,
                         :company_number,

--- a/app/policies/membership_application_policy.rb
+++ b/app/policies/membership_application_policy.rb
@@ -97,7 +97,7 @@ class MembershipApplicationPolicy < ApplicationPolicy
 
 
   def all_attributes
-    owner_attributes + [:membership_number]
+    owner_attributes + [:membership_number, :waiting_reason, :custom_reason_text, :member_app_waiting_reasons_id]
   end
 
 

--- a/app/views/membership_applications/_application_status_form.html.haml
+++ b/app/views/membership_applications/_application_status_form.html.haml
@@ -1,23 +1,31 @@
+- if @membership_application.waiting_for_applicant?
+  = render 'reason_waiting'
+
+
+
 #admin-change-status-buttons
   %p.header
     = "#{t('membership_applications.show.change_status')}:"
 
 
-  = button_to t('membership_applications.start_review_btn'), start_review_membership_application_path(@membership_application), {class: 'btn start-review', disabled: !(@membership_application.may_start_review?)}
+  .row
+    = button_to t('membership_applications.start_review_btn'), start_review_membership_application_path(@membership_application), {class: 'btn start-review', disabled: !(@membership_application.may_start_review?)}
 
-  = button_to t('membership_applications.accept_btn'), accept_membership_application_path(@membership_application), {class: 'btn accept', disabled: !(@membership_application.may_accept?)}
+    = button_to t('membership_applications.accept_btn'), accept_membership_application_path(@membership_application), {class: 'btn accept', disabled: !(@membership_application.may_accept?)}
 
-  = button_to t('membership_applications.reject_btn'), reject_membership_application_path(@membership_application), {class: 'btn reject', disabled: !(@membership_application.may_reject?)}
+    = button_to t('membership_applications.reject_btn'), reject_membership_application_path(@membership_application), {class: 'btn reject', disabled: !(@membership_application.may_reject?)}
 
-  = button_to t('membership_applications.ask_applicant_for_info_btn'), need_info_membership_application_path(@membership_application), {class: 'btn need-info', disabled: !(@membership_application.may_ask_applicant_for_info?)}
+    = button_to t('membership_applications.ask_applicant_for_info_btn'), need_info_membership_application_path(@membership_application), {class: 'btn need-info', disabled: !(@membership_application.may_ask_applicant_for_info?)}
 
-  = button_to t('membership_applications.cancel_waiting_for_applicant_btn'), cancel_need_info_membership_application_path(@membership_application), {class: 'btn cancel-need-info', disabled: !(@membership_application.may_cancel_waiting_for_applicant?)}
+  .row
+    = button_to t('membership_applications.cancel_waiting_for_applicant_btn'), cancel_need_info_membership_application_path(@membership_application), {class: 'btn cancel-need-info', disabled: !(@membership_application.may_cancel_waiting_for_applicant?)}
 
-  = button_to t('membership_applications.ask_applicant_for_payment_btn'), need_payment_membership_application_path(@membership_application), {class: 'btn need-payment', disabled: !(@membership_application.may_ask_for_payment?)}
+    = button_to t('membership_applications.ask_applicant_for_payment_btn'), need_payment_membership_application_path(@membership_application), {class: 'btn need-payment', disabled: !(@membership_application.may_ask_for_payment?)}
 
-  = button_to t('membership_applications.cancel_waiting_for_payment_btn'), cancel_need_payment_membership_application_path(@membership_application), {class: 'btn cancel_need-payment', disabled: !(@membership_application.may_cancel_waiting_for_payment?)}
+    = button_to t('membership_applications.cancel_waiting_for_payment_btn'), cancel_need_payment_membership_application_path(@membership_application), {class: 'btn cancel_need-payment', disabled: !(@membership_application.may_cancel_waiting_for_payment?)}
 
-  = button_to t('membership_applications.received_payment_btn'), received_payment_membership_application_path(@membership_application), {class: 'btn received-payment', disabled: !(@membership_application.may_received_payment?)}
+    = button_to t('membership_applications.received_payment_btn'), received_payment_membership_application_path(@membership_application), {class: 'btn received-payment', disabled: !(@membership_application.may_received_payment?)}
+
 
 %br
   - if !@membership_application.paid?

--- a/app/views/membership_applications/_reason_waiting.html.haml
+++ b/app/views/membership_applications/_reason_waiting.html.haml
@@ -1,0 +1,39 @@
+-# Submit the changed reason via javascript when a member_app_waiting_reasons_id is selected from the list or custom_reason_text is changed.
+  Do not make user press a "save" or "submit" button for these changes. (use AJAX)
+#reason-waiting
+  .row
+    .container
+      .reason-waiting-information
+        = label_tag :member_app_waiting_reasons, t('membership_applications.need_info.reason_title')
+        -# have to set selected into an interim variable because this needs to be evaluated before the collection
+        - selected = selected_reason_value(@membership_application, @other_waiting_reason_value)
+        = select_tag(:member_app_waiting_reasons,
+                         options_from_collection_for_select(reasons_collection(@other_waiting_reason_value, @other_waiting_reason_text),
+                                                            :id,
+                                                            reason_name_method,
+                                                            selected),
+                         { include_blank: t('membership_applications.need_info.select_a_reason'),
+                           class: 'reason-waiting-list',
+                           data: { remote: true,
+                                   url: membership_application_path(@membership_application),
+                                   method: 'put' } })
+
+  .row
+    .container
+      #other-text-field{ style: "display: #{selected == @other_waiting_reason_value ? nil : 'none'}" }
+        = label_tag :custom_reason_text, t('membership_applications.need_info.other_reason_label')
+        = text_field_tag :custom_reason_text, @membership_application.custom_reason_text,
+                    { data: { remote: true,
+                              url: membership_application_path(@membership_application),
+                              method: 'put' } }
+
+
+:javascript
+
+  $('#member_app_waiting_reasons').on('ajax:success', function (e, data) {
+    if (data === "#{@other_waiting_reason_value}") {
+      $('#other-text-field').show();
+    } else {
+      $('#other-text-field').hide();
+    }
+  });

--- a/app/views/membership_applications/_reason_waiting.html.haml
+++ b/app/views/membership_applications/_reason_waiting.html.haml
@@ -28,6 +28,7 @@
                               method: 'put' } }
 
 
+
 :javascript
 
   $('#member_app_waiting_reasons').on('ajax:success', function (e, data) {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -313,13 +313,12 @@ en:
 
     need_info:
       reason_title: Reason
-
       other_reason_label: "other reason:"
-      submit_button_label: "Save the reason"
-
+      select_a_reason: "Select a reason..."
 
       success: 'The application has been marked as needing info. (Send email to the applicant.)'
       error: "There was an error when trying to set the application to 'needing information.'"
+
 
     cancel_need_info:
       success: The application has been changed to no longer needing information from the applicant.
@@ -677,6 +676,7 @@ en:
       list_all_member_app_waiting_reasons: "List all Waiting for Information Reasons"
 
       other_custom_reason: "Other (enter the reason)"
+      other_custom_reason_desc: ""
 
       delete_confirm: "Are you sure you want to delete the reason: %{name_sv} (%{name_en})?"
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -316,12 +316,12 @@ sv:
 
     need_info:
       reason_title: Anledning
-
       other_reason_label: "Annan orsak"
-      submit_button_label: "Spara orsaken"
+      select_a_reason: "Välj en anledning..."
 
       success: 'Ansökan har markerats som: "Behöver kompletteras". (Skicka e-post till den sökande.)'
       error: 'Det uppstod ett fel när systemet försökte sätta status: "Behöver kompletteras".'
+
 
     cancel_need_info:
       success: Ansökan har ändrats och behöver ej längre kompletteras av sökande.
@@ -680,6 +680,7 @@ sv:
       list_all_member_app_waiting_reasons: "Lista alla orsaker"
 
       other_custom_reason: "Annat (skriv in orsaken)"
+      other_custom_reason_desc: ""
 
       delete_confirm: "Är du säker på att du vill radera orsaken: %{name_sv} (%{name_en})?"
 

--- a/db/migrate/20170615091313_add_reason_waiting_to_membership_application.rb
+++ b/db/migrate/20170615091313_add_reason_waiting_to_membership_application.rb
@@ -1,0 +1,8 @@
+class AddReasonWaitingToMembershipApplication < ActiveRecord::Migration[5.0]
+
+  def change
+    add_reference :membership_applications, :member_app_waiting_reasons, foreign_key: true
+    add_column :membership_applications, :custom_reason_text, :string
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170525201944) do
+ActiveRecord::Schema.define(version: 20170615091313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,16 +100,19 @@ ActiveRecord::Schema.define(version: 20170525201944) do
   create_table "membership_applications", force: :cascade do |t|
     t.string   "company_number"
     t.string   "phone_number"
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
+    t.datetime "created_at",                                    null: false
+    t.datetime "updated_at",                                    null: false
     t.integer  "user_id"
     t.string   "first_name"
     t.string   "last_name"
     t.string   "contact_email"
     t.integer  "company_id"
     t.string   "membership_number"
-    t.string   "state",             default: "new"
+    t.string   "state",                         default: "new"
+    t.integer  "member_app_waiting_reasons_id"
+    t.string   "custom_reason_text"
     t.index ["company_id"], name: "index_membership_applications_on_company_id", using: :btree
+    t.index ["member_app_waiting_reasons_id"], name: "index_membership_applications_on_member_app_waiting_reasons_id", using: :btree
     t.index ["user_id"], name: "index_membership_applications_on_user_id", using: :btree
   end
 
@@ -165,6 +168,7 @@ ActiveRecord::Schema.define(version: 20170525201944) do
   add_foreign_key "addresses", "kommuns"
   add_foreign_key "addresses", "regions"
   add_foreign_key "ckeditor_assets", "companies"
+  add_foreign_key "membership_applications", "member_app_waiting_reasons", column: "member_app_waiting_reasons_id"
   add_foreign_key "membership_applications", "users"
   add_foreign_key "shf_documents", "users", column: "uploader_id"
   add_foreign_key "uploaded_files", "membership_applications"

--- a/features/membership-application-status/admin-custom-reason-waiting.feature
+++ b/features/membership-application-status/admin-custom-reason-waiting.feature
@@ -1,0 +1,80 @@
+Feature: "Other/Custom" waiting reason comes from locale file and Admin cannot edit or delete it
+
+  As an Admin
+  Because the "Other/custom" reason needs to always exist so that the UI (e.g. view) can use it to display a custom text field if it's chosen,
+  And because the text displayed must be always translated,
+  The text displayed for "Other/custom" reason must always come from a locale file
+
+  PT: https://www.pivotaltracker.com/story/show/143810729
+  PT: https://www.pivotaltracker.com/epic/show/3619113 (epic)
+
+
+  This requires a different background set-up than the "admin-manage-reasons..." feature.
+  This requires that the system be seeded *before* any other information is entered (via other background statements).
+
+
+  Background:
+
+    # it is important that this statement is first so that tables are empty, so that things will be seeded
+    # Given the system is seeded with initial data
+
+
+    Given the following users exists
+      | email                                  | admin |
+      | anna_waiting_for_info@nosnarkybarky.se |       |
+      | anna_under_review@nosnarkybarky.se     |       |
+      | emma@happymutts.se                     |       |
+      | admin@shf.se                           | true  |
+
+    Given the following business categories exist
+      | name  | description           |
+      | rehab | physcial rehabitation |
+
+    Given the following regions exist:
+      | name      |
+      | Stockholm |
+
+    Given the following companies exist:
+      | name                 | company_number | email                 | region    |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.se | Stockholm |
+      | HappyMutts           | 2120000142     | woof@happymutts.com   | Stockholm |
+
+
+    And the following applications exist:
+      | first_name      | user_email                             | company_number | category_name | state                 |
+      | AnnaWaiting     | anna_waiting_for_info@nosnarkybarky.se | 5560360793     | rehab         | waiting_for_applicant |
+      | AnnaUnderReview | anna_under_review@nosnarkybarky.se     | 5560360793     | rehab         | under_review          |
+      | EmmaAccepted    | emma@happymutts.se                     | 2120000142     | rehab         | accepted              |
+
+
+    And the following member app waiting reasons exist:
+      | name_sv | name_en | description_sv | description_en | is_custom |
+      | namn 1  | name 1  | beskrivning 1  | description 1  | false     |
+      | namn 2  | name 2  | beskrivning 2  | description 2  | false     |
+
+
+    And I am logged in as "admin@shf.se"
+
+
+  @admin @javascript
+  Scenario: The "other/custom" reason is listed as a reason for the 'waiting for...' status
+    Given I am on "AnnaWaiting" application page
+    Then "member_app_waiting_reasons" should have t("admin_only.member_app_waiting_reasons.other_custom_reason") as an option
+
+  @admin @javascript
+  Scenario: "other/custom" reason is listed when the state is changed TO 'waiting for applicant'
+    Given I am on "AnnaUnderReview" application page
+    When I click on t("membership_applications.ask_applicant_for_info_btn")
+    Then "member_app_waiting_reasons" should have t("admin_only.member_app_waiting_reasons.other_custom_reason") as an option
+
+  @admin @javascript
+  Scenario: "other/custom" reason is listed when the language is changed
+    Given I am on "AnnaWaiting" application page
+    Then "member_app_waiting_reasons" should have t("admin_only.member_app_waiting_reasons.other_custom_reason") as an option
+
+
+  @admin @javascript
+  Scenario: The "other/custom" reason doesn't appear in the list of all reasons
+    Given I am on the "all waiting for info reasons" page
+    Then I should see 2 reasons listed
+    And I should not see t("admin_only.member_app_waiting_reasons.other_custom_reason")

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -1,0 +1,106 @@
+Feature: Admin sets or enters the reason they are waiting for info from a user
+  As an admin
+  so that SHF can talk with the user specifically about why they are waiting and know how long they might need to wait,
+  I need to set the reason why SHF is waiting
+  and if the reason is not available from a list,
+  I need to be able to type in text that describes the situation
+
+  PT: https://www.pivotaltracker.com/story/show/143810729
+
+  Background:
+    Given the following users exists
+      | email                                  | admin |
+      | anna_waiting_for_info@nosnarkybarky.se |       |
+      | admin@shf.com                          | true  |
+
+    Given the following business categories exist
+      | name  | description           |
+      | rehab | physcial rehabitation |
+
+    Given the following regions exist:
+      | name      |
+      | Stockholm |
+
+    Given the following companies exist:
+      | name                 | company_number | email                 | region    |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.se | Stockholm |
+
+
+    And the following applications exist:
+      | first_name  | user_email                             | company_number | category_name | state                 |
+      | AnnaWaiting | anna_waiting_for_info@nosnarkybarky.se | 5560360793     | rehab         | waiting_for_applicant |
+
+
+    And the following member app waiting reasons exist
+      | name_sv                  | description_sv            | name_en                  | description_en                             | is_custom |
+      | need doc                 | need doc                  | need documentation       | need more documents proving qualifications | false     |
+      | waiting for payment      | still waiting for payment | waiting for payment      | still waiting for payment                  | false     |
+
+
+
+
+    And I am logged in as "admin@shf.com"
+
+
+  @javascript @admin
+  Scenario: Admin selects 'need more documentation' as the reason SHF is waiting_for_applicant
+    Given I am on "AnnaWaiting" application page
+    When I set "member_app_waiting_reasons" to "need doc"
+    Then "member_app_waiting_reasons" should have "need doc" selected
+    And I am on the list applications page
+    And I am on "AnnaWaiting" application page
+    Then "member_app_waiting_reasons" should have "need doc" selected
+
+  @javascript @admin
+  Scenario: Admin selects 'waiting for payment' as the reason SHF is waiting_for_applicant
+    Given I am on "AnnaWaiting" application page
+    When I set "member_app_waiting_reasons" to "waiting for payment"
+    And I am on the list applications page
+    And I am on "AnnaWaiting" application page
+    And "member_app_waiting_reasons" should have "waiting for payment" selected
+
+
+  @javascript @admin
+  Scenario: Admin selects 'other' and enters text as the reason SHF is waiting_for_applicant
+    Given I am on "AnnaWaiting" application page
+    When I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
+    When I fill in "custom_reason_text" with "This is my reason"
+    And I press enter in "custom_reason_text"
+    And I am on the list applications page
+    And I am on "AnnaWaiting" application page
+
+    And I should see t("membership_applications.need_info.other_reason_label")
+    And the "custom_reason_text" field should be set to "This is my reason"
+    And "member_app_waiting_reasons" should have t("admin_only.member_app_waiting_reasons.other_custom_reason") selected
+
+
+  @javascript @admin
+  Scenario: Admin selects 'other' and fills in custom text but then changes reason to something else
+    Given I am on "AnnaWaiting" application page
+    When I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
+    And I fill in "custom_reason_text" with "This is my reason"
+    And I press enter in "custom_reason_text"
+    And I set "member_app_waiting_reasons" to "waiting for payment"
+    And I am on the list applications page
+    And I am on "AnnaWaiting" application page
+    And "member_app_waiting_reasons" should have "waiting for payment" selected
+
+
+  @javascript @admin
+  Scenario: When selected reason is not 'custom other,' the custom text is saved as blank (empty string)
+    Given I am on "AnnaWaiting" application page
+
+    When I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
+    And I fill in "custom_reason_text" with "This is my reason"
+    And I press enter in "custom_reason_text"
+    And I set "member_app_waiting_reasons" to "need doc"
+    # change back so the custom reason field shows. it should be blank
+    And I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
+    Then I should not see "This is my reason"
+
+
+  @javascript @member
+  Scenario: owner cannot see the fields for changing the reason
+    Given I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
+    And I am on the application page for "AnnaWaiting"
+    Then I should not see t("membership_applications.need_info.reason_title")

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -80,6 +80,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     When I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
     And I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
+    And I wait for all ajax requests to complete
     And I set "member_app_waiting_reasons" to "waiting for payment"
     And I am on the list applications page
     And I am on "AnnaWaiting" application page

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -420,8 +420,7 @@ end
 
 
 # Checks that a certain option is selected for a text field (from https://github.com/makandra/spreewald)
-Then /^"([^"]*)" should( not)? have (t\()?"([^"]*)"(?:\))? selected$/ do |select_list,
-  negate, translate_start, expected_string|
+Then /^"([^"]*)" should( not)? have t\("([^"]*)"\) selected$/ do |select_list, negate, expected_string |
 
     field = find_field(select_list)
 
@@ -438,11 +437,47 @@ Then /^"([^"]*)" should( not)? have (t\()?"([^"]*)"(?:\))? selected$/ do |select
                       field.value
                   end
 
-  if translate_start
-     expect(field_value).send( (negate ? :not_to : :to),  eq(i18n_content(expected_string)) )
-  else
-    expect(field_value).send( (negate ? :not_to : :to),  eq(expected_string) )
-  end
+
+    expect(field_value).send( (negate ? :not_to : :to),  eq(i18n_content(expected_string)) )
+
+end
+
+
+
+# Checks that a certain option is selected for a text field (from https://github.com/makandra/spreewald)
+Then /^"([^"]*)" should( not)? have "([^"]*)" selected$/ do | select_list, negate, expected_string |
+
+  field = find_field(select_list)
+
+  field_value = case field.tag_name
+                  when 'select'
+                    options = field.all('option')
+                    selected_option = options.detect(&:selected?) || options.first
+                    if selected_option && selected_option.text.present?
+                      selected_option.text.strip
+                    else
+                      ''
+                    end
+                  else
+                    field.value
+                end
+
+  expect(field_value).send( (negate ? :not_to : :to),  eq(expected_string) )
+
+end
+
+
+
+# Checks that a certain option does or does not exist in a select list
+Then /^"([^"]*)" should( not)? have t\("([^"]*)"\) as an option/ do | select_list, negate, expected_string |
+
+  field = find_field(select_list)
+
+  select_options= case field.tag_name
+                  when 'select'
+                    options = field.all('option')
+                end
+  expect(select_options.map(&:text)).send( (negate ? :not_to : :to),  include( i18n_content expected_string) )
 
 end
 

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -28,6 +28,10 @@ And(/^I fill in "([^"]*)" with "([^"]*)"$/) do |field, value|
   fill_in field, with: value
 end
 
+And(/^I press enter in "([^"]*)"$/) do |field|
+  find_field(field).send_keys :enter
+end
+
 And(/^I fill in t\("([^"]*)"\) with "([^"]*)"$/) do |field, value|
   fill_in i18n_content(field), with: value
 end
@@ -106,6 +110,11 @@ end
 
 When(/^(?:I|they) select "([^"]*)" in select list t\("([^"]*)"\)$/) do |item, lst|
   lst = i18n_content("#{lst}")
+  find(:select, lst).find(:option, item).select_option
+end
+
+
+When(/^(?:I|they) select "([^"]*)" in select list "([^"]*)"$/) do |item, lst|
   find(:select, lst).find(:option, item).select_option
 end
 

--- a/features/step_definitions/member_app_waiting_reason_steps.rb
+++ b/features/step_definitions/member_app_waiting_reason_steps.rb
@@ -17,8 +17,20 @@ Given(/^I am on the edit member app waiting reason with name_sv "([^"]*)"$/) do 
   visit path_with_locale(edit_admin_only_member_app_waiting_reason_path reason)
 end
 
+Given(/^I am on the edit member app waiting reason with name_sv t\("([^"]*)"\)$/) do | locale_reason_name_sv |
+  reason = AdminOnly::MemberAppWaitingReason.find_by_name_sv(  i18n_content(locale_reason_name_sv) )
+  visit path_with_locale(edit_admin_only_member_app_waiting_reason_path reason)
+end
+
 
 Given(/^I am on the member app waiting reason page for name_sv "([^"]*)"$/) do | reason_name_sv |
   reason = AdminOnly::MemberAppWaitingReason.find_by_name_sv(reason_name_sv)
   visit path_with_locale(admin_only_member_app_waiting_reason_path reason)
 end
+
+
+Given(/^I am on the member app waiting reason with name_sv t\("([^"]*)"\)$/) do | locale_reason_name_sv |
+  reason = AdminOnly::MemberAppWaitingReason.find_by_name_sv(  i18n_content(locale_reason_name_sv) )
+  visit path_with_locale(admin_only_member_app_waiting_reason_path reason)
+end
+

--- a/spec/helpers/membership_applications_helper_spec.rb
+++ b/spec/helpers/membership_applications_helper_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 RSpec.describe MembershipApplicationsHelper, type: :helper do
 
+  before(:all) do
+    # ensure MembershipAppWaitingReason.all is empty
+    AdminOnly::MemberAppWaitingReason.delete_all
+  end
+
+
   describe '#member_full_name' do
     it 'appends first and last with a space inbetween' do
       assign(:membership_application, create(:membership_application, first_name: 'Kitty', last_name: 'Kat', user: create(:user)))
@@ -10,4 +16,197 @@ RSpec.describe MembershipApplicationsHelper, type: :helper do
 
   end
 
+
+  describe 'returns a list of reasons_for_waiting for the right locale' do
+
+    before(:all) do
+      FactoryGirl.create(:member_app_waiting_reason, name_sv: 'name_sv1', name_en: 'name_en1', description_sv: 'desc_sv1', description_en: 'desc_en1')
+      FactoryGirl.create(:member_app_waiting_reason, name_sv: 'name_sv2', name_en: 'name_en2', description_sv: 'desc_sv2', description_en: 'desc_en2')
+      FactoryGirl.create(:member_app_waiting_reason, name_sv: 'name_sv3', name_en: 'name_en3', description_sv: 'desc_sv3', description_en: 'desc_en3')
+    end
+
+    let(:reason1) { AdminOnly::MemberAppWaitingReason.find_by_name_sv('name_sv1') }
+    let(:reason2) { AdminOnly::MemberAppWaitingReason.find_by_name_sv('name_sv2') }
+    let(:reason3) { AdminOnly::MemberAppWaitingReason.find_by_name_sv('name_sv3') }
+
+
+    describe '#reasons_for_waiting_names' do
+
+      let(:expected_sv_names) { [ [reason1.id, 'name_sv1'], [reason2.id, 'name_sv2'], [reason3.id, 'name_sv3'] ] }
+      let(:expected_en_names) { [ [reason1.id, 'name_en1'], [reason2.id, 'name_en2'], [reason3.id, 'name_en3'] ] }
+
+      it 'calls name_sv if locale == sv' do
+        name_list = helper.reasons_for_waiting_names(:sv)
+        expect(name_list).to match expected_sv_names
+      end
+
+      it 'calls name_en if locale == en' do
+        name_list = helper.reasons_for_waiting_names(:en)
+        expect(name_list).to match expected_en_names
+      end
+
+      it 'calls default_name_method if there is no name method for that locale' do
+        name_list = helper.reasons_for_waiting_names(:blorf)
+        expect(name_list).to match expected_sv_names
+      end
+
+      it 'calls default_name_method if no locale is specified' do
+        name_list = helper.reasons_for_waiting_names
+        expect(name_list).to match expected_sv_names
+      end
+
+
+      it 'returns a list of [id, text]' do
+        name_list = helper.reasons_for_waiting_names
+        first_item = name_list.first
+        expect(first_item.is_a?(Enumerable)).to be_truthy
+        expect(first_item.first.is_a?(Numeric)).to be_truthy
+        expect(first_item.last.is_a?(String)).to be_truthy
+      end
+
+    end
+
+
+    describe '#reason_name_method' do
+
+      it 'is :name_sv if locale == :sv' do
+        expect(helper.reason_name_method(:sv)).to eq :name_sv
+      end
+
+      it 'is :name_en if locale == :en' do
+        expect(helper.reason_name_method(:en)).to eq :name_en
+      end
+
+      it 'is default name method if there is no desc method for that locale' do
+        expect(helper.reason_name_method(:blorf)).to eq AdminOnly::MemberAppWaitingReason.default_name_method
+      end
+
+      it 'is default name method if no locale is specified' do
+        expect(helper.reason_name_method).to eq AdminOnly::MemberAppWaitingReason.default_name_method
+      end
+
+    end
+
+
+    describe '#reason_description_method' do
+
+      it 'is :desc_sv if locale == :sv' do
+        expect(helper.reason_desc_method(:sv)).to eq :description_sv
+      end
+
+      it 'is :desc_en if locale == :en' do
+        expect(helper.reason_desc_method(:en)).to eq :description_en
+      end
+
+      it 'is default desc method if there is no desc method for that locale' do
+        expect(helper.reason_desc_method(:blorf)).to eq AdminOnly::MemberAppWaitingReason.default_description_method
+      end
+
+      it 'is default desc method if no locale is specified' do
+        expect(helper.reason_desc_method).to eq AdminOnly::MemberAppWaitingReason.default_description_method
+      end
+
+    end
+
+
+    describe '#reasons_for_waiting_descs' do
+
+      let(:expected_sv_descs) { [ [reason1.id, 'desc_sv1'], [reason2.id, 'desc_sv2'], [reason3.id, 'desc_sv3'] ] }
+      let(:expected_en_descs) { [ [reason1.id, 'desc_en1'], [reason2.id, 'desc_en2'], [reason3.id, 'desc_en3'] ] }
+
+      it 'calls description_sv if locale == sv' do
+        desc_list = helper.reasons_for_waiting_descs(:sv)
+        expect(desc_list).to match expected_sv_descs
+      end
+
+      it 'calls description_en if locale == en' do
+        desc_list = helper.reasons_for_waiting_descs(:en)
+        expect(desc_list).to match expected_en_descs
+      end
+
+      it 'calls default_description_method if there is no desc method for that locale' do
+        desc_list = helper.reasons_for_waiting_descs(:blorf)
+        expect(desc_list).to match expected_sv_descs
+      end
+
+      it 'calls default_description_method if no locale is specified' do
+        desc_list = helper.reasons_for_waiting_descs
+        expect(desc_list).to match expected_sv_descs
+      end
+
+
+      it 'returns a list of [id, text]' do
+        desc_list = helper.reasons_for_waiting_descs
+        first_item = desc_list.first
+        expect(first_item.is_a?(Enumerable)).to be_truthy
+        expect(first_item.first.is_a?(Numeric)).to be_truthy
+        expect(first_item.last.is_a?(String)).to be_truthy
+      end
+
+    end
+
+  end
+
+
+  describe "#reasons_collection appends an 'other' reason with name from the locale file" do
+
+    it 'other reason is at the end of the list' do
+
+      FactoryGirl.create(:member_app_waiting_reason, name_sv: 'name_sv1', name_en: 'name_en1', description_sv: 'desc_sv1', description_en: 'desc_en1')
+      FactoryGirl.create(:member_app_waiting_reason, name_sv: 'name_sv2', name_en: 'name_en2', description_sv: 'desc_sv2', description_en: 'desc_en2')
+
+      last_r = helper.reasons_collection(-999, 'other').last
+      expect(last_r.name_sv).to eq 'other'
+      expect(last_r.id).to eq -999
+
+    end
+
+    it "locale = default ( == sv); sets the name_sv" do
+      last_r = helper.reasons_collection(-999, 'other').last
+      expect(last_r.name_sv).to eq 'other'
+      expect(last_r.name_en).to be_nil
+    end
+
+    it 'locale = sv; sets the name_sv' do
+      last_r = helper.reasons_collection(-999, 'other').last
+      expect(last_r.name_sv).to eq 'other'
+      expect(last_r.name_en).to be_nil
+    end
+
+    it 'locale = en; sets the name_en' do
+      orig_locale = I18n.locale
+      I18n.locale = :en
+      last_r = helper.reasons_collection(-999, 'other').last
+      expect(last_r.name_sv).to be_nil
+      expect(last_r.name_en).to eq 'other'
+      I18n.locale = orig_locale
+    end
+
+  end
+
+  describe '#selected_reason_value' do
+
+    let(:member_app) { create(:membership_application) }
+
+    it '@other_reason_value if there is something in custom reason text' do
+      member_app.custom_reason_text = 'something'
+      expect(helper.selected_reason_value(member_app, -999)).to eq -999
+    end
+
+
+    describe 'member_app_waiting_reasons_id if there is not something in custom reason text' do
+
+      it 'member_app_waiting_reasons_id if custom_reason_text == empty string ' do
+        member_app.custom_reason_text = ''
+        expect(helper.selected_reason_value(member_app, -999)).to eq member_app.member_app_waiting_reasons_id
+      end
+
+      it 'member_app_waiting_reasons_id if custom_reason_text == nil' do
+        member_app.custom_reason_text = nil
+        expect(helper.selected_reason_value(member_app, -999)).to eq member_app.member_app_waiting_reasons_id
+      end
+
+    end
+
+  end
 end

--- a/spec/models/member_app_waiting_reason_spec.rb
+++ b/spec/models/member_app_waiting_reason_spec.rb
@@ -24,30 +24,5 @@ RSpec.describe AdminOnly::MemberAppWaitingReason, type: :model do
 
   end
 
-  describe '#other_reason_placeholder?' do
-
-    let(:reason) { subject }
-
-    it 'false if name_sv is empty' do
-      reason.name_sv = ''
-      expect(reason.other_reason_placeholder?).to be_falsey
-    end
-
-    it 'false if name_sv is nil' do
-      reason.name_sv = nil
-      expect(reason.other_reason_placeholder?).to be_falsey
-    end
-
-    it "false if name_sv is not the 'other reason' name" do
-      reason.name_sv = "blorf"
-      expect(reason.other_reason_placeholder?).to be_falsey
-    end
-
-    it "true if name_sv is equal to the 'other reason' name" do
-      reason.name_sv = reason.class.other_reason_name
-      expect(reason.other_reason_placeholder?).to be_truthy
-    end
-
-  end
 
 end

--- a/spec/models/membership_application_spec.rb
+++ b/spec/models/membership_application_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe MembershipApplication, type: :model do
     it {is_expected.to have_db_column :contact_email}
     it {is_expected.to have_db_column :membership_number}
     it {is_expected.to have_db_column :state}
+    it {is_expected.to have_db_column :custom_reason_text}
   end
 
   describe 'Validations' do
@@ -81,6 +82,7 @@ RSpec.describe MembershipApplication, type: :model do
     it {is_expected.to belong_to :user}
     it {is_expected.to have_and_belong_to_many :business_categories}
     it {is_expected.to belong_to :company}
+    it {is_expected.to belong_to :waiting_reason}
   end
 
   describe "Uploaded Files" do


### PR DESCRIPTION
PT Story:  https://www.pivotaltracker.com/story/show/143810729

This is the 2nd PR (the 2nd half) for the story.
(And this is the 2nd version of the 2nd PR for the 2nd half of the story.)

Changes proposed in this pull request:
2. UI: the _reasons for waiting_ has been moved to above the _application status buttons
3.  Uses AJAX (UJS) to update the db immediately when a reason is selected from the list.  The db is also updated immediately when the text for a 'custom/other' reason is entered.

### Screenshots (Optional):

**"Select a reason..." is a placeholder prompt if no reason is set for the application:**

<img width="781" alt="screen shot 2017-06-28 at 1 46 10 am" src="https://user-images.githubusercontent.com/673794/27628429-da98557c-5ba3-11e7-8233-17428b43fd43.png">


<img width="770" alt="screen shot 2017-06-28 at 1 46 20 am" src="https://user-images.githubusercontent.com/673794/27628426-da938934-5ba3-11e7-9bdb-741e283c8ebb.png">

---

**List of reasons is in the correct locale**

<img width="745" alt="screen shot 2017-06-28 at 1 47 36 am" src="https://user-images.githubusercontent.com/673794/27628427-da952334-5ba3-11e7-8aad-10192cd47ec5.png">


<img width="748" alt="screen shot 2017-06-28 at 1 47 28 am" src="https://user-images.githubusercontent.com/673794/27628430-daa186d8-5ba3-11e7-8f1f-23f8fe62b825.png">


---

**The text field for typing in the "other reason" only shows if that reason is selected**

<img width="757" alt="screen shot 2017-06-28 at 1 44 35 am" src="https://user-images.githubusercontent.com/673794/27628312-7a2bca84-5ba3-11e7-9917-a9acd32102fc.png">


<img width="771" alt="screen shot 2017-06-28 at 1 46 39 am" src="https://user-images.githubusercontent.com/673794/27628428-da9568b2-5ba3-11e7-9612-210214e3bdb6.png">

---

#### The reason isn't shown if the status is not 'Waiting for Applicant'
<img width="623" alt="reasonwaiting-hidden-unless-status-en" src="https://user-images.githubusercontent.com/673794/27395497-dc49d9a2-5664-11e7-8ce8-74a0a92002da.png">

---


<img width="845" alt="reasonwaiting-other-reason-text-en" src="https://user-images.githubusercontent.com/673794/27395495-dc4919cc-5664-11e7-9919-3b4443db5264.png">


Ready for review:
@patmbolger @thesuss @RobertCram 
