### PR TITLE
Add missing translation for "save" when editing a membershipapplication 

### DIFF
--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -28,7 +28,7 @@ sv:
   send: &send Skicka
   new: &new Nytt
   change: &change Byt
-  save: &save Save
+  save: &save Spara
   back: &back Tillbaks
   search: &search Sök
   'yes': &yes Ja


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/147798991

**Changes proposed in this pull request:**

Adds "Spara" as translation for save

Ready for review:
@patmbolger @weedySeaDragon @thesuss 