### PR TITLE
Check for running ajax requests after cucumber scenarios

### DIFF
--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -90,13 +90,14 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
   @javascript @admin
   Scenario: When selected reason is not 'custom other,' the custom text is saved as blank (empty string)
     Given I am on "AnnaWaiting" application page
-
     When I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
     And I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
     And I set "member_app_waiting_reasons" to "need doc"
+    And I wait for all ajax requests to complete
     # change back so the custom reason field shows. it should be blank
     And I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
+    And I wait for all ajax requests to complete
     Then I should not see "This is my reason"
 
 

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -3,9 +3,9 @@ Before('@javascript, @poltergeist') do
 end
 
 After('@javascript, @poltergeist') do
-  Timeout.timeout(Capybara.default_max_wait_time) do
-    loop until page.evaluate_script('window.jQuery ? jQuery.active : 0').zero?
-  end
+  ajax_active = !page.evaluate_script('window.jQuery ? jQuery.active : 0').zero?
   Capybara.reset_sessions!
   Capybara.current_driver = :rack_test
+  raise "expected all ajax requests to be completed after scenario, but some ajax requests were still running." if ajax_active
 end
+


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/148093527

**Changes proposed in this pull request:**

In the cucumber after('@javascript, @poltergeist') hook we make sure that all ajax requests have time to finish, so that they can't influence other tests. But just waiting hides possible problems. It is better to raise an exception for all scenarios that end when there are still some ajax requests active. 

After implementing the exception, only one test had to be changed.

Ready for review:
@patmbolger @weedySeaDragon 