### PR TITLE
Spint17 #148093527 make js tests wait for ajax

### DIFF
--- a/features/delete-company.feature
+++ b/features/delete-company.feature
@@ -175,6 +175,7 @@ Feature: As an admin
 
   @poltergeist
   Scenario: Admin cannot delete a company with 1 accepted and 1 rejected membership application
+    Given I am logged in as "admin@shf.se"
 
 
   @poltergeist

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -113,7 +113,7 @@ Then(/^I wait(?: for)? (\d+) second(?:s)?$/) do |seconds|
   sleep seconds.to_i.seconds
 end
 
-And  /^I wait for all ajax requests to complete$/ do
+And /^I wait for all ajax requests to complete$/ do
   Timeout.timeout(Capybara.default_max_wait_time) do
     loop until page.evaluate_script('window.jQuery ? jQuery.active : false').zero?
   end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -115,7 +115,7 @@ end
 
 And /^I wait for all ajax requests to complete$/ do
   Timeout.timeout(Capybara.default_max_wait_time) do
-    loop until page.evaluate_script('window.jQuery ? jQuery.active : false').zero?
+    loop until page.evaluate_script('window.jQuery ? jQuery.active : 0').zero?
   end
 end
 

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -113,9 +113,9 @@ Then(/^I wait(?: for)? (\d+) second(?:s)?$/) do |seconds|
   sleep seconds.to_i.seconds
 end
 
-And (/^I wait for ajax$/) do
+And  /^I wait for all ajax requests to complete$/ do
   Timeout.timeout(Capybara.default_max_wait_time) do
-    loop until page.evaluate_script('window.jQuery ? jQuery.active : 0').zero?
+    loop until page.evaluate_script('window.jQuery ? jQuery.active : false').zero?
   end
 end
 

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -113,6 +113,11 @@ Then(/^I wait(?: for)? (\d+) second(?:s)?$/) do |seconds|
   sleep seconds.to_i.seconds
 end
 
+And (/^I wait for ajax$/) do
+  Timeout.timeout(Capybara.default_max_wait_time) do
+    loop until page.evaluate_script('window.jQuery ? jQuery.active : 0').zero?
+  end
+end
 
 When(/^(?:I|they) select t\("([^"]*)"\) in select list "([^"]*)"$/) do |item, lst|
   selected = i18n_content("#{item}")

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -4,7 +4,7 @@ end
 
 After('@javascript, @poltergeist') do
   Timeout.timeout(Capybara.default_max_wait_time) do
-    loop until page.evaluate_script('window.jQuery ? jQuery.active : false').zero?
+    loop until page.evaluate_script('window.jQuery ? jQuery.active : 0').zero?
   end
   Capybara.reset_sessions!
   Capybara.current_driver = :rack_test

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -4,7 +4,7 @@ end
 
 After('@javascript, @poltergeist') do
   Timeout.timeout(Capybara.default_max_wait_time) do
-    loop until page.evaluate_script('window.jQuery ? jQuery.active : 0').zero?
+    loop until page.evaluate_script('window.jQuery ? jQuery.active : false').zero?
   end
   Capybara.reset_sessions!
   Capybara.current_driver = :rack_test

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -3,6 +3,9 @@ Before('@javascript, @poltergeist') do
 end
 
 After('@javascript, @poltergeist') do
+  Timeout.timeout(Capybara.default_max_wait_time) do
+    loop until page.evaluate_script('window.jQuery ? 0 : jQuery.active').zero?
+  end
   Capybara.reset_sessions!
   Capybara.current_driver = :rack_test
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -4,7 +4,7 @@ end
 
 After('@javascript, @poltergeist') do
   Timeout.timeout(Capybara.default_max_wait_time) do
-    loop until page.evaluate_script('window.jQuery ? 0 : jQuery.active').zero?
+    loop until page.evaluate_script('window.jQuery ? jQuery.active : 0').zero?
   end
   Capybara.reset_sessions!
   Capybara.current_driver = :rack_test

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -112,11 +112,13 @@ Feature: As a visitor,
     And I am on the "landing" page
     Then I should see t("companies.index.h_companies_listed_below")
     And "items_count" should have "10" selected
+    Then I wait for ajax
     And I should see "10" companies
     And I should see "Company10"
     And I should not see "Company11"
     And I should not see "Company26"
     Then I set "items_count" to "25"
+    Then I wait for ajax
     And I should see "25" companies
     And "items_count" should have "25" selected
     And I should see "Company10"
@@ -124,6 +126,7 @@ Feature: As a visitor,
     And I should see "Company25"
     And I should not see "Company26"
     Then I set "items_count" to "All"
+    Then I wait for ajax
     And I should see "27" companies
     And I should see "Company26"
     And I should see "Company27"

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -112,21 +112,20 @@ Feature: As a visitor,
     And I am on the "landing" page
     Then I should see t("companies.index.h_companies_listed_below")
     And "items_count" should have "10" selected
-    Then I wait for ajax
     And I should see "10" companies
     And I should see "Company10"
     And I should not see "Company11"
     And I should not see "Company26"
     Then I set "items_count" to "25"
-    Then I wait for ajax
-    And I should see "25" companies
+    And I wait for all ajax requests to complete
+    Then I should see "25" companies
     And "items_count" should have "25" selected
     And I should see "Company10"
     And I should see "Company11"
     And I should see "Company25"
     And I should not see "Company26"
     Then I set "items_count" to "All"
-    Then I wait for ajax
-    And I should see "27" companies
+    And I wait for all ajax requests to complete
+    Then I should see "27" companies
     And I should see "Company26"
     And I should see "Company27"


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/148093527

**Changes proposed in this pull request:**

1) Make sure all ajax interactions have ended before ending tests, so they can't wreak havoc on other tests.

2) Add a separate "I wait for all ajax steps to complete" step to be used in between steps in feature tests

I couldn't find a quick way to DRY out the duplicate code, so that should still be done.

Ready for review:
@patrick @ashley