### PR TITLE
 Model validation display helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -131,4 +131,19 @@ module ApplicationHelper
     options_for_select(ITEMS_COUNT, count)
   end
 
+  def model_errors_helper(model_instance)
+    html = ''
+    if model_instance.errors.any?
+      model_instance.errors.full_messages.each do |msg|
+        html << content_tag(:div, msg, class: 'wpcf7-response-output')
+      end
+    end
+
+    return nil if html.empty?
+
+    tag.div(escape_attributes: false, class: 'wpcf7-response-output standard-label') do
+      "#{t('model_errors', count: model_instance.errors.count)}:"
+    end << raw(html)
+  end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -133,17 +133,18 @@ module ApplicationHelper
 
   def model_errors_helper(model_instance)
     html = ''
-    if model_instance.errors.any?
+    errs = model_instance.errors.count
+
+    if errs > 0
+      html = content_tag(:div, "#{t('model_errors', count: errs)}:",
+                         class: 'wpcf7-response-output standard-label')
+
       model_instance.errors.full_messages.each do |msg|
         html << content_tag(:div, msg, class: 'wpcf7-response-output')
       end
     end
 
-    return nil if html.empty?
-
-    tag.div(escape_attributes: false, class: 'wpcf7-response-output standard-label') do
-      "#{t('model_errors', count: model_instance.errors.count)}:"
-    end << raw(html)
+    html.empty? ? nil : html
   end
 
 end

--- a/app/views/admin_only/member_app_waiting_reasons/_form.html.haml
+++ b/app/views/admin_only/member_app_waiting_reasons/_form.html.haml
@@ -1,10 +1,6 @@
 = form_for @member_app_waiting_reason do |f|
 
-  - if @member_app_waiting_reason.errors.any?
-    .wpcf7-response-output
-      - @member_app_waiting_reason.errors.full_messages.each do |msg|
-        = msg
-
+  != model_errors_helper(@member_app_waiting_reason)
 
   = f.label :name_sv, t('activerecord.attributes.member_app_waiting_reason.name_sv'), class: 'required'
   - name_sv_required = t('activerecord.attributes.member_app_waiting_reason.name_sv') + ' ' + t('errors.messages.blank')

--- a/app/views/business_categories/_form.html.haml
+++ b/app/views/business_categories/_form.html.haml
@@ -1,8 +1,6 @@
 = form_for @business_category do |f|
-  - if @business_category.errors.any?
-    .wpcf7-response-output
-      - @business_category.errors.full_messages.each do |msg|
-        = msg
+
+  != model_errors_helper(@business_category)
 
   = f.label :name, t('activerecord.attributes.business_category.name') , class: 'required'
   = f.text_field :name, class: 'wpcf7-form-control'

--- a/app/views/companies/_form.html.haml
+++ b/app/views/companies/_form.html.haml
@@ -1,8 +1,6 @@
 = form_for @company do |f|
-  - if @company.errors.any?
-    .wpcf7-response-output
-      - @company.errors.full_messages.each do |msg|
-        = msg
+
+  != model_errors_helper(@company)
 
   = f.label :name, "#{t('companies.company_name')}", class: 'required'
   = f.text_field :name, class: 'wpcf7-form-control'

--- a/app/views/membership_applications/edit.html.haml
+++ b/app/views/membership_applications/edit.html.haml
@@ -11,10 +11,9 @@
     = render 'membership_number'
 
     = form_for @membership_application, html: {multipart: true}, url: membership_application_path do |f|
-      - if @membership_application.errors.any?
-        - @membership_application.errors.full_messages.each do |msg|
-          .wpcf7-response-output
-            = msg
+
+      != model_errors_helper(@membership_application)
+
       = render partial: 'membership_application_fields', locals: {f: f}
       = render 'application/required_fields'
       = f.submit t('.submit_button_label')

--- a/app/views/membership_applications/new.html.haml
+++ b/app/views/membership_applications/new.html.haml
@@ -8,10 +8,7 @@
 
   .entry-content.wpcf7
     = form_for @membership_application, html: {multipart: true}, url: membership_applications_path do |f|
-      - if @membership_application.errors.any?
-        - @membership_application.errors.full_messages.each do |msg|
-          .wpcf7-response-output
-            = msg
+      != model_errors_helper(@membership_application)
       = render partial: 'membership_application_fields', locals: {f: f}
       = render 'application/required_fields'
 

--- a/app/views/shf_documents/_form.html.haml
+++ b/app/views/shf_documents/_form.html.haml
@@ -1,11 +1,6 @@
 = form_for @shf_document do |f|
 
-  - if @shf_document.errors.any?
-    .wpcf7-response-output
-      #error_explanation
-        - @shf_document.errors.full_messages.each do |msg|
-          = msg
-
+  != model_errors_helper(@shf_document)
 
   = f.label :title
   = f.text_field :title

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,10 @@ en:
       delete: *delete
       next: 'Next'
 
+  model_errors:
+    one: Please fix 1 error
+    other: Please fix %{count} errors
+
  # Automatic and manual lookup for ActiveRecords:
   activerecord:
     models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,8 +80,8 @@ en:
       next: 'Next'
 
   model_errors:
-    one: Please fix 1 error
-    other: Please fix %{count} errors
+    one: Please fix this error
+    other: Please fix these %{count} errors
 
  # Automatic and manual lookup for ActiveRecords:
   activerecord:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -80,8 +80,8 @@ sv:
         next: 'Nästa'
 
   model_errors:
-    one: Var vänlig och åtgärda ett fel
-    other: Vänligen fixa %{count} fel
+    one: Vänligen åtgärda det här felet
+    other: Snälla fixa dessa %{count} fel
 
   # Automatisk och manuell sökning för Active Records
   activerecord:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -79,6 +79,10 @@ sv:
         delete: *delete
         next: 'Nästa'
 
+  model_errors:
+    one: Var vänlig och åtgärda ett fel
+    other: Vänligen fixa %{count} fel
+
   # Automatisk och manuell sökning för Active Records
   activerecord:
     models:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -220,5 +220,58 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe '#model_errors_helper' do
+
+    let(:good_ma) { FactoryGirl.create(:membership_application) }
+
+    let(:errors_html_sv)  do
+      I18n.locale = :sv
+      ma = MembershipApplication.new
+      ma.valid?
+      model_errors_helper(ma)
+    end
+
+    let(:errors_html_en)  do
+      I18n.locale = :en
+      ma = MembershipApplication.new
+      ma.valid?
+      model_errors_helper(ma)
+    end
+
+    it 'returns nil if no errors' do
+      expect(model_errors_helper(good_ma)).to be_nil
+    end
+
+    it 'returns all model errors - swedish' do
+      expect(errors_html_sv).to match(/Organisationsnummer måste anges/)
+
+      expect(errors_html_sv).
+        to match(/Organisationsnummer har fel längd \(ska vara 10 tecken\)/)
+
+      expect(errors_html_sv).
+        to match(/Organisationsnummer  är inte ett svenskt organisationsnummer/)
+
+      expect(errors_html_sv).to match(/Kontakt e-post måste anges/)
+
+      expect(errors_html_sv).to match(/Kontakt e-post har fel format/)
+
+    end
+
+    it 'returns all model errors - english' do
+      expect(errors_html_en).to match(/Company number cannot be blank/)
+
+      expect(errors_html_en).
+        to match(/Company number is the wrong length \(should be 10 characters\)/)
+
+      expect(errors_html_en).
+        to match(/Company number  är inte ett svenskt organisationsnummer/)
+
+      expect(errors_html_en).to match(/Contact Email cannot be blank/)
+
+      expect(errors_html_en).to match(/Contact Email is invalid/)
+
+    end
+  end
+
 
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -224,22 +224,30 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     let(:good_ma) { FactoryGirl.create(:membership_application) }
 
+    let(:user)    { FactoryGirl.create(:user) }
+
     let(:errors_html_sv)  do
       I18n.locale = :sv
-      ma = MembershipApplication.new
+      ma = MembershipApplication.new(user: user)
       ma.valid?
       model_errors_helper(ma)
     end
 
     let(:errors_html_en)  do
       I18n.locale = :en
-      ma = MembershipApplication.new
+      ma = MembershipApplication.new(user: user)
       ma.valid?
       model_errors_helper(ma)
     end
 
     it 'returns nil if no errors' do
       expect(model_errors_helper(good_ma)).to be_nil
+    end
+
+    it 'adds a count of errors' do
+      expect(errors_html_sv).to match(/#{t('model_errors', count: 5)}/)
+
+      expect(errors_html_en).to match(/#{t('model_errors', count: 5)}/)
     end
 
     it 'returns all model errors - swedish' do


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/148575869


Changes proposed in this pull request:
1. Helper method to produce HTML for model errors to be displayed on forms
2. Convert forms to user helper method
3. Unit test

Screenshots (Optional):
### Output from helper method - Swedish
<img width="360" alt="screen shot 2017-07-17 at 5 54 26 pm" src="https://user-images.githubusercontent.com/9968213/28291665-69c2f61a-6b19-11e7-864f-34bc96b06fef.png">

---
### Output - English
<img width="369" alt="screen shot 2017-07-17 at 5 54 03 pm" src="https://user-images.githubusercontent.com/9968213/28291675-7da65ac8-6b19-11e7-9f57-bc2c81f3d6ad.png">

---


Ready for review:
@RobertCram @thesuss @weedySeaDragon 