### PR TITLE
Refactor to use reader method instead of instance variable

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -11,11 +11,11 @@ class ApplicationPolicy
   end
 
   def index?
-    @user.admin?
+    user.admin?
   end
 
   def update?
-    @user.admin? ||  @record.user == @user
+    user.admin? || record.user == user
   end
 
   def edit?
@@ -24,7 +24,7 @@ class ApplicationPolicy
 
 
   def destroy?
-    @user.admin?
+    user.admin?
   end
 
 end

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -18,7 +18,7 @@ class CompanyPolicy < ApplicationPolicy
   end
 
   def update?
-   user.admin? || is_in_company?
+    user.admin? || is_in_company?
   end
 
 
@@ -26,6 +26,6 @@ class CompanyPolicy < ApplicationPolicy
   private
 
   def is_in_company?
-    @user.is_in_company_numbered?(@record.company_number)
+    user.is_in_company_numbered?(record.company_number)
   end
 end

--- a/app/policies/membership_application_policy.rb
+++ b/app/policies/membership_application_policy.rb
@@ -120,7 +120,7 @@ class MembershipApplicationPolicy < ApplicationPolicy
 
 
   def owner?
-    @record.respond_to?(:user) && @record.user == user
+    record.respond_to?(:user) && record.user == user
   end
 
   def not_a_visitor

--- a/app/policies/shf_document_policy.rb
+++ b/app/policies/shf_document_policy.rb
@@ -2,7 +2,7 @@ class ShfDocumentPolicy < ApplicationPolicy
 
 
   def index?
-    @user.is_member_or_admin? if @user
+    user.is_member_or_admin? if user
   end
 
   def update?


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/136451949

#### Changes proposed in this pull request:
1. Clean up Policy classes to use reader method for user and record instead of their instance variables
2. Removed extra spaces between methods

Screenshots (Optional):


Ready for review:
@weedySeaDragon @patmbolger 
