### PR TITLE
[WIP] Remove first_name & last_name calls to MembershipApplication instances

### DIFF
--- a/spec/models/membership_application_spec.rb
+++ b/spec/models/membership_application_spec.rb
@@ -107,16 +107,16 @@ RSpec.describe MembershipApplication, type: :model do
 
     it 'validates the presence of first_name' do
       expect {
-        member_app.first_name = ''
-        member_app.save!
-      }.to raise_exception(/#{I18n.t('activerecord.attributes.membership_application.first_name')} #{I18n.t('errors.messages.blank')}/)
+        user.first_name = ''
+        user.save!
+      }.to raise_exception(/#{I18n.t('activerecord.attributes.user.first_name')} #{I18n.t('errors.messages.blank')}/)
     end
 
     it 'validates the presence of last_name' do
       expect {
-        member_app.last_name = ''
-        member_app.save!
-      }.to raise_exception(/#{I18n.t('activerecord.attributes.membership_application.last_name')} #{I18n.t('errors.messages.blank')}/)
+        user.last_name = ''
+        user.save!
+      }.to raise_exception(/#{I18n.t('activerecord.attributes.user.last_name')} #{I18n.t('errors.messages.blank')}/)
     end
 
   end


### PR DESCRIPTION
PT Story: 
https://www.pivotaltracker.com/story/show/148546123

Changes proposed in this pull request:
1. Remove calls to `#first_name` and `#last_name` on `MembershipApplication` objects
2. 
3.

Screenshots (Optional):


Ready for review:
@
