### PR TITLE
User Profile Management

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,12 +3,21 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
   before_action :set_locale
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
 
   def index
 
+  end
+
+  protected
+
+  def configure_permitted_parameters
+    additional_permissions = [:first_name, :last_name]
+    devise_parameter_sanitizer.permit(:sign_up, keys: additional_permissions)
+    devise_parameter_sanitizer.permit(:account_update, keys: additional_permissions)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  validates_presence_of :first_name, :last_name, on: :update
+  validates_presence_of :first_name, :last_name
 
   def has_membership_application?
     membership_applications.size > 0

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -4,7 +4,12 @@
   %span
 .entry-content.wpcf7
   = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-    = devise_error_messages!
+    - if resource.errors.any?
+      .wpcf7-response-output
+        - resource.errors.full_messages.each do |msg|
+          = msg
+          %br/
+      %br/
     .field
       = f.label :first_name
       %br/

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -6,9 +6,17 @@
   = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
     = devise_error_messages!
     .field
+      = f.label :first_name
+      %br/
+      = f.text_field :first_name, autofocus: true, class: 'wpcf7-form-control'
+    .field
+      = f.label :last_name
+      %br/
+      = f.text_field :last_name, class: 'wpcf7-form-control'
+    .field
       = f.label :email
       %br/
-      = f.email_field :email, autofocus: true, class: 'wpcf7-form-control'
+      = f.email_field :email, class: 'wpcf7-form-control'
     - if devise_mapping.confirmable? && resource.pending_reconfirmation?
       %div
         "#{t('.unconfirmed_email_for', unconfirmed_email: resource.unconfirmed_email )}"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -4,7 +4,12 @@
   %span
 .entry-content.wpcf7
   = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-    = devise_error_messages!
+    - if resource.errors.any?
+      .wpcf7-response-output
+        - resource.errors.full_messages.each do |msg|
+          = msg
+          %br/
+      %br/
     .field
       = f.label :first_name, class: 'required'
       %br/

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -6,9 +6,17 @@
   = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
     = devise_error_messages!
     .field
+      = f.label :first_name, class: 'required'
+      %br/
+      = f.text_field :first_name, autofocus: true, class: 'wpcf7-form-control'
+    .field
+      = f.label :last_name, class: 'required'
+      %br/
+      = f.text_field :last_name, class: 'wpcf7-form-control'
+    .field
       = f.label :email, class: 'required'
       %br/
-      = f.email_field :email, autofocus: true, class: 'wpcf7-form-control'
+      = f.email_field :email, class: 'wpcf7-form-control'
     .field
       = f.label :password, class: 'required'
       = render 'devise/shared/min_password_length_info'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -707,6 +707,7 @@ en:
         confirm_password: &confirm_password Confirm password
         forgot_password: Forgot password
         submit_button_label: Sign up
+        success: You have signed up successfully
       edit:
         title: Edit your login information
         unconfirmed_email_for: 'Unconfirmed email address for: %{unconfirmed_email}'
@@ -719,6 +720,7 @@ en:
         unregister: Unregister
         confirm_are_you_sure: *are_you_sure_confirm
         back: *back
+        success: Your account has been updated successfully
     sessions:
       new:
         log_in: &log_in Log In

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -710,6 +710,7 @@ sv:
         forgot_password: Glömt lösenord
         confirm_password: &confirm_password Bekräfta lösenord
         submit_button_label: Skapa användare
+        success: Ett nytt konto har skapats
       edit:
         title: Redigera användare
         unconfirmed_email_for: 'Obekräftad mailadress för: %{unconfirmed_email}'
@@ -722,6 +723,7 @@ sv:
         unregister: Avregistrera dig
         confirm_are_you_sure: *are_you_sure_confirm
         back: *back
+        success: Ditt konto har uppdaterats
     sessions:
       new:
         log_in: &log_in Logga In

--- a/features/approve-member.feature
+++ b/features/approve-member.feature
@@ -13,7 +13,7 @@ Feature: As an admin
       | Emma       | emma@happymutts.se    |       |
       | Hans       | hans@happymutts.se    |       |
       | Anna       | anna@nosnarkybarky.se |       |
-      |            |admin@shf.com          | true  |
+      | admin      | admin@shf.com         | true  |
 
     Given the following business categories exist
       | name         | description                     |

--- a/features/create_account.feature
+++ b/features/create_account.feature
@@ -1,0 +1,35 @@
+Feature: As a visitor
+  in order to access the functions of the site
+  I need to be able to create an account
+
+  Scenario: Creating an account
+    Given I am on the "login" page
+    And I click on t("devise.registrations.new.create_account")
+    Then I should be on the "register as a new user" page
+    When I fill in t("activerecord.attributes.user.first_name") with "emma"
+    And I fill in t("activerecord.attributes.user.last_name") with "andersson"
+    And I fill in t("activerecord.attributes.user.email") with "emma@andersson.com"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I fill in t("devise.registrations.new.confirm_password") with "password"
+    And I click on t("devise.registrations.new.submit_button_label")
+    Then I should see t("devise.registrations.new.success")
+
+  Scenario: Sad path: Missing first name
+    Given I am on the "register as a new user" page
+    And I fill in t("activerecord.attributes.user.last_name") with "andersson"
+    And I fill in t("activerecord.attributes.user.email") with "emma@andersson.com"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I fill in t("devise.registrations.new.confirm_password") with "password"
+    And I click on t("devise.registrations.new.submit_button_label")
+    Then I should see translated error activerecord.attributes.user.first_name errors.messages.blank
+    And I should not see t("devise.registrations.new.success")
+
+  Scenario: Sad path: Missing last name
+    Given I am on the "register as a new user" page
+    And I fill in t("activerecord.attributes.user.first_name") with "emma"
+    And I fill in t("activerecord.attributes.user.email") with "emma@andersson.com"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I fill in t("devise.registrations.new.confirm_password") with "password"
+    And I click on t("devise.registrations.new.submit_button_label")
+    Then I should see translated error activerecord.attributes.user.last_name errors.messages.blank
+    And I should not see t("devise.registrations.new.success")

--- a/features/create_account.feature
+++ b/features/create_account.feature
@@ -13,6 +13,9 @@ Feature: As a visitor
     And I fill in t("devise.registrations.new.confirm_password") with "password"
     And I click on t("devise.registrations.new.submit_button_label")
     Then I should see t("devise.registrations.new.success")
+    When I am on the "edit registration for a user" page
+    Then the t("activerecord.attributes.user.first_name") field should be set to "emma"
+    And the t("activerecord.attributes.user.last_name") field should be set to "andersson"
 
   Scenario: Sad path: Missing first name
     Given I am on the "register as a new user" page
@@ -23,6 +26,8 @@ Feature: As a visitor
     And I click on t("devise.registrations.new.submit_button_label")
     Then I should see translated error activerecord.attributes.user.first_name errors.messages.blank
     And I should not see t("devise.registrations.new.success")
+    When I am on the "edit registration for a user" page
+    Then I should be on the "login" page
 
   Scenario: Sad path: Missing last name
     Given I am on the "register as a new user" page
@@ -33,3 +38,5 @@ Feature: As a visitor
     And I click on t("devise.registrations.new.submit_button_label")
     Then I should see translated error activerecord.attributes.user.last_name errors.messages.blank
     And I should not see t("devise.registrations.new.success")
+    When I am on the "edit registration for a user" page
+    Then I should be on the "login" page

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -12,8 +12,8 @@ Feature: As a user
 
   Background:
     Given the following users exists
-      | first_name | last_name | email                  |
-      |            |           | applicant_1@random.com |
+      | email                  |
+      | applicant_1@random.com |
 
     And the following business categories exist
       | name         |

--- a/features/delete_membership_application.feature
+++ b/features/delete_membership_application.feature
@@ -14,8 +14,8 @@ Feature: As an admin
       | Hans       | hans@bowsers.com |       |
       | Nils       | nils@bowsers.com |       |
       | Wils       | wils@woof.com    |       |
-      |            | admin@shf.se     | true  |
-      |            | bob@bowsers.com  |       |
+      | Bob        | bob@bowsers.com  |       |
+      | admin      | admin@shf.se     | true  |
 
     And the following regions exist:
       | name         |

--- a/features/edit_account.feature
+++ b/features/edit_account.feature
@@ -14,10 +14,14 @@ Feature: As a registered user
     Then the t("activerecord.attributes.user.first_name") field should be set to "emma"
     And the t("activerecord.attributes.user.last_name") field should be set to "andersson"
     And the t("activerecord.attributes.user.email") field should be set to "emma@andersson.com"
-    When I fill in t("activerecord.attributes.user.last_name") with "svensson"
+    When I fill in t("activerecord.attributes.user.first_name") with "emma (changed)"
+    When I fill in t("activerecord.attributes.user.last_name") with "andersson (changed)"
     And I fill in t("devise.registrations.edit.current_password") with "password"
     And I click on t("devise.registrations.edit.submit_button_label")
     Then I should see t("devise.registrations.edit.success")
+    When I am on the "edit registration for a user" page
+    Then the t("activerecord.attributes.user.first_name") field should be set to "emma (changed)"
+    And the t("activerecord.attributes.user.last_name") field should be set to "andersson (changed)"
 
   Scenario: Sad path: Missing first name
     Given I am on the "edit registration for a user" page
@@ -29,6 +33,8 @@ Feature: As a registered user
     And I click on t("devise.registrations.edit.submit_button_label")
     Then I should see translated error activerecord.attributes.user.first_name errors.messages.blank
     And I should not see t("devise.registrations.edit.success")
+    When I am on the "edit registration for a user" page
+    Then the t("activerecord.attributes.user.first_name") field should be set to "emma"
 
   Scenario: Sad path: Missing last name
     Given I am on the "edit registration for a user" page
@@ -40,3 +46,5 @@ Feature: As a registered user
     And I click on t("devise.registrations.edit.submit_button_label")
     Then I should see translated error activerecord.attributes.user.last_name errors.messages.blank
     And I should not see t("devise.registrations.edit.success")
+    When I am on the "edit registration for a user" page
+    Then the t("activerecord.attributes.user.last_name") field should be set to "andersson"

--- a/features/edit_account.feature
+++ b/features/edit_account.feature
@@ -1,0 +1,42 @@
+Feature: As a registered user
+  in order to keep my account information up to date
+  I need to be able to edit my account
+
+  Background:
+    Given the following users exists
+      | first_name | last_name | email              | password | admin |
+      | emma       | andersson | emma@andersson.com | password | false |
+
+    And I am logged in as "emma@andersson.com"
+
+  Scenario: Editing an account
+    Given I am on the "edit registration for a user" page
+    Then the t("activerecord.attributes.user.first_name") field should be set to "emma"
+    And the t("activerecord.attributes.user.last_name") field should be set to "andersson"
+    And the t("activerecord.attributes.user.email") field should be set to "emma@andersson.com"
+    When I fill in t("activerecord.attributes.user.last_name") with "svensson"
+    And I fill in t("devise.registrations.edit.current_password") with "password"
+    And I click on t("devise.registrations.edit.submit_button_label")
+    Then I should see t("devise.registrations.edit.success")
+
+  Scenario: Sad path: Missing first name
+    Given I am on the "edit registration for a user" page
+    Then the t("activerecord.attributes.user.first_name") field should be set to "emma"
+    And the t("activerecord.attributes.user.last_name") field should be set to "andersson"
+    And the t("activerecord.attributes.user.email") field should be set to "emma@andersson.com"
+    When I fill in t("activerecord.attributes.user.first_name") with ""
+    And I fill in t("devise.registrations.edit.current_password") with "password"
+    And I click on t("devise.registrations.edit.submit_button_label")
+    Then I should see translated error activerecord.attributes.user.first_name errors.messages.blank
+    And I should not see t("devise.registrations.edit.success")
+
+  Scenario: Sad path: Missing last name
+    Given I am on the "edit registration for a user" page
+    Then the t("activerecord.attributes.user.first_name") field should be set to "emma"
+    And the t("activerecord.attributes.user.last_name") field should be set to "andersson"
+    And the t("activerecord.attributes.user.email") field should be set to "emma@andersson.com"
+    When I fill in t("activerecord.attributes.user.last_name") with ""
+    And I fill in t("devise.registrations.edit.current_password") with "password"
+    And I click on t("devise.registrations.edit.submit_button_label")
+    Then I should see translated error activerecord.attributes.user.last_name errors.messages.blank
+    And I should not see t("devise.registrations.edit.success")

--- a/features/edit_membership_application.feature
+++ b/features/edit_membership_application.feature
@@ -12,7 +12,7 @@ Feature: As an applicant
       | Hans       | hans@random.com   | false     |       |
       | Nils       | nils@random.com   | true      |       |
       | Bob        | bob@barkybobs.com | true      |       |
-      |            | admin@shf.se      | true      | true  |
+      | admin      | admin@shf.se      | true      | true  |
 
     And the following applications exist:
       | first_name | user_email        | company_number | state                 |

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -109,3 +109,5 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     Given I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
     And I am on the application page for "AnnaWaiting"
     Then I should not see t("membership_applications.need_info.reason_title")
+
+    

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -108,3 +108,5 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     Given I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
     And I am on the application page for "AnnaWaiting"
     Then I should not see t("membership_applications.need_info.reason_title")
+
+    

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -83,7 +83,6 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     And I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
     And I set "member_app_waiting_reasons" to "waiting for payment"
-    And I wait for all ajax requests to complete
     And I am on the list applications page
     And I am on "AnnaWaiting" application page
     And "member_app_waiting_reasons" should have "waiting for payment" selected
@@ -109,5 +108,3 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     Given I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
     And I am on the application page for "AnnaWaiting"
     Then I should not see t("membership_applications.need_info.reason_title")
-
-    

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -83,6 +83,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     And I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
     And I set "member_app_waiting_reasons" to "waiting for payment"
+    And I wait for all ajax requests to complete
     And I am on the list applications page
     And I am on "AnnaWaiting" application page
     And "member_app_waiting_reasons" should have "waiting for payment" selected

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -82,7 +82,9 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     And I wait for all ajax requests to complete
     And I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
+    And I wait for all ajax requests to complete
     And I set "member_app_waiting_reasons" to "waiting for payment"
+    And I wait for all ajax requests to complete
     And I am on the list applications page
     And I am on "AnnaWaiting" application page
     And "member_app_waiting_reasons" should have "waiting for payment" selected
@@ -109,4 +111,3 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     And I am on the application page for "AnnaWaiting"
     Then I should not see t("membership_applications.need_info.reason_title")
 
-    

--- a/features/search_applications.feature
+++ b/features/search_applications.feature
@@ -11,7 +11,7 @@ Background:
     | John       | Johanssen  | john@happymutts.com  |       |
     | Anna       | Anderson   | anna@dogsrus.com     |       |
     | Emma       | Eriksson   | emma@weluvdogs.com   |       |
-    |            |            | admin@shf.se         | true  |
+    | admin      | admin      | admin@shf.se         | true  |
 
   And the following business categories exist
     | name         |

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -128,6 +128,12 @@ Then(/^I should be on (?:the )*"([^"]*)" page$/) do |page|
       path = admin_only_member_app_waiting_reasons_path
     when 'new waiting for info reason'
       path = new_admin_only_member_app_waiting_reason_path
+    when 'new waiting for info reason'
+      path = new_admin_only_member_app_waiting_reason_path
+    when 'register as a new user'
+      path = new_user_registration_path
+    when 'edit registration for a user'
+      path = edit_user_registration_path
   end
 
   expect(current_path_without_locale(current_path)).to eq path

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -48,9 +48,7 @@ end
 When(/^I fill in the translated form with data:$/) do |table|
   data = table.hashes.first
   data.each do |label, value|
-    unless value.empty?
-      fill_in i18n_content("#{label}"), with: value
-    end
+    fill_in i18n_content("#{label}"), with: value
   end
 end
 

--- a/spec/models/membership_application_spec.rb
+++ b/spec/models/membership_application_spec.rb
@@ -94,15 +94,15 @@ RSpec.describe MembershipApplication, type: :model do
 
   describe 'User attributes nesting' do
 
-    let(:user) {create(:user, first_name: '', last_name: '')}
-    let!(:member_app) {create(:membership_application, user: user, user_attributes: {first_name: 'Firstname', last_name: 'Lastname'})}
+    let(:user) {create(:user, first_name: 'Firstname', last_name: 'Lastname')}
+    let!(:member_app) {create(:membership_application, user: user, user_attributes: {first_name: 'New Firstname', last_name: 'New Lastname'})}
 
     it 'sets first_name on user' do
-      expect(user.first_name).to eq('Firstname')
+      expect(user.first_name).to eq('New Firstname')
     end
 
     it 'sets last_name on user' do
-      expect(user.last_name).to eq('Lastname')
+      expect(user.last_name).to eq('New Lastname')
     end
 
     it 'validates the presence of first_name' do


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/147882825

**Changes proposed in this pull request:**

1. Add first and last name fields to the Devise new registration and edit registration views.
2. Make first and last name required fields on user creation (before they were only required when editing a user)

**Note:**

This story does NOT include a UI link to the edit registration view. For that, see story  https://www.pivotaltracker.com/story/show/148847945

Ready for review:
@patmbolger @weedySeaDragon @thesuss 