### PR TITLE
Show all user emails - profile (login) as well as contact (application) emails

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -192,6 +192,10 @@ select {
   align-items: center;
 }
 
+.standard-label {
+  font-weight: bold;
+}
+
 /*!
  *nicelabel JQuery Plugin
  *

--- a/app/views/membership_applications/show.html.haml
+++ b/app/views/membership_applications/show.html.haml
@@ -10,7 +10,13 @@
 
     = render 'membership_number'
 
-    %p= mail_to @membership_application.contact_email, @membership_application.contact_email
+    %p= field_or_none("#{t('activerecord.attributes.user.email')}",
+                      mail_to(@membership_application.user.email),
+                      label_class: 'standard-label')
+
+    %p= field_or_none("#{t('.contact_email')}",
+                      mail_to(@membership_application.contact_email),
+                      label_class: 'standard-label')
 
     - if @membership_application.phone_number
       %p #{t('.phone_number')}: #{@membership_application.phone_number}

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -16,7 +16,7 @@
     = field_or_none("#{t('applications')}", t('none'), label_class: 'standard-label')
   - else
     -# .col-sm-3{ style: 'margin-left: -15px;' }
-    %strong #{t('applications')}:
+    %span.standard-label #{t('applications')}:
 
     .row
       %table.table.table-hover
@@ -42,7 +42,7 @@
               %td= link_to(app.company_number, membership_application_path(app))
               %td= app.company&.name
 
-  %strong #{t('user_activity')}:
+  %span.standard-label #{t('user_activity')}:
 
   .row
     Account #{t('.created')} #{i18n_time_ago_in_words(@user.created_at)}

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -52,7 +52,7 @@
       #{@user.email} #{t('.user_has_never_signed_in')}
 
     - else
-      = #{t('.last_login')}:
+      = "#{t('.last_login')}:"
       #{ most_recent_login_time @user}
       (#{i18n_time_ago_in_words(most_recent_login_time @user)})
       %br

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -13,7 +13,7 @@
   = field_or_none("#{t('.email')}", mail_to(@user.email), label_class: 'standard-label')
 
   - unless @user.membership_applications.exists?
-    = field_or_none("#{t('applications')}", 'None', label_class: 'standard-label')
+    = field_or_none("#{t('applications')}", t('none'), label_class: 'standard-label')
   - else
     -# .col-sm-3{ style: 'margin-left: -15px;' }
     %strong #{t('applications')}:
@@ -45,31 +45,27 @@
   %strong #{t('user_activity')}:
 
   .row
+    Account #{t('.created')} #{i18n_time_ago_in_words(@user.created_at)}
 
+    %p
     - if @user.last_sign_in_at.blank? && @user.current_sign_in_at.blank?
       #{@user.email} #{t('.user_has_never_signed_in')}
 
     - else
-      %b #{t('.last_login')}:
+      = "#{t('.last_login')}:"
       #{ most_recent_login_time @user}
       (#{i18n_time_ago_in_words(most_recent_login_time @user)})
-    %p
-      %b #{t('.logged_in_count')}:
+      %br
+      #{t('.logged_in_count')}:
       = @user.sign_in_count
 
     %p
-      - if @user.reset_password_sent_at.blank?
-        = t('.password_never_reset')
-      - else
-        %b #{t('.reset_password_sent_at')}:
-        #{@user.reset_password_sent_at}
-        #{i18n_time_ago_in_words(@user.reset_password_sent_at)})
-
-
-    %p
-      %b #{t('.created')}:
-      = @user.created_at
-      (#{i18n_time_ago_in_words(@user.created_at)})
+    - if @user.reset_password_sent_at.blank?
+      = t('.password_never_reset')
+    - else
+      %b #{t('.reset_password_sent_at')}:
+      #{@user.reset_password_sent_at}
+      #{i18n_time_ago_in_words(@user.reset_password_sent_at)})
 
   %hr
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -10,36 +10,66 @@
 
 
 .entry-content
-  %p
-    %b #{t('.email')}:
-    = @user.email
+  = field_or_none("#{t('.email')}", mail_to(@user.email), label_class: 'standard-label')
 
-  - if @user.last_sign_in_at.blank? && @user.current_sign_in_at.blank?
-    %p #{@user.email} #{t('.user_has_never_signed_in')}
-
+  - unless @user.membership_applications.exists?
+    = field_or_none("#{t('applications')}", 'None', label_class: 'standard-label')
   - else
-    %p
+    -# .col-sm-3{ style: 'margin-left: -15px;' }
+    %strong #{t('applications')}:
+
+    .row
+      %table.table.table-hover
+        %thead
+          %tr
+            %th
+              = t('activerecord.attributes.membership_application.contact_email')
+            %th
+              = t('activerecord.attributes.membership_application.state')
+            %th
+              = t('activerecord.attributes.membership_application.company_number')
+            %th
+              = t('activerecord.attributes.company.name')
+        %tbody
+          - @user.membership_applications.includes(:company).each do |app|
+            %tr.membership_application
+              %td= mail_to(app.contact_email)
+              %td
+                - if app.accepted?
+                  %span.yes= app.state
+                - else
+                  %span.no= app.state
+              %td= link_to(app.company_number, membership_application_path(app))
+              %td= app.company&.name
+
+  %strong #{t('user_activity')}:
+
+  .row
+
+    - if @user.last_sign_in_at.blank? && @user.current_sign_in_at.blank?
+      #{@user.email} #{t('.user_has_never_signed_in')}
+
+    - else
       %b #{t('.last_login')}:
       #{ most_recent_login_time @user}
       (#{i18n_time_ago_in_words(most_recent_login_time @user)})
-
     %p
       %b #{t('.logged_in_count')}:
       = @user.sign_in_count
 
-  %p
-    - if @user.reset_password_sent_at.blank?
-      = t('.password_never_reset')
-    - else
-      %b #{t('.reset_password_sent_at')}:
-      #{@user.reset_password_sent_at}
-      #{i18n_time_ago_in_words(@user.reset_password_sent_at)})
+    %p
+      - if @user.reset_password_sent_at.blank?
+        = t('.password_never_reset')
+      - else
+        %b #{t('.reset_password_sent_at')}:
+        #{@user.reset_password_sent_at}
+        #{i18n_time_ago_in_words(@user.reset_password_sent_at)})
 
 
-  %p
-    %b #{t('.created')}:
-    = @user.created_at
-    (#{i18n_time_ago_in_words(@user.created_at)})
+    %p
+      %b #{t('.created')}:
+      = @user.created_at
+      (#{i18n_time_ago_in_words(@user.created_at)})
 
   %hr
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -52,7 +52,7 @@
       #{@user.email} #{t('.user_has_never_signed_in')}
 
     - else
-      = "#{t('.last_login')}:"
+      = #{t('.last_login')}:
       #{ most_recent_login_time @user}
       (#{i18n_time_ago_in_words(most_recent_login_time @user)})
       %br

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
   'no': &no 'No'
   applications: &applications Applications
   user_activity: User Activity
+  none: &none None
 
   time_ago: '%{amount_of_time} ago'
 
@@ -203,7 +204,7 @@ en:
     post_code: *post_code
     city: *city
     kommun: *kommun
-    none: None
+    none: *none
 
  # Automatic and manual lookup for views:
   membership_applications:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,8 @@ en:
   search: &search Search
   'yes': &yes 'Yes'
   'no': &no 'No'
+  applications: &applications Applications
+  user_activity: User Activity
 
   time_ago: '%{amount_of_time} ago'
 
@@ -99,7 +101,7 @@ en:
     attributes:
 
       user:
-        email: &email Email
+        email: &email Profile Email
         password: *password
         password_confirmation: Password confirmation
         created: &created Created
@@ -116,7 +118,7 @@ en:
         company_number: &company_number Company number
         first_name: &first_name First name
         last_name: &last_name Last name
-        contact_email: &contact_email Email
+        contact_email: &contact_email Contact Email
         state: &state Status
         phone_number: Phone number
         membership_number: Membership number
@@ -518,7 +520,7 @@ en:
       last_login: *user_last_login
       logged_in_count: *sign_in_count
       member: Member
-      applications: Applications
+      applications: *applications
       applications_tooltip: Number of open applications
       'yes': *yes  # https://coderwall.com/p/ld65tq/rails-i18n-yes-no-translation
       'no': *no

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -33,6 +33,8 @@ sv:
   search: &search Sök
   'yes': &yes Ja
   'no': &no Nej
+  applications: &applications Ansökningar
+  user_activity: Användaraktivitet
 
   time_ago: '%{amount_of_time} sedan'
 
@@ -99,7 +101,7 @@ sv:
     attributes:
 
       user:
-        email: &email E-post
+        email: &email Profil E-post
         password: *password
         password_confirmation: Lösenordsbekräftelse
         created: &created Skapad
@@ -519,7 +521,7 @@ sv:
       last_login: *user_last_login
       logged_in_count: *sign_in_count
       member: Medlem
-      applications: Ansökningar
+      applications: *applications
       applications_tooltip: Antal öppna ansökningar
       'yes': *yes  # https://coderwall.com/p/ld65tq/rails-i18n-yes-no-translation
       'no': *no

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -35,6 +35,7 @@ sv:
   'no': &no Nej
   applications: &applications Ansökningar
   user_activity: Användaraktivitet
+  none: &none Ingen
 
   time_ago: '%{amount_of_time} sedan'
 
@@ -205,7 +206,7 @@ sv:
     post_code: *post_code
     city: *city
     kommun: *kommun
-    none: Ingen
+    none: *none
 
   # Automatisk och manuell sökning för views:
   membership_applications:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -98,22 +98,22 @@ ActiveRecord::Schema.define(version: 20170615091313) do
   end
 
   create_table "membership_applications", force: :cascade do |t|
-    t.string   "company_number"
-    t.string   "phone_number"
-    t.datetime "created_at",                                    null: false
-    t.datetime "updated_at",                                    null: false
-    t.integer  "user_id"
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "contact_email"
-    t.integer  "company_id"
-    t.string   "membership_number"
-    t.string   "state",                         default: "new"
-    t.integer  "member_app_waiting_reasons_id"
-    t.string   "custom_reason_text"
-    t.index ["company_id"], name: "index_membership_applications_on_company_id", using: :btree
-    t.index ["member_app_waiting_reasons_id"], name: "index_membership_applications_on_member_app_waiting_reasons_id", using: :btree
-    t.index ["user_id"], name: "index_membership_applications_on_user_id", using: :btree
+    t.string "company_number"
+    t.string "phone_number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "contact_email"
+    t.bigint "company_id"
+    t.string "membership_number"
+    t.string "state", default: "new"
+    t.integer "member_app_waiting_reasons_id"
+    t.string "custom_reason_text"
+    t.index ["company_id"], name: "index_membership_applications_on_company_id"
+    t.index ["member_app_waiting_reasons_id"], name: "index_membership_applications_on_member_app_waiting_reasons_id"
+    t.index ["user_id"], name: "index_membership_applications_on_user_id"
   end
 
   create_table "regions", force: :cascade do |t|

--- a/features/show-user-details.feature
+++ b/features/show-user-details.feature
@@ -7,27 +7,34 @@ Feature: As an admin
   Background:
 
     Given the following users exists
-      | email                  | admin |
-      | emma@happymutts.com    |       |
-      | lars@happymutts.com    |       |
-      | hannah@happymutts.com  |       |
-      | nils@bowsers.se        |       |
-      | anna@bowsers.se        |       |
-      | sam@bowsers.se         |       |
-      | admin@shf.se           | true  |
-      | yesterday_admin@shf.se | true  |
-      | lazy_admin@shf.se      | true  |
+      | email                   | admin |
+      | emma@personal.com       |       |
+      | lars@personal.com       |       |
+      | hannah@personal.com     |       |
+      | nils@personal.se        |       |
+      | anna@personal.se        |       |
+      | sam@personal.se         |       |
+      | admin@shf.se            | true  |
+      | yesterday_admin@shf.se  | true  |
+      | lazy_admin@shf.se       | true  |
 
+    And the following regions exist:
+      | name         |
+      | Stockholm    |
+      | Västerbotten |
 
     And the following companies exist:
-      | Happy Mutts | 5560360793 | woof@happymutts.com | Stockholm |
+      | name        | company_number | email               | region       |
+      | Happy Mutts | 5560360793     | woof@happymutts.com | Stockholm    |
+      | Bowsers     | 2120000142     | bark@bowsers.com    | Västerbotten |
 
 
     And the following applications exist:
-      | first_name | user_email            | company_number | state    |
-      | Emma       | emma@happymutts.com   | 5560360793     | accepted |
-      | Lars       | lars@happymutts.com   | 5560360793     | accepted |
-      | Hannah     | hannah@happymutts.com | 5560360793     | accepted |
+      | first_name | user_email          | contact_email         | company_number | state    |
+      | Emma       | emma@personal.com   | emma@happymutts.com   | 5560360793     | accepted |
+      | Lars       | lars@personal.com   | lars@happymutts.com   | 5560360793     | accepted |
+      | Hannah     | hannah@personal.com | hannah@happymutts.com | 5560360793     | accepted |
+      | Emma       | emma@personal.com   | emma@bowsers.com      | 2120000142     | new      |
 
 
 
@@ -60,31 +67,31 @@ Feature: As an admin
 
   @member
   Scenario: Show a member who has never logged in
-    When I am on the "user details" page for "hannah@happymutts.com"
+    When I am on the "user details" page for "hannah@personal.com"
     Then I should not see t("users.show.is_an_admin")
     And I should see t("users.show.user_has_never_signed_in")
     And I should not see t("users.show.last_login")
 
   @member
   Scenario: Show a member that is currently logged in
-    Given The user "emma@happymutts.com" is currently signed in
-    When I am on the "user details" page for "emma@happymutts.com"
+    Given The user "emma@personal.com" is currently signed in
+    When I am on the "user details" page for "emma@personal.com"
     Then I should not see t("users.show.is_an_admin")
     And I should not see t("users.show.user_has_never_signed_in")
     And I should see t("users.show.last_login")
 
   @member
   Scenario: Show a member that logged 3 days ago
-    Given The user "lars@happymutts.com" last logged in 3 days ago
-    When I am on the "user details" page for "lars@happymutts.com"
+    Given The user "lars@personal.com" last logged in 3 days ago
+    When I am on the "user details" page for "lars@personal.com"
     Then I should not see t("users.show.is_an_admin")
     And I should not see t("users.show.user_has_never_signed_in")
     And I should see t("users.show.last_login")
 
   @member
   Scenario: Show a member that has logged in 42 times
-    Given The user "lars@happymutts.com" has logged in 42 times
-    When I am on the "user details" page for "lars@happymutts.com"
+    Given The user "lars@personal.com" has logged in 42 times
+    When I am on the "user details" page for "lars@personal.com"
     Then I should see t("users.show.logged_in_count")
     And I should see "42"
     And I should see t("users.show.last_login")
@@ -92,35 +99,44 @@ Feature: As an admin
 
   @member
   Scenario: Show a member that has had her password reset
-    Given The user "emma@happymutts.com" has had her password reset now
-    When I am on the "user details" page for "emma@happymutts.com"
+    Given The user "emma@personal.com" has had her password reset now
+    When I am on the "user details" page for "emma@personal.com"
     Then I should see t("users.show.reset_password_sent_at")
 
   @member
   Scenario: Show a member that has never had her password reset
-    When I am on the "user details" page for "emma@happymutts.com"
+    When I am on the "user details" page for "emma@personal.com"
     Then I should see t("users.show.password_never_reset")
 
 
   @user
   Scenario: Show an user who has never logged in
-    When I am on the "user details" page for "nils@bowsers.se"
+    When I am on the "user details" page for "nils@personal.se"
     Then I should not see t("users.show.is_an_admin")
     And I should see t("users.show.user_has_never_signed_in")
     And I should not see t("users.show.last_login")
 
   @user
   Scenario: Show an user that is currently logged in
-    Given The user "anna@bowsers.se" is currently signed in
-    When I am on the "user details" page for "anna@bowsers.se"
+    Given The user "anna@personal.se" is currently signed in
+    When I am on the "user details" page for "anna@personal.se"
     Then I should not see t("users.show.is_an_admin")
     And I should not see t("users.show.user_has_never_signed_in")
     And I should see t("users.show.last_login")
 
   @user
   Scenario: Show an user that logged in 100 days ago
-    Given The user "sam@bowsers.se" last logged in 100 days ago
-    When I am on the "user details" page for "sam@bowsers.se"
+    Given The user "sam@personal.se" last logged in 100 days ago
+    When I am on the "user details" page for "sam@personal.se"
     Then I should not see t("users.show.is_an_admin")
     And I should not see t("users.show.user_has_never_signed_in")
     And I should see t("users.show.last_login")
+
+  @user
+  Scenario: Show all emails and applications for a user
+    When I am on the "user details" page for "emma@personal.com"
+    Then I should see "emma@personal.com"
+    And I should see "emma@happymutts.com"
+    And I should see "emma@bowsers.com"
+    And I should see "5560360793"
+    And I should see "2120000142"

--- a/features/show_membership_application.feature
+++ b/features/show_membership_application.feature
@@ -13,7 +13,7 @@ Feature: As an Admin
   Background:
     Given the following users exists
       | email                               | admin |
-      | emma@random.com                     |       |
+      | emma@personal.com                   |       |
       | hans@random.com                     |       |
       | anna_needs_info@random.com          |       |
       | lars_rejected@snarkybark.se         |       |
@@ -37,14 +37,14 @@ Feature: As an Admin
       | No More Snarky Barky | 5560360793     | snarky@snarkybarky.se |
 
     And the following applications exist:
-      | first_name         | user_email                          | company_number | state                 | categories   |
-      | Emma               | emma@random.com                     | 5562252998     | waiting_for_applicant | Psychologist |
-      | Hans               | hans@random.com                     | 5560360793     | waiting_for_applicant | Psychologist |
-      | Anna               | anna_needs_info@random.com          | 2120000142     | waiting_for_applicant | Psychologist |
-      | LarsRejected       | lars_rejected@snarkybark.se         | 0000000000     | rejected              | dog crooning |
-      | NilsApproved       | nils_member@bowwowwow.se            | 0000000000     | accepted              | Groomer      |
-      | EmmaUnderReview    | emma_under_review@happymutts.se     | 5562252998     | under_review          | rehab        |
-      | HansReadyForReview | hans_ready_for_review@happymutts.se | 5562252998     | ready_for_review      | dog grooming |
+      | first_name         | user_email                          | contact_email   | company_number | state                 | categories   |
+      | Emma               | emma@personal.com                   | emma@cmpy.com   | 5562252998     | waiting_for_applicant | Psychologist |
+      | Hans               | hans@random.com                     |                 | 5560360793     | waiting_for_applicant | Psychologist |
+      | Anna               | anna_needs_info@random.com          |                 | 2120000142     | waiting_for_applicant | Psychologist |
+      | LarsRejected       | lars_rejected@snarkybark.se         |                 | 0000000000     | rejected              | dog crooning |
+      | NilsApproved       | nils_member@bowwowwow.se            |                 | 0000000000     | accepted              | Groomer      |
+      | EmmaUnderReview    | emma_under_review@happymutts.se     |                 | 5562252998     | under_review          | rehab        |
+      | HansReadyForReview | hans_ready_for_review@happymutts.se |                 | 5562252998     | ready_for_review      | dog grooming |
 
 
   @admin
@@ -65,12 +65,6 @@ Feature: As an Admin
 
   @admin
   Scenario: Admin can see an application with one business categories given
-  #  Given I am logged in as "hans@random.com"
-  #  And I am on the "landing" page
-  #  And I click on t("menus.nav.users.my_application")
-  #  And I select "Groomer" Category
-  #  And I click on t("membership_applications.edit.submit_button_label")
-  #  And I am Logged out
     Given I am logged in as "admin@shf.com"
     And I am on the list applications page
     Then I should see "7" applications
@@ -85,7 +79,7 @@ Feature: As an Admin
 
   @admin
   Scenario: Admin can see an application with multiple business categories given
-    Given I am logged in as "emma@random.com"
+    Given I am logged in as "emma@personal.com"
     And I am on the "landing" page
     And I click on t("menus.nav.members.my_application")
     And I select "Trainer" Category
@@ -102,6 +96,8 @@ Feature: As an Admin
     And I should see "Trainer"
     And I should see "Psychologist"
     And I should not see "Groomer"
+    And I should see "emma@personal.com"
+    And I should see "emma@cmpy.com"
 
   @member
   Scenario: Approved member should see membership number

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -8,10 +8,12 @@ And(/^the following applications exist:$/) do |table|
        company = FactoryGirl.create(:company, company_number: hash['company_number'])
      end
    end
+   contact_email = hash['contact_email'] && ! hash['contact_email'].empty? ? 
+                   hash['contact_email'] : hash[:user_email]
    ma = FactoryGirl.create(:membership_application,
                             attributes.merge(user: user,
                             company: company,
-                            contact_email: hash['user_email']))
+                            contact_email: contact_email))
    ma.state = hash['state'].to_sym if hash.has_key?('state')
    if hash['categories']
      categories = []


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/142975583


Changes proposed in this pull request:
1. User "show" view now shows profile (login) email 
2. User "show" view shows all applications for the user, including contact_email for each
3. Membership Application "show" view shows both user emails - profile and contact

Screenshots (Optional):
### User with two applications:
---

<img width="774" alt="screen shot 2017-06-30 at 2 53 08 pm" src="https://user-images.githubusercontent.com/9968213/27749973-ded849d8-5da3-11e7-9a84-61ff23b06ba0.png">

---
### Membership Application page:

<img width="554" alt="screen shot 2017-06-30 at 2 53 58 pm" src="https://user-images.githubusercontent.com/9968213/27750009-fbbfffc8-5da3-11e7-9bb5-05b214e083b2.png">


Ready for review:
@weedySeaDragon @RobertCram @thesuss 