### PR TITLE
Remove name delegates from MembershipApplication

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -41,7 +41,7 @@ class AdminController < ApplicationController
     out_str = export_header_str
 
     membership_apps.each do |m_app|
-      out_str << "#{m_app.contact_email},#{m_app.first_name},#{m_app.last_name},#{m_app.membership_number},"
+      out_str << "#{m_app.contact_email},#{m_app.user.first_name},#{m_app.user.last_name},#{m_app.membership_number},"
       out_str << t("membership_applications.state.#{m_app.state}")
       out_str << ','
 

--- a/app/helpers/membership_applications_helper.rb
+++ b/app/helpers/membership_applications_helper.rb
@@ -6,7 +6,7 @@ module MembershipApplicationsHelper
 
 
   def member_full_name
-    @membership_application ? "#{@membership_application.first_name} #{@membership_application.last_name}" : '..'
+    @membership_application ? "#{@membership_application.user.first_name} #{@membership_application.user.last_name}" : '..'
 
   end
 

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -19,10 +19,10 @@ class MembershipApplication < ApplicationRecord
   #
   belongs_to :company, optional: true, inverse_of: :membership_applications
 
-  delegate :first_name, to: :user, allow_nil: true, prefix: false
-  delegate :last_name, to: :user, allow_nil: true, prefix: false
-  delegate :first_name=, to: :user, allow_nil: true, prefix: false
-  delegate :last_name=, to: :user, allow_nil: true, prefix: false
+  #delegate :first_name, to: :user, allow_nil: true, prefix: false
+  #delegate :last_name, to: :user, allow_nil: true, prefix: false
+  #delegate :first_name=, to: :user, allow_nil: true, prefix: false
+  #delegate :last_name=, to: :user, allow_nil: true, prefix: false
 
   has_and_belongs_to_many :business_categories
   has_many :uploaded_files

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -19,11 +19,6 @@ class MembershipApplication < ApplicationRecord
   #
   belongs_to :company, optional: true, inverse_of: :membership_applications
 
-  #delegate :first_name, to: :user, allow_nil: true, prefix: false
-  #delegate :last_name, to: :user, allow_nil: true, prefix: false
-  #delegate :first_name=, to: :user, allow_nil: true, prefix: false
-  #delegate :last_name=, to: :user, allow_nil: true, prefix: false
-
   has_and_belongs_to_many :business_categories
   has_many :uploaded_files
 

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -16,7 +16,7 @@
     %tbody
       - @membership_applications.each do | membership_application |
         %tr.applicant
-          %td.name= link_to "#{membership_application.first_name + ' ' + membership_application.last_name}", membership_application_path(membership_application.id)
+          %td.name= link_to "#{membership_application.user.first_name + ' ' + membership_application.user.last_name}", membership_application_path(membership_application.id)
           %td.company_number= membership_application.company_number
           %td.state= t("membership_applications.state.#{membership_application.state}")
           %td.action= link_to t('.manage'), membership_application_path(membership_application.id)

--- a/app/views/membership_applications/_membership_applications_list.html.haml
+++ b/app/views/membership_applications/_membership_applications_list.html.haml
@@ -18,7 +18,7 @@
     %tbody
       - @membership_applications.each do |membership_application|
         %tr.applicant
-          %td.name= link_to "#{membership_application.last_name + ', ' + membership_application.first_name}", membership_application_path(membership_application.id)
+          %td.name= link_to "#{membership_application.user.last_name + ', ' + membership_application.user.first_name}", membership_application_path(membership_application.id)
           %td.company_number= membership_application.company_number
           %td.state= t("membership_applications.state.#{membership_application.state}")
           %td.action= link_to "#{t('manage')}", membership_application_path(membership_application.id)

--- a/app/views/membership_applications/information.html.haml
+++ b/app/views/membership_applications/information.html.haml
@@ -6,7 +6,7 @@
   - if current_user.is_member?
     %h2
       = t('.member.title')
-      = current_user.membership_application.first_name
+      = current_user.first_name
     %p= t('.member.using_the_logo')
     %p "#{t('.member.upload_this_image')} http://www.sverigeshundforetagare.se"
     = image_tag('medlem.png')

--- a/features/admin_creates_company.feature
+++ b/features/admin_creates_company.feature
@@ -13,10 +13,10 @@ Feature: As an admin
 
   Background:
     Given the following users exists
-      | email                      | admin |
-      | applicant_1@happymutts.com |       |
-      | applicant_3@happymutts.com |       |
-      | admin@shf.se               | true  |
+      | first_name | email                      | admin |
+      | Emma       | applicant_1@happymutts.com |       |
+      | Anna       | applicant_3@happymutts.com |       |
+      | admin      | admin@shf.se               | true  |
 
     Given the following regions exist:
       | name         |
@@ -34,9 +34,9 @@ Feature: As an admin
       | Bowsers              | 2120000142     | bowwow@bowsersy.com    | Norrbotten |
 
     And the following applications exist:
-      | first_name | user_email                 | company_number | state    |
-      | Emma       | applicant_1@happymutts.com | 5560360793     | accepted |
-      | Anna       | applicant_3@happymutts.com | 2120000142     | accepted |
+      | user_email                 | company_number | state    |
+      | applicant_1@happymutts.com | 5560360793     | accepted |
+      | applicant_3@happymutts.com | 2120000142     | accepted |
 
 
     And the following business categories exist

--- a/features/company_shows_all_employee_categories.feature
+++ b/features/company_shows_all_employee_categories.feature
@@ -15,12 +15,12 @@ Feature: As a visitor
   Background:
 
     Given the following users exists
-      | email                 | admin |
-      | emma@happymutts.com   |       |
-      | lars@happymutts.com   |       |
-      | anna@happymutts.com   |       |
-      | bowser@snarkybarky.se |       |
-      | admin@shf.se          | true  |
+      | first_name | email                 | admin |
+      | Emma       | emma@happymutts.com   |       |
+      | Lars       | lars@happymutts.com   |       |
+      | Anna       | anna@happymutts.com   |       |
+      | Bowser     | bowser@snarkybarky.se |       |
+      | admin      | admin@shf.se          | true  |
 
     And the following companies exist:
       | name                 | company_number | email                  |
@@ -37,11 +37,11 @@ Feature: As a visitor
       | Agility      |
 
     And the following applications exist:
-      | first_name | user_email            | company_number | categories    | state    |
-      | Emma       | emma@happymutts.com   | 5562252998     | Groomer       | accepted |
-      | Lars       | lars@happymutts.com   | 5562252998     | Trainer       | accepted |
-      | Anna       | anna@happymutts.com   | 5562252998     | Psychologist  | accepted |
-      | Bowser     | bowser@snarkybarky.se | 2120000142     | Agility       | accepted |
+      | user_email            | company_number | categories    | state    |
+      | emma@happymutts.com   | 5562252998     | Groomer       | accepted |
+      | lars@happymutts.com   | 5562252998     | Trainer       | accepted |
+      | anna@happymutts.com   | 5562252998     | Psychologist  | accepted |
+      | bowser@snarkybarky.se | 2120000142     | Agility       | accepted |
 
 
   Scenario: Categories of 3 employees all show for a company

--- a/features/delete-company.feature
+++ b/features/delete-company.feature
@@ -14,21 +14,21 @@ Feature: As an admin
 
   Background:
     Given the following users exists
-      | email                          | admin |
-      | emma@happymutts.com            |       |
-      | hans@happymutts.com            |       |
-      | wils@woof.com                  |       |
-      | sam@snarkybarky.com            |       |
-      | lars@snarkybarky.com           |       |
-      | bob@bowsers.com                |       |
-      | kitty@kitties.com              |       |
-      | meow@kitties.com               |       |
-      | under_review@kats.com          |       |
-      | ready_for_review@kats.com      |       |
-      | waiting_for_review@kats.com    |       |
-      | new@kats.com                   |       |
-      | waiting_for_applicant@kats.com |       |
-      | admin@shf.se                   | true  |
+      | first_name       | email                          | admin |
+      | Emma             | emma@happymutts.com            |       |
+      | Hans             | hans@happymutts.com            |       |
+      | Wils             | wils@woof.com                  |       |
+      | Sam              | sam@snarkybarky.com            |       |
+      | Lars             | lars@snarkybarky.com           |       |
+      | Kitty            | kitty@kitties.com              |       |
+      | Meow             | meow@kitties.com               |       |
+      | Under_Review     | under_review@kats.com          |       |
+      | Ready for Review | ready_for_review@kats.com      |       |
+      | Waiting for A    | waiting_for_applicant@kats.com |       |
+      | New              | new@kats.com                   |       |
+      | Waiting for R    | waiting_for_review@kats.com    |       |
+      | Bob              | bob@bowsers.com                |       |
+      | admin            | admin@shf.se                   | true  |
 
     And the following business categories exist
       | name        | description                     |
@@ -67,18 +67,18 @@ Feature: As an admin
 
 
     And the following applications exist:
-      | first_name       | user_email                     | company_number | state                 | categories    |
-      | Emma             | emma@happymutts.com            | 2120000142     | accepted              | grooming      |
-      | Hans             | hans@happymutts.com            | 2120000142     | accepted              | training      |
-      | Sam              | sam@snarkybarky.com            | 5560360793     | rejected              | senior-play   |
-      | Lars             | lars@snarkybarky.com           | 5560360793     | rejected              | rehab         |
-      | Wils             | wils@woof.com                  | 5569467466     | rejected              | walking       |
-      | Kitty            | kitty@kitties.com              | 5906055081     | rejected              | training      |
-      | Meow             | meow@kitties.com               | 5906055081     | rejected              | training      |
-      | Under_Review     | under_review@kats.com          | 9697222900     | under_review          | psychology    |
-      | Ready for Review | ready_for_review@kats.com      | 9697222900     | ready_for_review      | psychology    |
-      | Waiting for A    | waiting_for_applicant@kats.com | 9697222900     | waiting_for_applicant | psychology    |
-      | New              | new@kats.com                   | 9697222900     | new                   | psychology    |
+      | user_email                     | company_number | state                 | categories    |
+      | emma@happymutts.com            | 2120000142     | accepted              | grooming      |
+      | hans@happymutts.com            | 2120000142     | accepted              | training      |
+      | wils@woof.com                  | 5569467466     | rejected              | walking       |
+      | sam@snarkybarky.com            | 5560360793     | rejected              | senior-play   |
+      | lars@snarkybarky.com           | 5560360793     | rejected              | rehab         |
+      | kitty@kitties.com              | 5906055081     | rejected              | training      |
+      | meow@kitties.com               | 5906055081     | rejected              | training      |
+      | under_review@kats.com          | 9697222900     | under_review          | psychology    |
+      | ready_for_review@kats.com      | 9697222900     | ready_for_review      | psychology    |
+      | waiting_for_applicant@kats.com | 9697222900     | waiting_for_applicant | psychology    |
+      | new@kats.com                   | 9697222900     | new                   | psychology    |
 
 
 

--- a/features/disallow-company-malicious-website.feature
+++ b/features/disallow-company-malicious-website.feature
@@ -7,9 +7,9 @@ Feature: Don't allow malicious code in Company website value
 
   Background:
     Given the following users exists
-      | email               | admin |
-      | emma@happymutts.com |       |
-      | admin@shf.se        | true  |
+      | first_name | email               | admin |
+      | Emma       | emma@happymutts.com |       |
+      | admin      | admin@shf.se        | true  |
 
     And the following regions exist:
       | name         |
@@ -27,8 +27,8 @@ Feature: Don't allow malicious code in Company website value
 
 
     And the following applications exist:
-      | first_name | user_email          | company_number | state    |
-      | Emma       | emma@happymutts.com | 5560360793     | accepted |
+      | user_email          | company_number | state    |
+      | emma@happymutts.com | 5560360793     | accepted |
 
 
 

--- a/features/edit_company.feature
+++ b/features/edit_company.feature
@@ -4,10 +4,10 @@ Feature: As a member
 
   Background:
     Given the following users exists
-      | email                      | admin | is_member |
-      | applicant_1@happymutts.com |       | true      |
-      | applicant_3@happymutts.com |       | false     |
-      | admin@shf.se               | true  | true      |
+      | first_name | email                      | admin | is_member |
+      | Emma       | applicant_1@happymutts.com |       | true      |
+      | Anna       | applicant_3@happymutts.com |       | false     |
+      | admin      | admin@shf.se               | true  | true      |
 
     And the following companies exist:
       | name                 | company_number | email                  |
@@ -15,9 +15,9 @@ Feature: As a member
       | Bowsers              | 2120000142     | bowwow@bowsersy.com    |
 
     And the following applications exist:
-      | first_name | user_email                 | company_number | state    |
-      | Emma       | applicant_1@happymutts.com | 5560360793     | accepted |
-      | Anna       | applicant_3@happymutts.com | 2120000142     | accepted |
+      | user_email                 | company_number | state    |
+      | applicant_1@happymutts.com | 5560360793     | accepted |
+      | applicant_3@happymutts.com | 2120000142     | accepted |
 
 
   Scenario: Member can edit their company

--- a/features/edit_membership_application.feature
+++ b/features/edit_membership_application.feature
@@ -15,11 +15,11 @@ Feature: As an applicant
       | admin      | admin@shf.se      | true      | true  |
 
     And the following applications exist:
-      | first_name | user_email        | company_number | state                 |
-      | Emma       | emma@random.com   | 5560360793     | waiting_for_applicant |
-      | Hans       | hans@random.com   | 2120000142     | under_review          |
-      | Nils       | nils@random.com   | 2120000142     | accepted              |
-      | Bob        | bob@barkybobs.com | 5560360793     | rejected              |
+      | user_email        | company_number | state                 |
+      | emma@random.com   | 5560360793     | waiting_for_applicant |
+      | hans@random.com   | 2120000142     | under_review          |
+      | nils@random.com   | 2120000142     | accepted              |
+      | bob@barkybobs.com | 5560360793     | rejected              |
 
   Scenario: Applicant wants to edit his own application
     Given I am logged in as "emma@random.com"

--- a/features/export-member-email-info.feature
+++ b/features/export-member-email-info.feature
@@ -6,10 +6,10 @@ Feature: export member information to a CSV file so I can use it in other system
 
   Background:
     Given the following users exists
-      | email                       | admin |
-      | emma@happymutts.com         |       |
-      | wils@woof.com               |       |
-      | admin@shf.se                | true  |
+      | first_name | last_name   | email                       | admin |
+      | Emma       | Emmasdottir | emma@happymutts.com         |       |
+      | Wils       | Wilson      | wils@woof.com               |       |
+      | admin      | admin       | admin@shf.se                | true  |
 
 
     And the following regions exist:
@@ -25,9 +25,9 @@ Feature: export member information to a CSV file so I can use it in other system
       | WOOF                 | 5569467466     | woof@woof.com         | Västerbotten |
 
     And the following applications exist:
-      | first_name | last_name   | user_email          | company_number | state    |
-      | Emma       | Emmasdottir | emma@happymutts.com | 2120000142     | accepted |
-      | Wils       | Wilson      | wils@woof.com       | 5569467466     | new      |
+      | user_email          | company_number | state    |
+      | emma@happymutts.com | 2120000142     | accepted |
+      | wils@woof.com       | 5569467466     | new      |
 
 
 

--- a/features/list_companies_of_category.feature
+++ b/features/list_companies_of_category.feature
@@ -5,11 +5,11 @@ Feature: As any type of visitor
 
   Background:
     Given the following users exists
-      | email               | admin | is_member |
-      | emma@happymutts.com |       | true      |
-      | anna@sadmutts.com   |       | true      |
-      | ernt@mutts.com      |       | true      |
-      | admin@shf.se        | true  | true      |
+      | first_name | email               | admin | is_member |
+      | Emma       | emma@happymutts.com |       | true      |
+      | Ernt       | ernt@mutts.com      |       | true      |
+      | Anna       | anna@sadmutts.com   |       | true      |
+      | admin      | admin@shf.se        | true  | true      |
 
     Given the following regions exist:
       | name         |
@@ -37,10 +37,10 @@ Feature: As any type of visitor
       | Extra   |
 
     And the following applications exist:
-      | first_name | user_email          | company_number | categories | state    |
-      | Emma       | emma@happymutts.com | 5562252998     | Awesome    | accepted |
-      | Ernt       | ernt@mutts.com      | 5569467466     | Awesome    | accepted |
-      | Anna       | anna@sadmutts.com   | 2120000142     | Sadness    | accepted |
+      | user_email          | company_number | categories | state    |
+      | emma@happymutts.com | 5562252998     | Awesome    | accepted |
+      | ernt@mutts.com      | 5569467466     | Awesome    | accepted |
+      | anna@sadmutts.com   | 2120000142     | Sadness    | accepted |
 
   Scenario: Categories list multiple businesses
     Given I am Logged out

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -4,16 +4,16 @@ Feature: As a registered user
 
   Background:
     Given the following users exists
-      | email                | password | admin | is_member |
-      | emma@random.com      | password | false | true      |
-      | anne@random.com      | password | false | false     |
-      | lars-user@random.com | password | false | false     |
-      | arne@random.com      | password | true  | true      |
+      | first_name | email                | password | admin | is_member |
+      | Emma       | emma@random.com      | password | false | true      |
+      | Lars       | lars-user@random.com | password | false | false     |
+      | Anne       | anne@random.com      | password | false | false     |
+      | Arne       | arne@random.com      | password | true  | true      |
 
     And the following applications exist:
-      | first_name | user_email           | company_number | state    |
-      | Emma       | emma@random.com      | 5562252998     | accepted |
-      | Lars       | lars-user@random.com | 2120000142     | under_review |
+      | user_email           | company_number | state    |
+      | emma@random.com      | 5562252998     | accepted |
+      | lars-user@random.com | 2120000142     | under_review |
 
 
   Scenario: Logging in

--- a/features/manage_users.feature
+++ b/features/manage_users.feature
@@ -4,11 +4,11 @@ Feature: As an admin
 
   Background:
     Given the following users exist
-      | email               | admin |
-      | emma@happymutts.com |       |
-      | anna@sadmutts.com   |       |
-      | ernt@mutts.com      |       |
-      | admin@shf.se        | true  |
+      | first_name | email               | admin |
+      | Emma       | emma@happymutts.com |       |
+      | Anna       | anna@sadmutts.com   |       |
+      | Ernt       | ernt@mutts.com      |       |
+      | admin      | admin@shf.se        | true  |
 
     And the following business categories exist
       | name         |
@@ -17,10 +17,10 @@ Feature: As an admin
       | Trainer      |
 
     And the following applications exist:
-      | first_name | user_email          | company_number | categories   | state    |
-      | Emma       | emma@happymutts.com | 5562252998     | Trainer      | accepted |
-      | Anna       | anna@sadmutts.com   | 2120000142     | Psychologist | accepted |
-      | Ernt       | ernt@mutts.com      | 2120000142     | Psychologist | new      |
+      | user_email          | company_number | categories   | state    |
+      | emma@happymutts.com | 5562252998     | Trainer      | accepted |
+      | anna@sadmutts.com   | 2120000142     | Psychologist | accepted |
+      | ernt@mutts.com      | 2120000142     | Psychologist | new      |
 
   Scenario: Admin can view all users
     Given I am logged in as "admin@shf.se"

--- a/features/mapping_and_geocoding/companies_are_geocoded_when_viewing_all.feature
+++ b/features/mapping_and_geocoding/companies_are_geocoded_when_viewing_all.feature
@@ -23,10 +23,10 @@ Feature: All companies are geocoded before being shown on the view all companies
 
 
     And the following users exists
-      | email               | admin |
-      | emma@happymutts.com |       |
-      | a@happymutts.com    |       |
-      | admin@shf.se        | true  |
+      | first_name | email               | admin |
+      | Emma       | emma@happymutts.com |       |
+      | Anna       | a@happymutts.com    |       |
+      | admin      | admin@shf.se        | true  |
 
     And the following business categories exist
       | name         |
@@ -34,9 +34,9 @@ Feature: All companies are geocoded before being shown on the view all companies
       | Trainer      |
 
     And the following applications exist:
-      | first_name | user_email          | company_number | categories | state    |
-      | Emma       | emma@happymutts.com | 5560360793     | Groomer    | accepted |
-      | Anna       | a@happymutts.com    | 2120000142     | Trainer    | accepted |
+      | user_email          | company_number | categories | state    |
+      | emma@happymutts.com | 5560360793     | Groomer    | accepted |
+      | a@happymutts.com    | 2120000142     | Trainer    | accepted |
 
 
 

--- a/features/member_edits_company_page.feature
+++ b/features/member_edits_company_page.feature
@@ -6,9 +6,9 @@ Feature: As a member
 
   Background:
     Given the following users exists
-      | email               | admin | is_member |
-      | emma@happymutts.com |       | true      |
-      | admin@shf.se        | true  | true      |
+      | first_name | email               | admin | is_member |
+      | Emma       | emma@happymutts.com |       | true      |
+      | admin      | admin@shf.se        | true  | true      |
 
     Given the following regions exist:
       | name         |
@@ -31,8 +31,8 @@ Feature: As a member
       | Awesome      |
 
     And the following applications exist:
-      | first_name | user_email          | company_number | categories | state    |
-      | Emma       | emma@happymutts.com | 5562252998     | Awesome    | accepted |
+      | user_email          | company_number | categories | state    |
+      | emma@happymutts.com | 5562252998     | Awesome    | accepted |
 
   Scenario: Member goes to company page after membership approval
     Given I am logged in as "emma@happymutts.com"

--- a/features/membership-application-status/admin-custom-reason-waiting.feature
+++ b/features/membership-application-status/admin-custom-reason-waiting.feature
@@ -20,11 +20,11 @@ Feature: "Other/Custom" waiting reason comes from locale file and Admin cannot e
 
 
     Given the following users exists
-      | email                                  | admin |
-      | anna_waiting_for_info@nosnarkybarky.se |       |
-      | anna_under_review@nosnarkybarky.se     |       |
-      | emma@happymutts.se                     |       |
-      | admin@shf.se                           | true  |
+      | first_name      | email                                  | admin |
+      | AnnaWaiting     | anna_waiting_for_info@nosnarkybarky.se |       |
+      | AnnaUnderReview | anna_under_review@nosnarkybarky.se     |       |
+      | EmmaAccepted    | emma@happymutts.se                     |       |
+      | admin           | admin@shf.se                           | true  |
 
     Given the following business categories exist
       | name  | description           |
@@ -41,10 +41,10 @@ Feature: "Other/Custom" waiting reason comes from locale file and Admin cannot e
 
 
     And the following applications exist:
-      | first_name      | user_email                             | company_number | category_name | state                 |
-      | AnnaWaiting     | anna_waiting_for_info@nosnarkybarky.se | 5560360793     | rehab         | waiting_for_applicant |
-      | AnnaUnderReview | anna_under_review@nosnarkybarky.se     | 5560360793     | rehab         | under_review          |
-      | EmmaAccepted    | emma@happymutts.se                     | 2120000142     | rehab         | accepted              |
+      | user_email                             | company_number | category_name | state                 |
+      | anna_waiting_for_info@nosnarkybarky.se | 5560360793     | rehab         | waiting_for_applicant |
+      | anna_under_review@nosnarkybarky.se     | 5560360793     | rehab         | under_review          |
+      | emma@happymutts.se                     | 2120000142     | rehab         | accepted              |
 
 
     And the following member app waiting reasons exist:

--- a/features/membership-application-status/admin-manage-reasons-waiting-for-info.feature
+++ b/features/membership-application-status/admin-manage-reasons-waiting-for-info.feature
@@ -12,10 +12,10 @@ Feature: Admin manages the list of reasons why SHF is waiting for info from an a
 
   Background:
     Given the following users exists
-      | email                                  | admin |
-      | anna_waiting_for_info@nosnarkybarky.se |       |
-      | emma@happymutts.se                     |       |
-      | admin@shf.se                           | true  |
+      | first_name   | email                                  | admin |
+      | AnnaWaiting  | anna_waiting_for_info@nosnarkybarky.se |       |
+      | EmmaAccepted | emma@happymutts.se                     |       |
+      | admin        | admin@shf.se                           | true  |
 
     Given the following business categories exist
       | name  | description           |
@@ -32,9 +32,9 @@ Feature: Admin manages the list of reasons why SHF is waiting for info from an a
 
 
     And the following applications exist:
-      | first_name   | user_email                             | company_number | category_name | state                 |
-      | AnnaWaiting  | anna_waiting_for_info@nosnarkybarky.se | 5560360793     | rehab         | waiting_for_applicant |
-      | EmmaAccepted | emma@happymutts.se                     | 2120000142     | rehab         | accepted              |
+      | user_email                             | company_number | category_name | state                 |
+      | anna_waiting_for_info@nosnarkybarky.se | 5560360793     | rehab         | waiting_for_applicant |
+      | emma@happymutts.se                     | 2120000142     | rehab         | accepted              |
 
 
     And the following member app waiting reasons exist:

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -9,9 +9,9 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
 
   Background:
     Given the following users exists
-      | email                                  | admin |
-      | anna_waiting_for_info@nosnarkybarky.se |       |
-      | admin@shf.com                          | true  |
+      | first_name  | email                                  | admin |
+      | AnnaWaiting | anna_waiting_for_info@nosnarkybarky.se |       |
+      | admin       | admin@shf.com                          | true  |
 
     Given the following business categories exist
       | name  | description           |
@@ -27,8 +27,8 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
 
 
     And the following applications exist:
-      | first_name  | user_email                             | company_number | category_name | state                 |
-      | AnnaWaiting | anna_waiting_for_info@nosnarkybarky.se | 5560360793     | rehab         | waiting_for_applicant |
+      | user_email                             | company_number | category_name | state                 |
+      | anna_waiting_for_info@nosnarkybarky.se | 5560360793     | rehab         | waiting_for_applicant |
 
 
     And the following member app waiting reasons exist

--- a/features/search_companies.feature
+++ b/features/search_companies.feature
@@ -6,11 +6,11 @@ I want to search for available companies by various criteria
 
 Background:
   Given the following users exists
-    | email                | admin |
-    | fred@barkyboys.com   |       |
-    | john@happymutts.com  |       |
-    | anna@dogsrus.com     |       |
-    | emma@weluvdogs.com   |       |
+    | first_name | email                | admin |
+    | Fred       | fred@barkyboys.com   |       |
+    | John       | john@happymutts.com  |       |
+    | Anna       | anna@dogsrus.com     |       |
+    | Emma       | emma@weluvdogs.com   |       |
 
   And the following business categories exist
     | name         |
@@ -41,11 +41,11 @@ Background:
     | We Luv Dogs | 5569467466     | alpha@weluvdogs.com  | Sweden       | Laxå      |
 
   And the following applications exist:
-    | first_name | user_email          | company_number | state    | categories      |
-    | Fred       | fred@barkyboys.com  | 5560360793     | accepted | Groomer, Trainer|
-    | John       | john@happymutts.com | 2120000142     | accepted | Psychologist    |
-    | Anna       | anna@dogsrus.com    | 5562252998     | accepted | Trainer         |
-    | Emma       | emma@weluvdogs.com  | 5569467466     | accepted | Groomer, Walker |
+    | user_email          | company_number | state    | categories      |
+    | fred@barkyboys.com  | 5560360793     | accepted | Groomer, Trainer|
+    | john@happymutts.com | 2120000142     | accepted | Psychologist    |
+    | anna@dogsrus.com    | 5562252998     | accepted | Trainer         |
+    | emma@weluvdogs.com  | 5569467466     | accepted | Groomer, Walker |
 
 @javascript
 Scenario: View all companies, sort by columns

--- a/features/shf-documents/admin-deletes-shf-document.feature
+++ b/features/shf-documents/admin-deletes-shf-document.feature
@@ -9,18 +9,18 @@ Feature: Admin can delete uploaded SHF Documents
 
 
     Given the following users exists
-      | email              | admin |
-      | emma@happymutts.se |       |
-      | bob@snarkybarky.se |       |
-      | admin@shf.se       | true  |
+      | first_name | email              | admin |
+      | Emma       | emma@happymutts.se |       |
+      | Bob        | bob@snarkybarky.se |       |
+      | admin      | admin@shf.se       | true  |
 
     And the following companies exist:
       | name        | company_number | email               |
       | Happy Mutts | 2120000142     | bowwow@bowsersy.com |
 
     And the following applications exist:
-      | first_name | user_email         | company_number | state    |
-      | Emma       | emma@happymutts.se | 2120000142     | accepted |
+      | user_email         | company_number | state    |
+      | emma@happymutts.se | 2120000142     | accepted |
 
     And I am logged in as "admin@shf.se"
 

--- a/features/shf-documents/admin-edits-shf-document.feature
+++ b/features/shf-documents/admin-edits-shf-document.feature
@@ -9,18 +9,18 @@ Feature: Admin can edit details about an uploaded SHF Document
 
 
     Given the following users exists
-      | email               | admin |
-      | emma@happymutts.se |       |
-      | bob@snarkybarky.se  |       |
-      | admin@shf.se        | true  |
+      | first_name | email               | admin |
+      | Emma       | emma@happymutts.se  |       |
+      | Bob        | bob@snarkybarky.se  |       |
+      | admin      | admin@shf.se        | true  |
 
     And the following companies exist:
       | name        | company_number | email               |
       | Happy Mutts | 2120000142     | bowwow@bowsersy.com |
 
     And the following applications exist:
-      | first_name | user_email          | company_number | state    |
-      | Emma       | emma@happymutts.se | 2120000142     | accepted |
+      | user_email          | company_number | state    |
+      | emma@happymutts.se | 2120000142     | accepted |
 
     And I am logged in as "admin@shf.se"
 

--- a/features/shf-documents/admin-uploads-shf-documents.feature
+++ b/features/shf-documents/admin-uploads-shf-documents.feature
@@ -7,18 +7,18 @@ Feature: Admin uploads meeting PDFs
   Background:
 
     Given the following users exists
-      | email               | admin |
-      | emma@happymutts.se |       |
-      | bob@snarkybarky.se  |       |
-      | admin@shf.se        | true  |
+      | first_name | email               | admin |
+      | Emma       | emma@happymutts.se |       |
+      | Bob        | bob@snarkybarky.se  |       |
+      | admin      | admin@shf.se        | true  |
 
     And the following companies exist:
       | name        | company_number | email               |
       | Happy Mutts | 2120000142     | bowwow@bowsersy.com |
 
     And the following applications exist:
-      | first_name | user_email          | company_number | state    |
-      | Emma       | emma@happymutts.se | 2120000142     | accepted |
+      | user_email          | company_number | state    |
+      | emma@happymutts.se  | 2120000142     | accepted |
 
 
     And I am logged in as "admin@shf.se"

--- a/features/shf-documents/admin-views-shf-document-details.feature
+++ b/features/shf-documents/admin-views-shf-document-details.feature
@@ -9,18 +9,18 @@ Feature: Admin can edit details about an uploaded SHF Document
 
 
     Given the following users exists
-      | email               | admin |
-      | emma@happymutts.se |       |
-      | bob@snarkybarky.se  |       |
-      | admin@shf.se        | true  |
+      | first_name | email               | admin |
+      | Emma       | emma@happymutts.se  |       |
+      | Bob        | bob@snarkybarky.se  |       |
+      | admin      | admin@shf.se        | true  |
 
     And the following companies exist:
       | name        | company_number | email               |
       | Happy Mutts | 2120000142     | bowwow@bowsersy.com |
 
     And the following applications exist:
-      | first_name | user_email          | company_number | state    |
-      | Emma       | emma@happymutts.se | 2120000142     | accepted |
+      | user_email          | company_number | state    |
+      | emma@happymutts.se | 2120000142      | accepted |
 
     And I am logged in as "admin@shf.se"
 

--- a/features/shf-documents/view-all-shf-documents.feature
+++ b/features/shf-documents/view-all-shf-documents.feature
@@ -11,18 +11,18 @@ Feature: SHF members (and admins) can views board meeting minutes (SHF documents
   Background:
 
     Given the following users exists
-      | email              | admin |
-      | emma@happymutts.se |       |
-      | bob@snarkybarky.se |       |
-      | admin@shf.se       | true  |
+      | first_name | email              | admin |
+      | Emma       | emma@happymutts.se |       |
+      | Bob        | bob@snarkybarky.se |       |
+      | admin      | admin@shf.se       | true  |
 
     And the following companies exist:
       | name        | company_number | email               |
       | Happy Mutts | 2120000142     | bowwow@bowsersy.com |
 
     And the following applications exist:
-      | first_name | user_email         | company_number | state    |
-      | Emma       | emma@happymutts.se | 2120000142     | accepted |
+      | user_email         | company_number | state    |
+      | emma@happymutts.se | 2120000142     | accepted |
 
 
   Scenario: An admin can see the list of SHF documents and click on title link

--- a/features/show-company-map.feature
+++ b/features/show-company-map.feature
@@ -8,8 +8,8 @@ Feature: As a visitor
   Background:
 
     Given the following users exist
-      | email               | admin |
-      | emma@happymutts.com |       |
+      | first_name | email               | admin |
+      | Emma       | emma@happymutts.com |       |
 
 
     And the following regions exist:
@@ -32,8 +32,8 @@ Feature: As a visitor
 
 
     And the following applications exist:
-      | first_name | user_email          | company_number | categories | state    |
-      | Emma       | emma@happymutts.com | 5560360793     | Groomer    | accepted |
+      | user_email          | company_number | categories | state    |
+      | emma@happymutts.com | 5560360793     | Groomer    | accepted |
 
 
   @javascript

--- a/features/show-company.feature
+++ b/features/show-company.feature
@@ -32,11 +32,11 @@ Feature: As a visitor,
       | Company6             | 6914762726     | cmpy6@mail.com         | Stockholm    | Alingsås | none               |
 
     And the following users exists
-      | email               | admin |
-      | emma@happymutts.com |       |
-      | a@happymutts.com    |       |
-      | member@cmpy6.com    |       |
-      | admin@shf.se        | true  |
+      | first_name | email               | admin |
+      | Emma       | emma@happymutts.com |       |
+      | Anna       | a@happymutts.com    |       |
+      | Anna       | member@cmpy6.com    |       |
+      | admin      | admin@shf.se        | true  |
 
     And the following business categories exist
       | name         |
@@ -48,14 +48,14 @@ Feature: As a visitor,
       | JustForFun   |
 
     And the following applications exist:
-      | first_name | user_email          | company_number | categories              | state    |
-      | Emma       | emma@happymutts.com | 5560360793     | Groomer, JustForFun     | accepted |
-      | Anna       | a@happymutts.com    | 2120000142     | Groomer, Trainer, Rehab | accepted |
-      | Emma       | emma@happymutts.com | 2120000142     | Psychologist, Groomer   | accepted |
-      | Anna       | a@happymutts.com    | 6613265393     | Groomer                 | accepted |
-      | Anna       | a@happymutts.com    | 6222279082     | Groomer                 | accepted |
-      | Anna       | a@happymutts.com    | 8025085252     | Groomer                 | accepted |
-      | Anna       | member@cmpy6.com    | 6914762726     | Groomer                 | accepted |
+      | user_email          | company_number | categories              | state    |
+      | emma@happymutts.com | 5560360793     | Groomer, JustForFun     | accepted |
+      | a@happymutts.com    | 2120000142     | Groomer, Trainer, Rehab | accepted |
+      | emma@happymutts.com | 2120000142     | Psychologist, Groomer   | accepted |
+      | a@happymutts.com    | 6613265393     | Groomer                 | accepted |
+      | a@happymutts.com    | 6222279082     | Groomer                 | accepted |
+      | a@happymutts.com    | 8025085252     | Groomer                 | accepted |
+      | member@cmpy6.com    | 6914762726     | Groomer                 | accepted |
 
   Scenario: Show company details to a visitor, but don't show the org nr.
     Given I am Logged out

--- a/features/show-user-details.feature
+++ b/features/show-user-details.feature
@@ -7,16 +7,16 @@ Feature: As an admin
   Background:
 
     Given the following users exists
-      | email                   | admin |
-      | emma@personal.com       |       |
-      | lars@personal.com       |       |
-      | hannah@personal.com     |       |
-      | nils@personal.se        |       |
-      | anna@personal.se        |       |
-      | sam@personal.se         |       |
-      | admin@shf.se            | true  |
-      | yesterday_admin@shf.se  | true  |
-      | lazy_admin@shf.se       | true  |
+      | first_name | email                   | admin |
+      | Emma       | emma@personal.com       |       |
+      | Lars       | lars@personal.com       |       |
+      | Hannah     | hannah@personal.com     |       |
+      | Nils       | nils@personal.se        |       |
+      | Anna       | anna@personal.se        |       |
+      | Sam        | sam@personal.se         |       |
+      | admin      | admin@shf.se            | true  |
+      | admin      | yesterday_admin@shf.se  | true  |
+      | admin      | lazy_admin@shf.se       | true  |
 
     And the following regions exist:
       | name         |
@@ -30,11 +30,11 @@ Feature: As an admin
 
 
     And the following applications exist:
-      | first_name | user_email          | contact_email         | company_number | state    |
-      | Emma       | emma@personal.com   | emma@happymutts.com   | 5560360793     | accepted |
-      | Lars       | lars@personal.com   | lars@happymutts.com   | 5560360793     | accepted |
-      | Hannah     | hannah@personal.com | hannah@happymutts.com | 5560360793     | accepted |
-      | Emma       | emma@personal.com   | emma@bowsers.com      | 2120000142     | new      |
+      | user_email          | contact_email         | company_number | state    |
+      | emma@personal.com   | emma@happymutts.com   | 5560360793     | accepted |
+      | lars@personal.com   | lars@happymutts.com   | 5560360793     | accepted |
+      | hannah@personal.com | hannah@happymutts.com | 5560360793     | accepted |
+      | emma@personal.com   | emma@bowsers.com      | 2120000142     | new      |
 
 
 

--- a/features/show_membership_application.feature
+++ b/features/show_membership_application.feature
@@ -12,15 +12,15 @@ Feature: As an Admin
 
   Background:
     Given the following users exists
-      | email                               | admin |
-      | emma@personal.com                   |       |
-      | hans@random.com                     |       |
-      | anna_needs_info@random.com          |       |
-      | lars_rejected@snarkybark.se         |       |
-      | nils_member@bowwowwow.se            |       |
-      | admin@shf.com                       | true  |
-      | emma_under_review@happymutts.se     |       |
-      | hans_ready_for_review@happymutts.se |       |
+      | first_name         | email                               | admin |
+      | Emma               | emma@personal.com                   |       |
+      | Hans               | hans@random.com                     |       |
+      | Anna               | anna_needs_info@random.com          |       |
+      | LarsRejected       | lars_rejected@snarkybark.se         |       |
+      | NilsApproved       | nils_member@bowwowwow.se            |       |
+      | EmmaUnderReview    | emma_under_review@happymutts.se     |       |
+      | HansReadyForReview | hans_ready_for_review@happymutts.se |       |
+      | admin              | admin@shf.com                       | true  |
 
 
     And the following business categories exist
@@ -37,14 +37,14 @@ Feature: As an Admin
       | No More Snarky Barky | 5560360793     | snarky@snarkybarky.se |
 
     And the following applications exist:
-      | first_name         | user_email                          | contact_email   | company_number | state                 | categories   |
-      | Emma               | emma@personal.com                   | emma@cmpy.com   | 5562252998     | waiting_for_applicant | Psychologist |
-      | Hans               | hans@random.com                     |                 | 5560360793     | waiting_for_applicant | Psychologist |
-      | Anna               | anna_needs_info@random.com          |                 | 2120000142     | waiting_for_applicant | Psychologist |
-      | LarsRejected       | lars_rejected@snarkybark.se         |                 | 0000000000     | rejected              | dog crooning |
-      | NilsApproved       | nils_member@bowwowwow.se            |                 | 0000000000     | accepted              | Groomer      |
-      | EmmaUnderReview    | emma_under_review@happymutts.se     |                 | 5562252998     | under_review          | rehab        |
-      | HansReadyForReview | hans_ready_for_review@happymutts.se |                 | 5562252998     | ready_for_review      | dog grooming |
+      | user_email                          | contact_email   | company_number | state                 | categories   |
+      | emma@personal.com                   | emma@cmpy.com   | 5562252998     | waiting_for_applicant | Psychologist |
+      | hans@random.com                     |                 | 5560360793     | waiting_for_applicant | Psychologist |
+      | anna_needs_info@random.com          |                 | 2120000142     | waiting_for_applicant | Psychologist |
+      | lars_rejected@snarkybark.se         |                 | 0000000000     | rejected              | dog crooning |
+      | nils_member@bowwowwow.se            |                 | 0000000000     | accepted              | Groomer      |
+      | emma_under_review@happymutts.se     |                 | 5562252998     | under_review          | rehab        |
+      | hans_ready_for_review@happymutts.se |                 | 5562252998     | ready_for_review      | dog grooming |
 
 
   @admin

--- a/features/show_only_complete_companies.feature
+++ b/features/show_only_complete_companies.feature
@@ -29,24 +29,24 @@ Feature: So that I do not get frustrated by trying to find out more
       |              | 5906055081     | hello@noName.se        | Stockholm             | Alingsås |
 
     And the following users exists
-      | email                        | admin |
-      | admin@shf.se                 | true  |
-      | emmaGroomer@happymutts.com   |       |
-      | annaTrainer@bowsers.com      |       |
-      | larsGroomer@noRegionOrOld.se |       |
-      | larsTrainer@noRegionOrOld.se |       |
-      | ole@noOldRegion.se           |       |
-      | maja@onlyNoRegion.se         |       |
-      | kikki@noName.se              |       |
+      | first_name  | email                        | admin |
+      | EmmaGroomer | emmaGroomer@happymutts.com   |       |
+      | AnnaTrainer | annaTrainer@bowsers.com      |       |
+      | Ole         | ole@noOldRegion.se           |       |
+      | Maja        | maja@onlyNoRegion.se         |       |
+      | Kikki       | kikki@noName.se              |       |
+      | LarsGroomer | larsGroomer@noRegionOrOld.se |       |
+      | LarsTrainer | larsTrainer@noRegionOrOld.se |       |
+      | admin       | admin@shf.se                 | true  |
 
 
     And the following applications exist:
-      | first_name  | user_email                 | company_number | categories       | state    |
-      | EmmaGroomer | emmaGroomer@happymutts.com | 5560360793     | Groomer          | accepted |
-      | AnnaTrainer | annaTrainer@bowsers.com    | 2120000142     | Trainer          | accepted |
-      | Ole         | ole@noOldRegion.se         | 5569467466     | Groomer, Trainer | accepted |
-      | Maja        | maja@onlyNoRegion.se       | 8028973322     | Groomer, Trainer | accepted |
-      | Kikki       | kikki@noName.se            | 5906055081     | Groomer, Trainer | accepted |
+      | user_email                 | company_number | categories       | state    |
+      | emmaGroomer@happymutts.com | 5560360793     | Groomer          | accepted |
+      | annaTrainer@bowsers.com    | 2120000142     | Trainer          | accepted |
+      | ole@noOldRegion.se         | 5569467466     | Groomer, Trainer | accepted |
+      | maja@onlyNoRegion.se       | 8028973322     | Groomer, Trainer | accepted |
+      | kikki@noName.se            | 5906055081     | Groomer, Trainer | accepted |
 
     And the region for company named "NoRegion" is set to nil
 

--- a/features/size_validation.feature
+++ b/features/size_validation.feature
@@ -5,13 +5,13 @@ Feature: As an applicant
 
   Background:
     Given the following users exists
-      | email                 | admin |
-      | hans@new_applicant.se |       |
-      | emma@happymutts.se    |       |
+      | first_name | email                 | admin |
+      | Hans       | hans@new_applicant.se |       |
+      | Emma       | emma@happymutts.se    |       |
 
     And the following applications exist:
-      | first_name | user_email         | company_number | state        |
-      | Emma       | emma@happymutts.se | 5560360793     | under_review |
+      | user_email         | company_number | state        |
+      | emma@happymutts.se | 5560360793     | under_review |
 
 
   Scenario: New application - Uploads a file that is too large

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -28,8 +28,6 @@ end
 And(/^the following simple applications exist:$/) do |table|
   table.hashes.each do |hash|
     ma = FactoryGirl.build(:membership_application,
-                           first_name: 'Fred',
-                           last_name: 'Flintstone',
                            company_number: hash['company_number'],
                            contact_email: hash['user_email'],
                            state: hash['state'])

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -5,16 +5,16 @@ Feature: As an Admin
 
   Background:
     Given the following users exists
-      | email                                  | admin |
-      | applicant_1@random.com                 |       |
-      | applicant_2@random.com                 |       |
-      | emma_under_review@happymutts.se        |       |
-      | hans_under_review@happymutts.se        |       |
-      | lars_waiting_for_payment@happymutts.se |       |
-      | anna_waiting_for_info@nosnarkybarky.se |       |
-      | nils_member@bowwowwow.se               |       |
-      | lars_rejected@snarkybark.se            |       |
-      | admin@shf.se                           | true  |
+      | first_name            | email                                  | admin |
+      | EmmaUnderReview       | emma_under_review@happymutts.se        |       |
+      | HansUnderReview       | hans_under_review@happymutts.se        |       |
+      | AnnaWaiting           | anna_waiting_for_info@nosnarkybarky.se |       |
+      | LarsRejected          | lars_rejected@snarkybark.se            |       |
+      | NilsAccepted          | nils_member@bowwowwow.se               |       |
+      | LarsWaitingForPayment | lars_waiting_for_payment@happymutts.se |       |
+      | Applicant1            | applicant_1@random.com                 |       |
+      | Applicant2            | applicant_2@random.com                 |       |
+      | admin                 | admin@shf.se                           | true  |
 
     Given the following business categories exist
       | name         | description                     |
@@ -29,13 +29,13 @@ Feature: As an Admin
 
 
     And the following applications exist:
-      | first_name            | user_email                             | company_number | categories   | state                 |
-      | EmmaUnderReview       | emma_under_review@happymutts.se        | 5562252998     | rehab        | under_review          |
-      | HansUnderReview       | hans_under_review@happymutts.se        | 5562252998     | dog grooming | under_review          |
-      | AnnaWaiting           | anna_waiting_for_info@nosnarkybarky.se | 5560360793     | rehab        | waiting_for_applicant |
-      | LarsRejected          | lars_rejected@snarkybark.se            | 0000000000     | rehab        | rejected              |
-      | NilsAccepted          | nils_member@bowwowwow.se               | 0000000000     | dog crooning | accepted              |
-      | LarsWaitingForPayment | lars_waiting_for_payment@happymutts.se | 0000000000     | dog crooning | waiting_for_payment   |
+      | user_email                             | company_number | categories   | state                 |
+      | emma_under_review@happymutts.se        | 5562252998     | rehab        | under_review          |
+      | hans_under_review@happymutts.se        | 5562252998     | dog grooming | under_review          |
+      | anna_waiting_for_info@nosnarkybarky.se | 5560360793     | rehab        | waiting_for_applicant |
+      | lars_rejected@snarkybark.se            | 0000000000     | rehab        | rejected              |
+      | nils_member@bowwowwow.se               | 0000000000     | dog crooning | accepted              |
+      | lars_waiting_for_payment@happymutts.se | 0000000000     | dog crooning | waiting_for_payment   |
 
     And I am logged in as "admin@shf.se"
     And time is frozen at 2016-12-16

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -5,15 +5,15 @@ Feature: As an applicant
 
   Background:
     Given the following users exists
-      | email                  | admin |
-      | applicant_1@random.com |       |
-      | applicant_2@random.com |       |
-      | admin@shf.com          | true  |
+      | first_name | email                  | admin |
+      | Emma       | applicant_1@random.com |       |
+      | Applicant2 | applicant_2@random.com |       |
+      | admin      | admin@shf.com          | true  |
 
 
     And the following applications exist:
-      | first_name | user_email             | company_number | state                 |
-      | Emma       | applicant_1@random.com | 5562252998     | waiting_for_applicant |
+      | user_email             | company_number | state                 |
+      | applicant_1@random.com | 5562252998     | waiting_for_applicant |
 
 
   Scenario: Upload a file during a new application

--- a/features/user_profile/admin-resets-users-password.feature
+++ b/features/user_profile/admin-resets-users-password.feature
@@ -6,19 +6,18 @@ Feature: As an admin
   Background:
 
     Given the following users exists
-      | email               | admin |
-      | emma@happymutts.com |       |
-      | bob@snarkybarky.se  |       |
-      | admin@shf.se        | true  |
+      | first_name | email               | admin |
+      | Emma       | emma@happymutts.com |       |
+      | Bob        | bob@snarkybarky.se  |       |
+      | admin      | admin@shf.se        | true  |
 
     And the following companies exist:
       | name        | company_number | email               |
       | Happy Mutts | 2120000142     | bowwow@bowsersy.com |
 
     And the following applications exist:
-      | first_name | user_email          | company_number | state    |
-      | Emma       | emma@happymutts.com | 2120000142     | accepted |
-
+      | user_email          | company_number | state    |
+      | emma@happymutts.com | 2120000142     | accepted |
 
     And I am logged in as "admin@shf.se"
 

--- a/features/view_hidden_pages.feature
+++ b/features/view_hidden_pages.feature
@@ -3,18 +3,18 @@ Feature: Only members and admins can see members only (hidden) pages
   Background:
 
     Given the following users exists
-      | email                    | admin | is_member |
-      | not_a_member@bowsers.com |       | false     |
-      | emma@happymutts.com      |       | true      |
-      | admin@shf.se             | true  | true      |
+      | first_name | email                    | admin | is_member |
+      | Emma       | emma@happymutts.com      |       | true      |
+      | NoMember   | not_a_member@bowsers.com |       | false     |
+      | admin      | admin@shf.se             | true  | true      |
 
     And the following business categories exist
       | name  |
       | Rehab |
 
     And the following applications exist:
-      | first_name | user_email          | company_number | categories | state    |
-      | Emma       | emma@happymutts.com | 5562252998     | Rehab      | accepted |
+      | user_email          | company_number | categories | state    |
+      | emma@happymutts.com | 5562252998     | Rehab      | accepted |
 
 
   Scenario: Visitor cannot see members only pages

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe AdminController, type: :controller do
                                    state:         app_state.name,
                                    user:          u
 
-            member1_info = "#{m.contact_email},#{m.first_name},#{m.last_name},#{m.membership_number},"+ I18n.t("membership_applications.state.#{app_state.name}")
+            member1_info = "#{m.contact_email},#{u.first_name},#{u.last_name},#{m.membership_number},"+ I18n.t("membership_applications.state.#{app_state.name}")
 
             result_str << member1_info + ','
             result_str << '"",'  # no business categories
@@ -136,7 +136,7 @@ RSpec.describe AdminController, type: :controller do
 
           result_str = csv_header
 
-          member1_info = "#{member1.contact_email},#{member1.first_name},#{member1.last_name},#{member1.membership_number},"+ I18n.t("membership_applications.state.#{member1.state}")
+          member1_info = "#{member1.contact_email},#{u1.first_name},#{u1.last_name},#{member1.membership_number},"+ I18n.t("membership_applications.state.#{member1.state}")
 
           result_str << member1_info + ','
           result_str << '"",'  # no business categories
@@ -174,7 +174,7 @@ RSpec.describe AdminController, type: :controller do
                              response.body
                            }
 
-        let(:member1_info) {  "#{member1.contact_email},#{member1.first_name},#{member1.last_name},#{member1.membership_number},"+ I18n.t("membership_applications.state.#{member1.state}") }
+        let(:member1_info) {  "#{member1.contact_email},#{u1.first_name},#{u1.last_name},#{member1.membership_number},"+ I18n.t("membership_applications.state.#{member1.state}") }
 
 
         it 'zero/nil business categories' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -41,7 +41,6 @@ FactoryGirl.define do
 
       after(:create) do |user, evaluator|
         create_list(:membership_application, 1, :accepted, user: user,
-                    first_name: evaluator.email,
                     contact_email: evaluator.email,
                     company_number:  evaluator.company_number)
       end

--- a/spec/helpers/membership_applications_helper_spec.rb
+++ b/spec/helpers/membership_applications_helper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MembershipApplicationsHelper, type: :helper do
 
   describe '#member_full_name' do
     it 'appends first and last with a space inbetween' do
-      assign(:membership_application, create(:membership_application, first_name: 'Kitty', last_name: 'Kat', user: create(:user)))
+      assign(:membership_application, create(:membership_application, user: create(:user, first_name: 'Kitty', last_name: 'Kat')))
       expect(helper.member_full_name).to eq('Kitty Kat')
     end
 

--- a/spec/models/membership_application_spec.rb
+++ b/spec/models/membership_application_spec.rb
@@ -107,14 +107,14 @@ RSpec.describe MembershipApplication, type: :model do
 
     it 'validates the presence of first_name' do
       expect {
-        member_app.first_name = ''
+        user.first_name = ''
         member_app.save!
       }.to raise_exception(/#{I18n.t('activerecord.attributes.membership_application.first_name')} #{I18n.t('errors.messages.blank')}/)
     end
 
     it 'validates the presence of last_name' do
       expect {
-        member_app.last_name = ''
+        user.last_name = ''
         member_app.save!
       }.to raise_exception(/#{I18n.t('activerecord.attributes.membership_application.last_name')} #{I18n.t('errors.messages.blank')}/)
     end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/148546123

**Changes proposed in this pull request:**

1) Rewrite Rspec and Cucumber tests to use the `first_name` and `last_name` attributes from the User model instead of from the MembershipApplication model.

2) Remove the `first_name` and `last_name` delegates from the MembershipApplication model

Ready for review:
@patmbolger @weedySeaDragon