### PR TITLE
BUG: Companies not showing in Heroku

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -64,7 +64,7 @@ else
   User.create(email: email, password: pwd, admin: true)
 end
 
-unless Rails.env.production? || Rails.env.test?
+if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_STAGING']
 
   puts 'Creating additional users ...'
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/148601419

Changes proposed in this pull request:
1. See story description in PT.

We now need to:

1) Merge this PR and deploy to Heroku
2) Run `rake shf:db_recreate` on Heroku (someone with appropriate DB privilege needs to run that - probably @thesuss ). 

Ready for review:
@weedySeaDragon @thesuss @RobertCram 