### PR TITLE
Move first_name and last_name from MembershipApplication to User model

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,4 @@ Please describe the problem in detail including information about your operating
 The authors and contributors have agreed to license all other software
 under the MIT license, an open source free software license. See the
 file named COPYING which includes a disclaimer of warranty.
+ 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -3,7 +3,7 @@ class AdminController < ApplicationController
 
 
   def index
-    @membership_applications = MembershipApplication.all
+    @membership_applications = MembershipApplication.includes(:user).all
   end
 
 
@@ -11,7 +11,7 @@ class AdminController < ApplicationController
   def export_ansokan_csv
 
     begin
-      @membership_applications = MembershipApplication.all
+      @membership_applications = MembershipApplication.includes(:user).all
 
       export_name = "shf-ankosan-#{Time.now.strftime('%Y-%m-%d--%H-%M-%S')}.csv"
 

--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -7,7 +7,7 @@ class MembershipApplicationsController < ApplicationController
 
 
   def new
-    @membership_application = MembershipApplication.new
+    @membership_application = MembershipApplication.new(user: current_user)
     @all_business_categories = BusinessCategory.all
     @uploaded_file = @membership_application.uploaded_files.build
   end
@@ -19,11 +19,12 @@ class MembershipApplicationsController < ApplicationController
     action_params, @items_count, items_per_page =
       process_pagination_params('membership_application')
 
-    @search_params = MembershipApplication.ransack(action_params)
+    @search_params = MembershipApplication.includes(:user).ransack(action_params )
 
     @membership_applications = @search_params
                                    .result
                                    .includes(:business_categories)
+                                   .includes(:user)
                                    .page(params[:page]).per_page(items_per_page)
 
     render partial: 'membership_applications_list' if request.xhr?
@@ -41,7 +42,8 @@ class MembershipApplicationsController < ApplicationController
 
 
   def create
-    @membership_application = current_user.membership_applications.build(membership_application_params)
+    @membership_application = MembershipApplication.new(user: current_user)
+    @membership_application.update(membership_application_params)
     if @membership_application.save
 
       if new_file_uploaded(params)

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -42,6 +42,7 @@ class MembershipApplication < ApplicationRecord
   validate :swedish_organisationsnummer
 
   accepts_nested_attributes_for :uploaded_files, allow_destroy: true
+  accepts_nested_attributes_for :user, update_only: true
 
   scope :open, -> { where.not(state: [:accepted, :rejected]) }
 

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -19,6 +19,10 @@ class MembershipApplication < ApplicationRecord
   #
   belongs_to :company, optional: true, inverse_of: :membership_applications
 
+  delegate :first_name, to: :user, allow_nil: true, prefix: false
+  delegate :last_name, to: :user, allow_nil: true, prefix: false
+  delegate :first_name=, to: :user, allow_nil: true, prefix: false
+  delegate :last_name=, to: :user, allow_nil: true, prefix: false
 
   has_and_belongs_to_many :business_categories
   has_many :uploaded_files
@@ -28,9 +32,7 @@ class MembershipApplication < ApplicationRecord
              class_name: 'AdminOnly::MemberAppWaitingReason'
 
 
-  validates_presence_of :first_name,
-                        :last_name,
-                        :company_number,
+  validates_presence_of :company_number,
                         :contact_email,
                         :state
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
+  validates_presence_of :first_name, :last_name, on: :update
 
   def has_membership_application?
     membership_applications.size > 0

--- a/app/policies/membership_application_policy.rb
+++ b/app/policies/membership_application_policy.rb
@@ -77,8 +77,7 @@ class MembershipApplicationPolicy < ApplicationPolicy
 
 
   def user_owner_attributes
-    [:first_name,
-     :last_name,
+    [
      :company_number,
      :contact_email,
      :phone_number,
@@ -91,8 +90,10 @@ class MembershipApplicationPolicy < ApplicationPolicy
                                  :actual_file_file_size,
                                  :actual_file_content_type,
                                  :actual_file_updated_at,
-                                 :_destroy]
-    ]
+                                 :_destroy],
+     user_attributes: [:first_name,
+                       :last_name]
+     ]
   end
 
 

--- a/app/views/membership_applications/_membership_application_fields.html.haml
+++ b/app/views/membership_applications/_membership_application_fields.html.haml
@@ -5,11 +5,15 @@
       = f.label :membership_number, t('membership_applications.show.membership_number'), class: 'required'
       = f.text_field :membership_number, class: 'wpcf7-form-control'
 
-    = f.label :first_name, t('membership_applications.show.first_name'), class: 'required'
-    = f.text_field :first_name, class: 'wpcf7-form-control'
 
-    = f.label :last_name, t('membership_applications.show.last_name'), class: 'required'
-    = f.text_field :last_name, class: 'wpcf7-form-control'
+    = f.fields_for :user do |ff|
+      = ff.label :first_name, t('membership_applications.show.first_name'), class: 'required'
+      = ff.text_field :first_name, class: 'wpcf7-form-control'
+
+
+      = ff.label :last_name, t('membership_applications.show.last_name'), class: 'required'
+      = ff.text_field :last_name, class: 'wpcf7-form-control'
+
 
     = f.label :company_number, t('membership_applications.show.company_number'), class: 'required'
     = f.number_field :company_number, class: 'wpcf7-form-control'

--- a/app/views/membership_applications/_search_form.html.haml
+++ b/app/views/membership_applications/_search_form.html.haml
@@ -7,7 +7,7 @@
                 class: 'control-label',
                 style: 'text-align: left; font-size: 12px;'
       = f.collection_select :user_last_name_in,
-                      User.distinct.order(:last_name).pluck(:last_name),
+                      User.distinct.order(:last_name).pluck(:last_name).reject(&:blank?),
                       :to_s, :to_s, { include_blank: false },
                       { multiple: true, size: 5, style: 'width: 100%;',
                         class: 'form-control search_field',

--- a/app/views/membership_applications/_search_form.html.haml
+++ b/app/views/membership_applications/_search_form.html.haml
@@ -2,12 +2,12 @@
                                   class: 'form-horizontal' do |f|
   .form-group
     .col-sm-5
-      = f.label :last_name_in,
+      = f.label :user_last_name_in,
                 "#{t('activerecord.attributes.membership_application.last_name')}",
                 class: 'control-label',
                 style: 'text-align: left; font-size: 12px;'
-      = f.collection_select :last_name_in,
-                      MembershipApplication.distinct.order(:last_name).pluck(:last_name),
+      = f.collection_select :user_last_name_in,
+                      User.distinct.order(:last_name).pluck(:last_name),
                       :to_s, :to_s, { include_blank: false },
                       { multiple: true, size: 5, style: 'width: 100%;',
                         class: 'form-control search_field',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,8 @@ en:
     attributes:
 
       user:
+        first_name: &first_name First name
+        last_name: &last_name Last name
         email: &email Email
         password: *password
         password_confirmation: Password confirmation
@@ -114,8 +116,8 @@ en:
 
       membership_application:
         company_number: &company_number Company number
-        first_name: &first_name First name
-        last_name: &last_name Last name
+        first_name: *first_name
+        last_name: *last_name
         contact_email: &contact_email Email
         state: &state Status
         phone_number: Phone number
@@ -513,6 +515,8 @@ en:
   users:
     index:
       title: All Users
+      first_name: *first_name
+      last_name: *last_name
       email: *email
       created: *created
       last_login: *user_last_login

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -99,6 +99,8 @@ sv:
     attributes:
 
       user:
+        first_name: &first_name Förnamn
+        last_name: &last_name Efternamn
         email: &email E-post
         password: *password
         password_confirmation: Lösenordsbekräftelse
@@ -114,8 +116,8 @@ sv:
 
       membership_application:
         company_number: &company_number Organisationsnummer
-        first_name: &first_name Förnamn
-        last_name: &last_name Efternamn
+        first_name: *first_name
+        last_name: *last_name
         contact_email: &contact_email Kontakt e-post
         state: &state Status
         phone_number: Telefonnummer
@@ -514,6 +516,8 @@ sv:
   users:
     index:
       title: Alla Användare
+      first_name: *first_name
+      last_name: *last_name
       email: *email
       created: *created
       last_login: *user_last_login

--- a/db/migrate/20170704095534_move_firstname_and_lastname_to_user.rb
+++ b/db/migrate/20170704095534_move_firstname_and_lastname_to_user.rb
@@ -1,0 +1,19 @@
+class MoveFirstnameAndLastnameToUser < ActiveRecord::Migration[5.1]
+  def self.up
+    add_column :users, :first_name, :string
+    add_column :users, :last_name, :string
+    execute "UPDATE users u SET first_name = ma.first_name FROM membership_applications ma WHERE u.id = ma.user_id;"
+    execute "UPDATE users u SET last_name = ma.last_name FROM membership_applications ma WHERE u.id = ma.user_id;"
+    remove_column :membership_applications, :first_name
+    remove_column :membership_applications, :last_name
+  end
+
+  def self.down
+    add_column :membership_applications, :first_name, :string
+    add_column :membership_applications, :last_name, :string
+    execute "UPDATE membership_applications ma SET first_name = u.first_name FROM users u WHERE ma.user_id = u.id;"
+    execute "UPDATE membership_applications ma SET last_name = u.last_name FROM users u WHERE ma.user_id = u.id;"
+    remove_column :users, :first_name
+    remove_column :users, :last_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170615091313) do
+ActiveRecord::Schema.define(version: 20170704095534) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,22 +98,20 @@ ActiveRecord::Schema.define(version: 20170615091313) do
   end
 
   create_table "membership_applications", force: :cascade do |t|
-    t.string   "company_number"
-    t.string   "phone_number"
-    t.datetime "created_at",                                    null: false
-    t.datetime "updated_at",                                    null: false
-    t.integer  "user_id"
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "contact_email"
-    t.integer  "company_id"
-    t.string   "membership_number"
-    t.string   "state",                         default: "new"
-    t.integer  "member_app_waiting_reasons_id"
-    t.string   "custom_reason_text"
-    t.index ["company_id"], name: "index_membership_applications_on_company_id", using: :btree
-    t.index ["member_app_waiting_reasons_id"], name: "index_membership_applications_on_member_app_waiting_reasons_id", using: :btree
-    t.index ["user_id"], name: "index_membership_applications_on_user_id", using: :btree
+    t.string "company_number"
+    t.string "phone_number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.string "contact_email"
+    t.bigint "company_id"
+    t.string "membership_number"
+    t.string "state", default: "new"
+    t.integer "member_app_waiting_reasons_id"
+    t.string "custom_reason_text"
+    t.index ["company_id"], name: "index_membership_applications_on_company_id"
+    t.index ["member_app_waiting_reasons_id"], name: "index_membership_applications_on_member_app_waiting_reasons_id"
+    t.index ["user_id"], name: "index_membership_applications_on_user_id"
   end
 
   create_table "regions", force: :cascade do |t|
@@ -161,6 +159,8 @@ ActiveRecord::Schema.define(version: 20170615091313) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "admin", default: false
+    t.string "first_name"
+    t.string "last_name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/features/approve-member.feature
+++ b/features/approve-member.feature
@@ -9,11 +9,11 @@ Feature: As an admin
 
   Background:
     Given the following users exists
-      | email                 | admin |
-      | emma@happymutts.se    |       |
-      | hans@happymutts.se    |       |
-      | anna@nosnarkybarky.se |       |
-      | admin@shf.com         | true  |
+      | first_name | email                 | admin |
+      | Emma       | emma@happymutts.se    |       |
+      | Hans       | hans@happymutts.se    |       |
+      | Anna       | anna@nosnarkybarky.se |       |
+      |            |admin@shf.com          | true  |
 
     Given the following business categories exist
       | name         | description                     |
@@ -30,10 +30,10 @@ Feature: As an admin
       | No More Snarky Barky | 5560360793     | snarky@snarkybarky.se | Stockholm |
 
     And the following applications exist:
-      | first_name | user_email            | company_number | categories   | state        |
-      | Emma       | emma@happymutts.se    | 5562252998     | rehab        | under_review |
-      | Hans       | hans@happymutts.se    | 5562252998     | dog grooming | under_review |
-      | Anna       | anna@nosnarkybarky.se | 5560360793     | rehab        | under_review |
+      | user_email            | company_number | categories   | state        |
+      | emma@happymutts.se    | 5562252998     | rehab        | under_review |
+      | hans@happymutts.se    | 5562252998     | dog grooming | under_review |
+      | anna@nosnarkybarky.se | 5560360793     | rehab        | under_review |
 
     And I am logged in as "admin@shf.com"
 

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -12,8 +12,8 @@ Feature: As a user
 
   Background:
     Given the following users exists
-      | email                  |
-      | applicant_1@random.com |
+      | first_name | last_name | email                  |
+      |            |           | applicant_1@random.com |
 
     And the following business categories exist
       | name         |

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -33,6 +33,9 @@ Feature: As a user
     And I click on t("membership_applications.new.submit_button_label")
     Then I should be on the landing page
     And I should see t("membership_applications.create.success")
+    When I click on t("menus.nav.users.my_application")
+    Then the t("membership_applications.new.first_name") field should be set to "Kicki"
+    And the t("membership_applications.new.last_name") field should be set to "Andersson"
 
 
   Scenario: A user can submit a new Membership Application with multiple categories

--- a/features/delete_membership_application.feature
+++ b/features/delete_membership_application.feature
@@ -9,15 +9,13 @@ Feature: As an admin
 
   Background:
     Given the following users exists
-      | email            | admin |
-      | emma@random.com  |       |
-      | hans@bowsers.com |       |
-      | nils@bowsers.com |       |
-      | admin@shf.se     | true  |
-      | wils@woof.com    |       |
-      | bob@bowsers.com  |       |
-
-
+      | first_name | email            | admin |
+      | Emma       | emma@random.com  |       |
+      | Hans       | hans@bowsers.com |       |
+      | Nils       | nils@bowsers.com |       |
+      | Wils       | wils@woof.com    |       |
+      |            | admin@shf.se     | true  |
+      |            | bob@bowsers.com  |       |
 
     And the following regions exist:
       | name         |
@@ -39,11 +37,11 @@ Feature: As an admin
 
 
     And the following applications exist:
-      | first_name | user_email       | company_number | state        |
-      | Emma       | emma@random.com  | 5560360793     | under_review |
-      | Hans       | hans@bowsers.com | 2120000142     | under_review |
-      | Nils       | nils@bowsers.com | 2120000142     | accepted     |
-      | Wils       | wils@woof.com    | 5569467466     | accepted     |
+      | user_email       | company_number | state        |
+      | emma@random.com  | 5560360793     | under_review |
+      | hans@bowsers.com | 2120000142     | under_review |
+      | nils@bowsers.com | 2120000142     | accepted     |
+      | wils@woof.com    | 5569467466     | accepted     |
 
 
   Scenario: Admin should see the 'delete' button

--- a/features/edit_membership_application.feature
+++ b/features/edit_membership_application.feature
@@ -7,12 +7,12 @@ Feature: As an applicant
 
   Background:
     Given the following users exists
-      | email             | is_member | admin |
-      | emma@random.com   | false     |       |
-      | hans@random.com   | false     |       |
-      | nils@random.com   | true      |       |
-      | bob@barkybobs.com | true      |       |
-      | admin@shf.se      | true      | true  |
+      | first_name | email             | is_member | admin |
+      | Emma       | emma@random.com   | false     |       |
+      | Hans       | hans@random.com   | false     |       |
+      | Nils       | nils@random.com   | true      |       |
+      | Bob        | bob@barkybobs.com | true      |       |
+      |            | admin@shf.se      | true      | true  |
 
     And the following applications exist:
       | first_name | user_email        | company_number | state                 |

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -70,7 +70,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     And I am on "AnnaWaiting" application page
 
     And I should see t("membership_applications.need_info.other_reason_label")
-    And the "custom_reason_text" field should be set to "This is my reason"
+    And the t("membership_applications.need_info.other_reason_label") field should be set to "This is my reason"
     And "member_app_waiting_reasons" should have t("admin_only.member_app_waiting_reasons.other_custom_reason") selected
 
 

--- a/features/search_applications.feature
+++ b/features/search_applications.feature
@@ -6,12 +6,12 @@ I want to search for applications by various criteria
 
 Background:
   Given the following users exists
-    | email                | admin |
-    | fred@barkyboys.com   |       |
-    | john@happymutts.com  |       |
-    | anna@dogsrus.com     |       |
-    | emma@weluvdogs.com   |       |
-    | admin@shf.se         | true  |
+    | first_name | last_name  | email                | admin |
+    | Fred       | Fransson   | fred@barkyboys.com   |       |
+    | John       | Johanssen  | john@happymutts.com  |       |
+    | Anna       | Anderson   | anna@dogsrus.com     |       |
+    | Emma       | Eriksson   | emma@weluvdogs.com   |       |
+    |            |            | admin@shf.se         | true  |
 
   And the following business categories exist
     | name         |
@@ -35,11 +35,11 @@ Background:
     | We Luv Dogs | 5569467466     | alpha@weluvdogs.com  | Sweden       |             |
 
   And the following applications exist:
-    | first_name | last_name  | user_email          | company_number | state        | categories   |
-    | Fred       | Fransson   | fred@barkyboys.com  | 5560360793     | rejected     | Groomer      |
-    | John       | Johanssen  | john@happymutts.com | 2120000142     | accepted     | Psychologist |
-    | Anna       | Anderson   | anna@dogsrus.com    | 5562252998     | new          | Trainer      |
-    | Emma       | Eriksson   | emma@weluvdogs.com  | 5569467466     | under_review | Walker       |
+    | user_email          | company_number | state        | categories   |
+    | fred@barkyboys.com  | 5560360793     | rejected     | Groomer      |
+    | john@happymutts.com | 2120000142     | accepted     | Psychologist |
+    | anna@dogsrus.com    | 5562252998     | new          | Trainer      |
+    | emma@weluvdogs.com  | 5569467466     | under_review | Walker       |
 
   And I am logged in as "admin@shf.se"
   And I am on the "membership applications" page

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -302,9 +302,9 @@ end
 
 
 # Tests that an input or button with the given label is disabled.
-Then /^the "([^\"]*)" field should( not)? be set to "([^\"]*)"$/ do |label, negate, text_value|
+Then /^the t\("([^"]*)"\) field should( not)? be set to "([^\"]*)"$/ do |i18n_key, negate, text_value|
 
-  element = find_field(label)
+  element = find_field(I18n.t(i18n_key))
 
   expect(["false", "", nil]).send(negate ? :to : :not_to,  have_content(text_value) )
 

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -301,12 +301,12 @@ Then /^the "([^\"]*)" (field|button|item) should( not)? be disabled$/ do |label,
 end
 
 
-# Tests that an input or button with the given label is disabled.
-Then /^the t\("([^"]*)"\) field should( not)? be set to "([^\"]*)"$/ do |i18n_key, negate, text_value|
+# Tests that an input has a given value
+Then /^the t\("([^"]*)"\) field should be set to "([^\"]*)"$/ do |i18n_key, text_value|
 
   element = find_field(I18n.t(i18n_key))
 
-  expect(["false", "", nil]).send(negate ? :to : :not_to,  have_content(text_value) )
+  expect(element.value).to eq(text_value)
 
 end
 

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -154,12 +154,14 @@ end
 
 
 Then(/^I should be on the application page for "([^"]*)"$/) do |first_name|
-  membership_application = MembershipApplication.find_by(first_name: first_name)
+  user = User.find_by(first_name: first_name)
+  membership_application = user.membership_application
   expect(current_path_without_locale(current_path)).to eq membership_application_path(membership_application)
 end
 
 Then(/^I should be on the edit application page for "([^"]*)"$/) do |first_name|
-  membership_application = MembershipApplication.find_by(first_name: first_name)
+  user = User.find_by(first_name: first_name)
+  membership_application = user.membership_application
   expect(current_path_without_locale(current_path)).to eq edit_membership_application_path(membership_application)
 end
 

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -2,7 +2,7 @@ And(/^the following applications exist:$/) do |table|
  table.hashes.each do |hash|
    attributes = hash.except('user_email', 'categories')
    user = User.find_by(email: hash[:user_email].downcase)
-    if hash['state'] == 'accepted' || hash['state'] == 'rejected'
+   if hash['state'] == 'accepted' || hash['state'] == 'rejected'
      company = Company.find_by(company_number: hash['company_number'])
      unless company
        company = FactoryGirl.create(:company, company_number: hash['company_number'])
@@ -38,13 +38,15 @@ end
 
 
 And(/^I navigate to the edit page for "([^"]*)"$/) do |first_name|
-  membership_application = MembershipApplication.find_by(first_name: first_name)
+  user = User.find_by(first_name: first_name)
+  membership_application = user.membership_application
   visit path_with_locale(edit_membership_application_path(membership_application))
 end
 
 Given(/^I am on "([^"]*)" application page$/) do |first_name|
-  membership = MembershipApplication.find_by(first_name: first_name)
-  visit path_with_locale(membership_application_path(membership))
+  user = User.find_by(first_name: first_name)
+  membership_application = user.membership_application
+  visit path_with_locale(membership_application_path(membership_application))
 end
 
 Given(/^I am on the list applications page$/) do

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -108,8 +108,9 @@ end
 
 
 When(/^I am on the application page for "([^"]*)"$/) do |first_name|
-    membership_application = MembershipApplication.find_by(first_name: first_name)
-    visit path_with_locale(membership_application_path(membership_application))
+  user = User.find_by(first_name: first_name)
+  membership_application = user.membership_application
+  visit path_with_locale(membership_application_path(membership_application))
 end
 
 

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -72,11 +72,12 @@ RSpec.describe AdminController, type: :controller do
           # create 1 application in each state
           MembershipApplication.aasm.states.each do |app_state|
 
-            u = FactoryGirl.create(:user, email: "#{app_state.name}@example.com")
-
-            m = FactoryGirl.create :membership_application,
+            u = FactoryGirl.create(:user,
                                    first_name:    "First#{app_state.name}",
                                    last_name:     "Last#{app_state.name}",
+                                   email: "#{app_state.name}@example.com")
+
+            m = FactoryGirl.create :membership_application,
                                    contact_email: "#{app_state.name}@example.com",
                                    state:         app_state.name,
                                    user:          u
@@ -109,11 +110,13 @@ RSpec.describe AdminController, type: :controller do
         end
 
 
-        let(:u1) { FactoryGirl.create(:user, email: "user1@example.com") }
+        let(:u1) { FactoryGirl.create(:user,
+                                      first_name:     "u1",
+                                      email: "user1@example.com") }
+
         let(:c1) { FactoryGirl.create(:company) }
 
         let(:member1) { m1 = FactoryGirl.create :membership_application,
-                                                      first_name:     "u1",
                                                       contact_email:  "u1@example.com",
                                                       state:          :accepted,
                                                       company_number: c1.company_number,
@@ -151,11 +154,13 @@ RSpec.describe AdminController, type: :controller do
       describe 'with business categories (surrounded by double quotes)' do
 
 
-        let(:u1) { FactoryGirl.create(:user, email: "user1@example.com") }
+        let(:u1) { FactoryGirl.create(:user,
+                                      first_name:     "u1",
+                                      email: "user1@example.com") }
+
         let(:c1) { FactoryGirl.create(:company) }
 
         let(:member1) { m1 = FactoryGirl.create :membership_application,
-                                                first_name:     "u1",
                                                 contact_email:  "u1@example.com",
                                                 state:          :accepted,
                                                 company_number: c1.company_number,

--- a/spec/factories/membership_applications.rb
+++ b/spec/factories/membership_applications.rb
@@ -3,8 +3,6 @@ FactoryGirl.define do
   sequence(:cat_name_seq, "Business Category", 1) { |name, num| "#{name} #{num}" }
 
   factory :membership_application do
-    first_name 'Firstname'
-    last_name 'Lastname'
     company_number '5562252998'
     phone_number 'MyString'
     contact_email 'MyString@email.com'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,6 +2,8 @@ FactoryGirl.define do
   sequence(:email) { |num| "email_#{num}@random.com" }
 
   factory :user do
+    first_name 'Firstname'
+    last_name 'Lastname'
     email
     password 'my_password'
     admin false

--- a/spec/models/membership_application_spec.rb
+++ b/spec/models/membership_application_spec.rb
@@ -109,14 +109,14 @@ RSpec.describe MembershipApplication, type: :model do
       expect {
         member_app.first_name = ''
         member_app.save!
-      }.to raise_exception /#{I18n.t('activerecord.attributes.membership_application.first_name')} #{I18n.t('errors.messages.blank')}/
+      }.to raise_exception(/#{I18n.t('activerecord.attributes.membership_application.first_name')} #{I18n.t('errors.messages.blank')}/)
     end
 
     it 'validates the presence of last_name' do
       expect {
         member_app.last_name = ''
         member_app.save!
-      }.to raise_exception /#{I18n.t('activerecord.attributes.membership_application.last_name')} #{I18n.t('errors.messages.blank')}/
+      }.to raise_exception(/#{I18n.t('activerecord.attributes.membership_application.last_name')} #{I18n.t('errors.messages.blank')}/)
     end
 
   end

--- a/spec/models/membership_application_spec.rb
+++ b/spec/models/membership_application_spec.rb
@@ -41,8 +41,6 @@ RSpec.describe MembershipApplication, type: :model do
 
   describe 'DB Table' do
     it {is_expected.to have_db_column :id}
-    it {is_expected.to have_db_column :first_name}
-    it {is_expected.to have_db_column :last_name}
     it {is_expected.to have_db_column :company_number}
     it {is_expected.to have_db_column :phone_number}
     it {is_expected.to have_db_column :contact_email}
@@ -52,10 +50,8 @@ RSpec.describe MembershipApplication, type: :model do
   end
 
   describe 'Validations' do
-    it {is_expected.to validate_presence_of :first_name}
     it {is_expected.to validate_presence_of :contact_email}
     it {is_expected.to validate_presence_of :company_number}
-    it {is_expected.to validate_presence_of :last_name}
     it {is_expected.to validate_presence_of :state}
 
     it {is_expected.to allow_value('user@example.com').for(:contact_email)}

--- a/spec/models/membership_application_spec.rb
+++ b/spec/models/membership_application_spec.rb
@@ -92,6 +92,34 @@ RSpec.describe MembershipApplication, type: :model do
 
   end
 
+  describe 'User attributes nesting' do
+
+    let(:user) {create(:user, first_name: '', last_name: '')}
+    let!(:member_app) {create(:membership_application, user: user, user_attributes: {first_name: 'Firstname', last_name: 'Lastname'})}
+
+    it 'sets first_name on user' do
+      expect(user.first_name).to eq('Firstname')
+    end
+
+    it 'sets last_name on user' do
+      expect(user.last_name).to eq('Lastname')
+    end
+
+    it 'validates the presence of first_name' do
+      expect {
+        member_app.first_name = ''
+        member_app.save!
+      }.to raise_exception /#{I18n.t('activerecord.attributes.membership_application.first_name')} #{I18n.t('errors.messages.blank')}/
+    end
+
+    it 'validates the presence of last_name' do
+      expect {
+        member_app.last_name = ''
+        member_app.save!
+      }.to raise_exception /#{I18n.t('activerecord.attributes.membership_application.last_name')} #{I18n.t('errors.messages.blank')}/
+    end
+
+  end
 
   describe '#is_accepted?' do
     let!(:states) {MembershipApplication.aasm.states.map(&:name)}

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe User, type: :model do
 
   describe 'DB Table' do
     it { is_expected.to have_db_column :id }
+    it {is_expected.to have_db_column :first_name}
+    it {is_expected.to have_db_column :last_name}
     it { is_expected.to have_db_column :email }
     it { is_expected.to have_db_column :admin }
   end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/147882625

**Changes proposed in this pull request:**

1. Migrate database - move fields _first_name_ and _last_name_ from the _membership_applications_ to the _user_ table

2. Delegate read/write methods for _first_name_ and _last_name_ from the _MembershipApplication_ model to the _User_ model. This allows for a gradual transition of factories, unit- and feature tests to adapt to the change, instead of doing it all in one PR. (https://www.pivotaltracker.com/story/show/148546123)

3. Make the _MembershipApplication_ model accept nested attributes from the _User_ model, so we can keep using the _first_name_ and _last_name_ fields in the membership application edit and search form.


**Question:**

I got it to work eventually, but I am not really happy with the way I had to change the _create_ method on the _MembershipApplicationsController_ (line 45/46). I would expect there to be a more direct way to create the membershipapplication from the membership_application_params. I've tried numerous permutations of permitted parameters, but none of them worked. Am I missing something?

@patmbolger @weedySeaDragon 