### PR TITLE
Errors not shown when editing membership application.

### DIFF
--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -257,7 +257,7 @@ class MembershipApplicationsController < ApplicationController
       render json: @membership_application.errors.full_messages, status: :unprocessable_entity if request.xhr?
     else
       helpers.flash_message(:alert, error_message)
-      redirect_to edit_membership_application_path(@membership_application)
+      render :edit
     end
 
   end

--- a/features/edit_membership_application.feature
+++ b/features/edit_membership_application.feature
@@ -38,9 +38,11 @@ Feature: As an applicant
     And I click on t("menus.nav.users.my_application")
     Then I should be on "Edit My Application" page
     And I fill in t("membership_applications.show.contact_email") with "sussimmi.nu"
+    And I fill in t("membership_applications.show.company_number") with ""
     And I click on t("membership_applications.edit.submit_button_label")
     Then I should see t("membership_applications.update.error")
-    And I should be on "Edit My Application" page
+    And I should see translated error membership_applications.show.company_number errors.messages.blank
+    And I should see button t("membership_applications.edit.submit_button_label")
 
   Scenario: Applicant can not edit applications not created by him
     Given I am logged in as "emma@random.com"


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/148990401

**Changes proposed in this pull request:**

1. Change the redirect in `update_error` to a simple render 
2. Add checking for individual errors to the relevant feature test


Ready for review:
@patmbolger @weedySeaDragon