### PR TITLE
Use model errors helper in devise views

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -144,7 +144,7 @@ module ApplicationHelper
       end
     end
 
-    html.empty? ? nil : html
+    html.empty? ? nil : html + tag(:br)
   end
 
 end

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -6,17 +6,15 @@
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
 
     != model_errors_helper(resource)
+    %br/
 
     = f.hidden_field :reset_password_token
     .field
       = f.label :password, "#{t('.new_password')}", class: 'required'
-      %br/
       = render 'devise/shared/min_password_length_info'
-      %br/
       = f.password_field :password, autofocus: true, autocomplete: 'off', class: 'wpcf7-form-control'
     .field
       = f.label :password_confirmation, "#{t('.confirm_password')}", class: 'required'
-      %br/
       = f.password_field :password_confirmation, autocomplete: 'off', class: 'wpcf7-form-control'
     .actions
       = f.submit "#{t('.submit_button_label')}"

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -4,10 +4,9 @@
   %span
 .entry-content.wpcf7
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-    - if resource.errors.any?
-      .wpcf7-response-output
-        - resource.errors.full_messages.each do |msg|
-          = msg
+
+    != model_errors_helper(resource)
+
     = f.hidden_field :reset_password_token
     .field
       = f.label :password, "#{t('.new_password')}", class: 'required'

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -6,7 +6,6 @@
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
 
     != model_errors_helper(resource)
-    %br/
 
     = f.hidden_field :reset_password_token
     .field

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -6,7 +6,6 @@
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
 
     != model_errors_helper(resource)
-    %br/
 
     .field
       = f.label :email, class: 'required'

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -6,10 +6,10 @@
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
 
     != model_errors_helper(resource)
+    %br/
 
     .field
       = f.label :email, class: 'required'
-      %br/
       = f.email_field :email, autofocus: true, class: 'wpcf7-form-control'
     .actions
       = f.submit "#{t('.submit_button_label')}"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -4,10 +4,9 @@
   %span
 .entry-content.wpcf7
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-    - if resource.errors.any?
-      .wpcf7-response-output
-        - resource.errors.full_messages.each do |msg|
-          = msg
+
+    != model_errors_helper(resource)
+
     .field
       = f.label :email, class: 'required'
       %br/

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -4,12 +4,9 @@
   %span
 .entry-content.wpcf7
   = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-    - if resource.errors.any?
-      .wpcf7-response-output
-        - resource.errors.full_messages.each do |msg|
-          = msg
-          %br/
-      %br/
+
+    != model_errors_helper(resource)
+
     .field
       = f.label :first_name
       %br/

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -6,18 +6,16 @@
   = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
 
     != model_errors_helper(resource)
+    %br/
 
     .field
       = f.label :first_name
-      %br/
       = f.text_field :first_name, autofocus: true, class: 'wpcf7-form-control'
     .field
       = f.label :last_name
-      %br/
       = f.text_field :last_name, class: 'wpcf7-form-control'
     .field
       = f.label :email
-      %br/
       = f.email_field :email, class: 'wpcf7-form-control'
     - if devise_mapping.confirmable? && resource.pending_reconfirmation?
       %div
@@ -25,17 +23,14 @@
     .field
       = f.label :password
       %i= t('.leave_blank_if_no_change')
-      %br/
       = f.password_field :password, autocomplete: 'off', class: 'wpcf7-form-control'
       = render 'devise/shared/min_password_length_info'
     .field
       = f.label :password_confirmation, "#{t('.confirm_password')}"
-      %br/
       = f.password_field :password_confirmation, autocomplete: 'off', class: 'wpcf7-form-control'
     .field
       = f.label :current_password, "#{t('.current_password')}", class: 'required'
       %i= t('.required_to_save_changes')
-      %br/
       = f.password_field :current_password, autocomplete: 'off', class: 'wpcf7-form-control'
     .actions
       = f.submit "#{t('.submit_button_label')}"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -6,7 +6,6 @@
   = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
 
     != model_errors_helper(resource)
-    %br/
 
     .field
       = f.label :first_name

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -6,27 +6,23 @@
   = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
 
     != model_errors_helper(resource)
+    %br/
 
     .field
       = f.label :first_name, class: 'required'
-      %br/
       = f.text_field :first_name, autofocus: true, class: 'wpcf7-form-control'
     .field
       = f.label :last_name, class: 'required'
-      %br/
       = f.text_field :last_name, class: 'wpcf7-form-control'
     .field
       = f.label :email, class: 'required'
-      %br/
       = f.email_field :email, class: 'wpcf7-form-control'
     .field
       = f.label :password, class: 'required'
       = render 'devise/shared/min_password_length_info'
-      %br/
       = f.password_field :password, autocomplete: 'off', class: 'wpcf7-form-control'
     .field
       = f.label :password_confirmation, "#{t('.confirm_password')}", class: 'required'
-      %br/
       = f.password_field :password_confirmation, autocomplete: 'off', class: 'wpcf7-form-control'
     .actions
       = f.submit "#{t('.submit_button_label')}"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -6,7 +6,6 @@
   = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
 
     != model_errors_helper(resource)
-    %br/
 
     .field
       = f.label :first_name, class: 'required'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -4,12 +4,9 @@
   %span
 .entry-content.wpcf7
   = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-    - if resource.errors.any?
-      .wpcf7-response-output
-        - resource.errors.full_messages.each do |msg|
-          = msg
-          %br/
-      %br/
+
+    != model_errors_helper(resource)
+
     .field
       = f.label :first_name, class: 'required'
       %br/

--- a/app/views/membership_applications/new.html.haml
+++ b/app/views/membership_applications/new.html.haml
@@ -8,7 +8,9 @@
 
   .entry-content.wpcf7
     = form_for @membership_application, html: {multipart: true}, url: membership_applications_path do |f|
+
       != model_errors_helper(@membership_application)
+
       = render partial: 'membership_application_fields', locals: {f: f}
       = render 'application/required_fields'
 

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -55,6 +55,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
   Scenario: Admin selects 'waiting for payment' as the reason SHF is waiting_for_applicant
     Given I am on "AnnaWaiting" application page
     When I set "member_app_waiting_reasons" to "waiting for payment"
+    And I wait for all ajax requests to complete
     And I am on the list applications page
     And I am on "AnnaWaiting" application page
     And "member_app_waiting_reasons" should have "waiting for payment" selected


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/149263775

**Changes proposed in this pull request:**

Use the model_errors_helper in the devise password and registration views and bring view layouts in line with other views.

<img width="1094" alt="password" src="https://user-images.githubusercontent.com/19589814/28473803-6da284d2-6e46-11e7-9420-8124a8d94aeb.png">

Ready for review:
@patmbolger @weedySeaDragon 