### PR TITLE
[WIP] Cannot change language after errors No code changes - meant for discussion.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,6 +41,7 @@ class ApplicationController < ActionController::Base
   end
 
   def user_not_authorized
+    #TODO prevent infinite loop when user tries to translate a create membership application page with errors
     flash[:alert] = t('errors.not_permitted')
     redirect_back(fallback_location: root_path)
   end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/149028973


**PROBLEM DESCRIPTION**

Under certain conditions pressing the translate button will lead to a "too many redirects" browser error. The easiest way to understand why this error occurs is to look at the rails urls when updating a membership application.

1. Log in as administrator
2. Goto http://localhost:3000/en/ansokan/1/redigera
3. Delete the company number, and press save
4. Note that the url has changed to http://localhost:3000/en/ansokan/1. The changed url (with a :post http verb) is the correct route for #update. However, when we press the translate button we do a :get on that url which is the route for #show. 
5. Press the translate button and note that the translated page is now a show instead of an edit.


Wen creating a new membership application, a similar mechanism happens, but it now leads to an error. 

1. Log in as a user (without membership application)
2. Goto http://localhost:3000/en/ansokan/ny
3. Press submit
4. Note that the url has changed to http://localhost:3000/en/ansokan. The changed url (with a :post http verb) is the correct route for #create. However, when we press the translate button we do a :get on that url, which is the route for #index
5. Press the translate button and note the "too many redirects" error in your browser. This happens because, through ApplicationPolicy, the #index route is only permitted for admins. The not permitted error is handled by redirecting back to the referrer page, but in this case that's also the #index route (only in another locale) and still not permitted, giving rise to an infinite number of redirections.

As discussed during the team meeting, this is a relative corner case, and (at the moment) only a problem for developers. It would be nice if we can find an easy and elegant solution. But everything I can think of feels either to big of a change for such a corner case, or just too clumsy.


**SOME SOLUTION DIRECTIONS**

1. Use Redirect instead of a simple render. This means having to find a way to make model and errors survive that redirect
2. Change Rails' default routes for create and update (https://hibbard.eu/custom-routes-with-resources-in-rails-3/)
3. Don't redirect back when request url and referrer are the same. (but where should we go then?)
4. Make the translate button issue an error when trying to translate a create or update page with errors. 


Ready for review:
@patmbolger @weedySeaDragon @lollypop27 @thesuss @Zsuark