### PR TITLE
Sprint 20 - pwd reset link bug#149435419

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -3,7 +3,7 @@
 %p= t('devise.mailer.reset_password_instructions.reset_requested')
 
 %p= link_to t('devise.mailer.reset_password_instructions.change_password'),
-            edit_password_url(@resource, reset_password_token: @token)
+            edit_user_password_url(@resource, reset_password_token: @token)
 
 %p= t('devise.mailer.reset_password_instructions.ignore')
 

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -3,9 +3,7 @@
 %p= t('devise.mailer.reset_password_instructions.reset_requested')
 
 %p= link_to t('devise.mailer.reset_password_instructions.change_password'),
-            edit_user_password_url(@resource, reset_password_token: @token)
-
-- puts "URL = #{edit_password_url(@resource, reset_password_token: @token)}"
+            edit_password_url(@resource, reset_password_token: @token)
 
 %p= t('devise.mailer.reset_password_instructions.ignore')
 

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -5,6 +5,8 @@
 %p= link_to t('devise.mailer.reset_password_instructions.change_password'),
             edit_user_password_url(@resource, reset_password_token: @token)
 
+- puts "URL = #{edit_password_url(@resource, reset_password_token: @token)}"
+
 %p= t('devise.mailer.reset_password_instructions.ignore')
 
 %p= t('devise.mailer.reset_password_instructions.follow_link')

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,10 +66,10 @@ Rails.application.configure do
   # (as a controller does) and thus the full URL will be required to create
   # links in the email.  This setting defines the host (domain) for the URL.
   config.action_mailer.default_url_options = { :host => ENV['DEFAULT_HOST'] ||
-                                                        'sverigeshundforetagare.se'}
+                                                        'hitta.sverigeshundforetagare.se'}
 
   config.action_mailer.delivery_method = :mailgun
-  
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/149435419


Changes proposed in this pull request:
1.  Correct config setting for `config.action_mailer.default_url_options` in `production.rb` to have the correct default host for production ("hitta.sverigeshundforetagare.se")
2. Added config var to shf-project on Heroku (DEFAULT_HOST == shf-project.herokuapp.com) 
3. Added a wiki page describing how to manage this setting in Heroku (https://github.com/AgileVentures/shf-project/wiki/Configure-email-(default-url-host)-on-Heroku) (linked from home page)

**NOTE**: We do _not_ need to set this var (DEFAULT_HOST) in Digital Ocean (the "real" production env) as the host will default to the correct value - see wiki page).


Ready for review:
@weedySeaDragon @RobertCram