### PR TITLE
Add error message for "invalid company number" to locale files.

### DIFF
--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -110,7 +110,7 @@ class MembershipApplication < ApplicationRecord
 
 
   def swedish_organisationsnummer
-    errors.add(:company_number, "#{self.company_number} är inte ett svenskt organisationsnummer") unless Orgnummer.new(self.company_number).valid?
+    errors.add(:company_number, :invalid, company_number: self.company_number) unless errors.include?(:company_number) || Orgnummer.new(self.company_number).valid?
   end
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,6 +198,11 @@ en:
             actual_file:
               file_too_large: 'The uploaded file size must be smaller than %{max}. (Your file is %{value} bytes.)'
 
+        membership_application:
+          attributes:
+            company_number:
+              invalid: "%{company_number} is not a valid Swedish company number"
+
 
       messages:
         record_invalid: "Validation failed: %{errors}"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -200,6 +200,10 @@ sv:
             actual_file:
               file_too_large: 'Filen måste vara mindre än %{max}. (Filen är %{value} byte.)'
 
+        membership_application:
+          attributes:
+            company_number:
+              invalid: "%{company_number} är inte ett svenskt organisationsnummer"
 
       messages:
         record_invalid: 'Ett fel uppstod: %{errors}'

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -64,6 +64,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
   Scenario: Admin selects 'other' and enters text as the reason SHF is waiting_for_applicant
     Given I am on "AnnaWaiting" application page
     When I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
+    And I wait for all ajax requests to complete
     When I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
     And I am on the list applications page
@@ -78,9 +79,9 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
   Scenario: Admin selects 'other' and fills in custom text but then changes reason to something else
     Given I am on "AnnaWaiting" application page
     When I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
+    And I wait for all ajax requests to complete
     And I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
-    And I wait for all ajax requests to complete
     And I set "member_app_waiting_reasons" to "waiting for payment"
     And I am on the list applications page
     And I am on "AnnaWaiting" application page
@@ -91,6 +92,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
   Scenario: When selected reason is not 'custom other,' the custom text is saved as blank (empty string)
     Given I am on "AnnaWaiting" application page
     When I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
+    And I wait for all ajax requests to complete
     And I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
     And I set "member_app_waiting_reasons" to "need doc"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -245,9 +245,9 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     it 'adds a count of errors' do
-      expect(errors_html_sv).to match(/#{t('model_errors', count: 5)}/)
+      expect(errors_html_sv).to match(/#{t('model_errors', count: 4)}/)
 
-      expect(errors_html_en).to match(/#{t('model_errors', count: 5)}/)
+      expect(errors_html_en).to match(/#{t('model_errors', count: 4)}/)
     end
 
     it 'returns all model errors - swedish' do
@@ -255,9 +255,6 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       expect(errors_html_sv).
         to match(/Organisationsnummer har fel längd \(ska vara 10 tecken\)/)
-
-      expect(errors_html_sv).
-        to match(/Organisationsnummer  är inte ett svenskt organisationsnummer/)
 
       expect(errors_html_sv).to match(/Kontakt e-post måste anges/)
 
@@ -270,9 +267,6 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       expect(errors_html_en).
         to match(/Company number is the wrong length \(should be 10 characters\)/)
-
-      expect(errors_html_en).
-        to match(/Company number  är inte ett svenskt organisationsnummer/)
 
       expect(errors_html_en).to match(/Contact Email cannot be blank/)
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/148993049 

**Changes proposed in this pull request:**

Add entries for the "%{company_number} is not a valid Swedish company number" error message to the english en swedish locale files.

Ready for review:
@patmbolger @weedySeaDragon @thesuss 