### PR TITLE
Remove unnecessary datafields from features

### DIFF
--- a/features/admin_creates_company.feature
+++ b/features/admin_creates_company.feature
@@ -13,10 +13,10 @@ Feature: As an admin
 
   Background:
     Given the following users exists
-      | first_name | email                      | admin |
-      | Emma       | applicant_1@happymutts.com |       |
-      | Anna       | applicant_3@happymutts.com |       |
-      | admin      | admin@shf.se               | true  |
+      | email                      | admin |
+      | applicant_1@happymutts.com |       |
+      | applicant_3@happymutts.com |       |
+      | admin@shf.se               | true  |
 
     Given the following regions exist:
       | name         |

--- a/features/approve-member.feature
+++ b/features/approve-member.feature
@@ -38,9 +38,9 @@ Feature: As an admin
     And I am logged in as "admin@shf.com"
 
   Scenario: Admin approves, no company exists so one is created
-    Given I am on "Emma" application page
+    Given I am on "emma@happymutts.se" application page
     When I click on t("membership_applications.accept_btn")
-    And I should be on the edit application page for "Emma"
+    And I should be on the edit application page for "emma@happymutts.se"
     And I should see t("membership_applications.accept.success")
     And I should see t("membership_applications.update.enter_member_number")
     And I fill in t("membership_applications.show.membership_number") with "901"
@@ -52,9 +52,9 @@ Feature: As an admin
 
 
   Scenario: Admin approves, member is added to existing company
-    Given I am on "Anna" application page
+    Given I am on "anna@nosnarkybarky.se" application page
     When I click on t("membership_applications.accept_btn")
-    And I should be on the edit application page for "Anna"
+    And I should be on the edit application page for "anna@nosnarkybarky.se"
     And I should see t("membership_applications.update.enter_member_number")
     And I fill in t("membership_applications.show.membership_number") with "902"
     And I click on t("membership_applications.edit.submit_button_label")
@@ -77,29 +77,29 @@ Feature: As an admin
     Then I should see "No More Snarky Barky"
 
   Scenario: Admin approves, but then rejects it
-    Given I am on "Emma" application page
+    Given I am on "emma@happymutts.se" application page
     When I click on t("membership_applications.accept_btn")
-    And I should be on the edit application page for "Emma"
+    And I should be on the edit application page for "emma@happymutts.se"
     And I should see t("membership_applications.update.enter_member_number")
     And I fill in t("membership_applications.show.membership_number") with "901"
     And I click on t("membership_applications.edit.submit_button_label")
     Then I should see t("membership_applications.update.success")
     And I should see t("membership_applications.accepted")
     And I should see "901"
-    When I am on "Emma" application page
+    When I am on "emma@happymutts.se" application page
     And I click on t("membership_applications.reject_btn")
     Then I should see status line with status t("membership_applications.rejected")
     And I am Logged out
     And I am on the "landing" page
     Then I should not see "5562252998"
     And I am logged in as "emma@happymutts.se"
-    And I navigate to the edit page for "Emma"
+    And I navigate to the edit page for "emma@happymutts.se"
     Then I should be on "Edit My Application" page
     And I should not see t("membership_applications.show.membership_number")
 
 
   Scenario: Member owes money so Admin cannot approve
-    Given I am on "Emma" application page
+    Given I am on "emma@happymutts.se" application page
 
 
   Scenario: things go wrong

--- a/features/approve-member.feature
+++ b/features/approve-member.feature
@@ -9,11 +9,11 @@ Feature: As an admin
 
   Background:
     Given the following users exists
-      | first_name | email                 | admin |
-      | Emma       | emma@happymutts.se    |       |
-      | Hans       | hans@happymutts.se    |       |
-      | Anna       | anna@nosnarkybarky.se |       |
-      | admin      | admin@shf.com         | true  |
+      | email                 | admin |
+      | emma@happymutts.se    |       |
+      | hans@happymutts.se    |       |
+      | anna@nosnarkybarky.se |       |
+      | admin@shf.com         | true  |
 
     Given the following business categories exist
       | name         | description                     |

--- a/features/company_shows_all_employee_categories.feature
+++ b/features/company_shows_all_employee_categories.feature
@@ -15,12 +15,12 @@ Feature: As a visitor
   Background:
 
     Given the following users exists
-      | first_name | email                 | admin |
-      | Emma       | emma@happymutts.com   |       |
-      | Lars       | lars@happymutts.com   |       |
-      | Anna       | anna@happymutts.com   |       |
-      | Bowser     | bowser@snarkybarky.se |       |
-      | admin      | admin@shf.se          | true  |
+      | email                 | admin |
+      | emma@happymutts.com   |       |
+      | lars@happymutts.com   |       |
+      | anna@happymutts.com   |       |
+      | bowser@snarkybarky.se |       |
+      | admin@shf.se          | true  |
 
     And the following companies exist:
       | name                 | company_number | email                  |

--- a/features/delete-company.feature
+++ b/features/delete-company.feature
@@ -14,21 +14,21 @@ Feature: As an admin
 
   Background:
     Given the following users exists
-      | first_name       | email                          | admin |
-      | Emma             | emma@happymutts.com            |       |
-      | Hans             | hans@happymutts.com            |       |
-      | Wils             | wils@woof.com                  |       |
-      | Sam              | sam@snarkybarky.com            |       |
-      | Lars             | lars@snarkybarky.com           |       |
-      | Kitty            | kitty@kitties.com              |       |
-      | Meow             | meow@kitties.com               |       |
-      | Under_Review     | under_review@kats.com          |       |
-      | Ready for Review | ready_for_review@kats.com      |       |
-      | Waiting for A    | waiting_for_applicant@kats.com |       |
-      | New              | new@kats.com                   |       |
-      | Waiting for R    | waiting_for_review@kats.com    |       |
-      | Bob              | bob@bowsers.com                |       |
-      | admin            | admin@shf.se                   | true  |
+      | email                          | admin |
+      | emma@happymutts.com            |       |
+      | hans@happymutts.com            |       |
+      | wils@woof.com                  |       |
+      | sam@snarkybarky.com            |       |
+      | lars@snarkybarky.com           |       |
+      | kitty@kitties.com              |       |
+      | meow@kitties.com               |       |
+      | under_review@kats.com          |       |
+      | ready_for_review@kats.com      |       |
+      | waiting_for_applicant@kats.com |       |
+      | new@kats.com                   |       |
+      | waiting_for_review@kats.com    |       |
+      | bob@bowsers.com                |       |
+      | admin@shf.se                   | true  |
 
     And the following business categories exist
       | name        | description                     |

--- a/features/delete_membership_application.feature
+++ b/features/delete_membership_application.feature
@@ -9,13 +9,13 @@ Feature: As an admin
 
   Background:
     Given the following users exists
-      | first_name | email            | admin |
-      | Emma       | emma@random.com  |       |
-      | Hans       | hans@bowsers.com |       |
-      | Nils       | nils@bowsers.com |       |
-      | Wils       | wils@woof.com    |       |
-      | Bob        | bob@bowsers.com  |       |
-      | admin      | admin@shf.se     | true  |
+      | email            | admin |
+      | emma@random.com  |       |
+      | hans@bowsers.com |       |
+      | nils@bowsers.com |       |
+      | wils@woof.com    |       |
+      | bob@bowsers.com  |       |
+      | admin@shf.se     | true  |
 
     And the following regions exist:
       | name         |

--- a/features/delete_membership_application.feature
+++ b/features/delete_membership_application.feature
@@ -46,27 +46,27 @@ Feature: As an admin
 
   Scenario: Admin should see the 'delete' button
     Given I am logged in as "admin@shf.se"
-    And I am on the application page for "Emma"
+    And I am on the application page for "emma@random.com"
     Then I should not see t("errors.not_permitted")
     And I should see t("membership_applications.show.delete")
 
 
   Scenario: Member should not see the 'delete' button on their own application
     Given I am logged in as "emma@random.com"
-    And I am on the application page for "Emma"
+    And I am on the application page for "emma@random.com"
     Then I should not see t("errors.not_permitted")
     And I should not see t("membership_applications.show.delete")
 
   Scenario: Visitor should not see the 'delete' button
     Given I am Logged out
-    And I am on the application page for "Emma"
+    And I am on the application page for "emma@random.com"
     Then I should see t("errors.not_permitted")
     And I should not see t("membership_applications.show.delete")
 
 
   Scenario: Admin wants to delete a membership application
     Given I am logged in as "admin@shf.se"
-    And I am on the application page for "Emma"
+    And I am on the application page for "emma@random.com"
     And I click on t("membership_applications.show.delete")
     Then I should see t("membership_applications.application_deleted")
     And I should not see "Emma"
@@ -74,7 +74,7 @@ Feature: As an admin
 
   Scenario: Admin deletes a membership application; company should still exist (has another application assoc.)
     Given I am logged in as "admin@shf.se"
-    And I am on the application page for "Hans"
+    And I am on the application page for "hans@bowsers.com"
     And I click on t("membership_applications.show.delete")
     Then I should see t("membership_applications.application_deleted")
     And I should not see "Hans"
@@ -87,7 +87,7 @@ Feature: As an admin
     And I am on the "all companies" page
     Then I should see "3" companies
     And I should see "WOOF"
-    And I am on the application page for "Wils"
+    And I am on the application page for "wils@woof.com"
     And I click on t("membership_applications.show.delete")
     Then I should see t("membership_applications.application_deleted")
     And I should not see "Wils"

--- a/features/disallow-company-malicious-website.feature
+++ b/features/disallow-company-malicious-website.feature
@@ -7,9 +7,9 @@ Feature: Don't allow malicious code in Company website value
 
   Background:
     Given the following users exists
-      | first_name | email               | admin |
-      | Emma       | emma@happymutts.com |       |
-      | admin      | admin@shf.se        | true  |
+      | email               | admin |
+      | emma@happymutts.com |       |
+      | admin@shf.se        | true  |
 
     And the following regions exist:
       | name         |

--- a/features/edit_account.feature
+++ b/features/edit_account.feature
@@ -4,7 +4,6 @@ Feature: As a registered user
 
   Background:
     Given the following users exists
-      #TODO-Robert keep names!
       | first_name | last_name | email              | password | admin |
       | emma       | andersson | emma@andersson.com | password | false |
 

--- a/features/edit_account.feature
+++ b/features/edit_account.feature
@@ -4,6 +4,7 @@ Feature: As a registered user
 
   Background:
     Given the following users exists
+      #TODO-Robert keep names!
       | first_name | last_name | email              | password | admin |
       | emma       | andersson | emma@andersson.com | password | false |
 

--- a/features/edit_company.feature
+++ b/features/edit_company.feature
@@ -4,10 +4,10 @@ Feature: As a member
 
   Background:
     Given the following users exists
-      | first_name | email                      | admin | is_member |
-      | Emma       | applicant_1@happymutts.com |       | true      |
-      | Anna       | applicant_3@happymutts.com |       | false     |
-      | admin      | admin@shf.se               | true  | true      |
+      | email                      | admin | is_member |
+      | applicant_1@happymutts.com |       | true      |
+      | applicant_3@happymutts.com |       | false     |
+      | admin@shf.se               | true  | true      |
 
     And the following companies exist:
       | name                 | company_number | email                  |

--- a/features/edit_membership_application.feature
+++ b/features/edit_membership_application.feature
@@ -7,12 +7,12 @@ Feature: As an applicant
 
   Background:
     Given the following users exists
-      | first_name | email             | is_member | admin |
-      | Emma       | emma@random.com   | false     |       |
-      | Hans       | hans@random.com   | false     |       |
-      | Nils       | nils@random.com   | true      |       |
-      | Bob        | bob@barkybobs.com | true      |       |
-      | admin      | admin@shf.se      | true      | true  |
+      | email             | is_member | admin |
+      | emma@random.com   | false     |       |
+      | hans@random.com   | false     |       |
+      | nils@random.com   | true      |       |
+      | bob@barkybobs.com | true      |       |
+      | admin@shf.se      | true      | true  |
 
     And the following applications exist:
       | user_email        | company_number | state                 |

--- a/features/edit_membership_application.feature
+++ b/features/edit_membership_application.feature
@@ -29,7 +29,7 @@ Feature: As an applicant
     And I fill in t("membership_applications.show.first_name") with "Anna"
     And I click on t("membership_applications.edit.submit_button_label")
     Then I should see t("membership_applications.update.success")
-    And I should be on the application page for "Anna"
+    And I should be on the application page for "emma@random.com"
     And I should see "Anna Lastname"
 
   Scenario: Applicant makes mistake when editing his own application
@@ -46,7 +46,7 @@ Feature: As an applicant
 
   Scenario: Applicant can not edit applications not created by him
     Given I am logged in as "emma@random.com"
-    And I navigate to the edit page for "Hans"
+    And I navigate to the edit page for "hans@random.com"
     Then I should see t("errors.not_permitted")
 
   Scenario: Member wants to view their own application
@@ -57,11 +57,11 @@ Feature: As an applicant
 
   Scenario: Admin should be able to edit membership number
     Given I am logged in as "admin@shf.se"
-    And I navigate to the edit page for "Nils"
+    And I navigate to the edit page for "nils@random.com"
     Then I should see t("membership_applications.show.membership_number")
 
   Scenario: Admin can't edit membership number for a rejected application
     Given I am logged in as "admin@shf.se"
-    And I navigate to the edit page for "Bob"
+    And I navigate to the edit page for "bob@barkybobs.com"
     Then I should not see t("membership_applications.show.membership_number")
 

--- a/features/export-member-email-info.feature
+++ b/features/export-member-email-info.feature
@@ -6,10 +6,10 @@ Feature: export member information to a CSV file so I can use it in other system
 
   Background:
     Given the following users exists
-      | first_name | last_name   | email                       | admin |
-      | Emma       | Emmasdottir | emma@happymutts.com         |       |
-      | Wils       | Wilson      | wils@woof.com               |       |
-      | admin      | admin       | admin@shf.se                | true  |
+      | last_name   | email                       | admin |
+      | Emmasdottir | emma@happymutts.com         |       |
+      | Wilson      | wils@woof.com               |       |
+      | admin       | admin@shf.se                | true  |
 
 
     And the following regions exist:

--- a/features/list_companies_of_category.feature
+++ b/features/list_companies_of_category.feature
@@ -5,11 +5,11 @@ Feature: As any type of visitor
 
   Background:
     Given the following users exists
-      | first_name | email               | admin | is_member |
-      | Emma       | emma@happymutts.com |       | true      |
-      | Ernt       | ernt@mutts.com      |       | true      |
-      | Anna       | anna@sadmutts.com   |       | true      |
-      | admin      | admin@shf.se        | true  | true      |
+      | email               | admin | is_member |
+      | emma@happymutts.com |       | true      |
+      | ernt@mutts.com      |       | true      |
+      | anna@sadmutts.com   |       | true      |
+      | admin@shf.se        | true  | true      |
 
     Given the following regions exist:
       | name         |

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -4,11 +4,11 @@ Feature: As a registered user
 
   Background:
     Given the following users exists
-      | first_name | email                | password | admin | is_member |
-      | Emma       | emma@random.com      | password | false | true      |
-      | Lars       | lars-user@random.com | password | false | false     |
-      | Anne       | anne@random.com      | password | false | false     |
-      | Arne       | arne@random.com      | password | true  | true      |
+      | email                | password | admin | is_member |
+      | emma@random.com      | password | false | true      |
+      | lars-user@random.com | password | false | false     |
+      | anne@random.com      | password | false | false     |
+      | arne@random.com      | password | true  | true      |
 
     And the following applications exist:
       | user_email           | company_number | state    |

--- a/features/manage_users.feature
+++ b/features/manage_users.feature
@@ -4,11 +4,11 @@ Feature: As an admin
 
   Background:
     Given the following users exist
-      | first_name | email               | admin |
-      | Emma       | emma@happymutts.com |       |
-      | Anna       | anna@sadmutts.com   |       |
-      | Ernt       | ernt@mutts.com      |       |
-      | admin      | admin@shf.se        | true  |
+      | email               | admin |
+      | emma@happymutts.com |       |
+      | anna@sadmutts.com   |       |
+      | ernt@mutts.com      |       |
+      | admin@shf.se        | true  |
 
     And the following business categories exist
       | name         |

--- a/features/mapping_and_geocoding/companies_are_geocoded_when_viewing_all.feature
+++ b/features/mapping_and_geocoding/companies_are_geocoded_when_viewing_all.feature
@@ -23,10 +23,10 @@ Feature: All companies are geocoded before being shown on the view all companies
 
 
     And the following users exists
-      | first_name | email               | admin |
-      | Emma       | emma@happymutts.com |       |
-      | Anna       | a@happymutts.com    |       |
-      | admin      | admin@shf.se        | true  |
+      | email               | admin |
+      | emma@happymutts.com |       |
+      | a@happymutts.com    |       |
+      | admin@shf.se        | true  |
 
     And the following business categories exist
       | name         |

--- a/features/member_edits_company_page.feature
+++ b/features/member_edits_company_page.feature
@@ -6,9 +6,9 @@ Feature: As a member
 
   Background:
     Given the following users exists
-      | first_name | email               | admin | is_member |
-      | Emma       | emma@happymutts.com |       | true      |
-      | admin      | admin@shf.se        | true  | true      |
+      | email               | admin | is_member |
+      | emma@happymutts.com |       | true      |
+      | admin@shf.se        | true  | true      |
 
     Given the following regions exist:
       | name         |

--- a/features/membership-application-status/admin-custom-reason-waiting.feature
+++ b/features/membership-application-status/admin-custom-reason-waiting.feature
@@ -20,11 +20,11 @@ Feature: "Other/Custom" waiting reason comes from locale file and Admin cannot e
 
 
     Given the following users exists
-      | first_name      | email                                  | admin |
-      | AnnaWaiting     | anna_waiting_for_info@nosnarkybarky.se |       |
-      | AnnaUnderReview | anna_under_review@nosnarkybarky.se     |       |
-      | EmmaAccepted    | emma@happymutts.se                     |       |
-      | admin           | admin@shf.se                           | true  |
+      | email                                  | admin |
+      | anna_waiting_for_info@nosnarkybarky.se |       |
+      | anna_under_review@nosnarkybarky.se     |       |
+      | emma@happymutts.se                     |       |
+      | admin@shf.se                           | true  |
 
     Given the following business categories exist
       | name  | description           |

--- a/features/membership-application-status/admin-custom-reason-waiting.feature
+++ b/features/membership-application-status/admin-custom-reason-waiting.feature
@@ -58,18 +58,18 @@ Feature: "Other/Custom" waiting reason comes from locale file and Admin cannot e
 
   @admin @javascript
   Scenario: The "other/custom" reason is listed as a reason for the 'waiting for...' status
-    Given I am on "AnnaWaiting" application page
+    Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     Then "member_app_waiting_reasons" should have t("admin_only.member_app_waiting_reasons.other_custom_reason") as an option
 
   @admin @javascript
   Scenario: "other/custom" reason is listed when the state is changed TO 'waiting for applicant'
-    Given I am on "AnnaUnderReview" application page
+    Given I am on "anna_under_review@nosnarkybarky.se" application page
     When I click on t("membership_applications.ask_applicant_for_info_btn")
     Then "member_app_waiting_reasons" should have t("admin_only.member_app_waiting_reasons.other_custom_reason") as an option
 
   @admin @javascript
   Scenario: "other/custom" reason is listed when the language is changed
-    Given I am on "AnnaWaiting" application page
+    Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     Then "member_app_waiting_reasons" should have t("admin_only.member_app_waiting_reasons.other_custom_reason") as an option
 
 

--- a/features/membership-application-status/admin-manage-reasons-waiting-for-info.feature
+++ b/features/membership-application-status/admin-manage-reasons-waiting-for-info.feature
@@ -12,10 +12,10 @@ Feature: Admin manages the list of reasons why SHF is waiting for info from an a
 
   Background:
     Given the following users exists
-      | first_name   | email                                  | admin |
-      | AnnaWaiting  | anna_waiting_for_info@nosnarkybarky.se |       |
-      | EmmaAccepted | emma@happymutts.se                     |       |
-      | admin        | admin@shf.se                           | true  |
+      | email                                  | admin |
+      | anna_waiting_for_info@nosnarkybarky.se |       |
+      | emma@happymutts.se                     |       |
+      | admin@shf.se                           | true  |
 
     Given the following business categories exist
       | name  | description           |

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -44,32 +44,32 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
 
   @javascript @admin
   Scenario: Admin selects 'need more documentation' as the reason SHF is waiting_for_applicant
-    Given I am on "AnnaWaiting" application page
+    Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     When I set "member_app_waiting_reasons" to "need doc"
     Then "member_app_waiting_reasons" should have "need doc" selected
     And I am on the list applications page
-    And I am on "AnnaWaiting" application page
+    And I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     Then "member_app_waiting_reasons" should have "need doc" selected
 
   @javascript @admin
   Scenario: Admin selects 'waiting for payment' as the reason SHF is waiting_for_applicant
-    Given I am on "AnnaWaiting" application page
+    Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     When I set "member_app_waiting_reasons" to "waiting for payment"
     And I wait for all ajax requests to complete
     And I am on the list applications page
-    And I am on "AnnaWaiting" application page
+    And I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     And "member_app_waiting_reasons" should have "waiting for payment" selected
 
 
   @javascript @admin
   Scenario: Admin selects 'other' and enters text as the reason SHF is waiting_for_applicant
-    Given I am on "AnnaWaiting" application page
+    Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     When I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
     And I wait for all ajax requests to complete
     When I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
     And I am on the list applications page
-    And I am on "AnnaWaiting" application page
+    And I am on "anna_waiting_for_info@nosnarkybarky.se" application page
 
     And I should see t("membership_applications.need_info.other_reason_label")
     And the t("membership_applications.need_info.other_reason_label") field should be set to "This is my reason"
@@ -78,7 +78,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
 
   @javascript @admin
   Scenario: Admin selects 'other' and fills in custom text but then changes reason to something else
-    Given I am on "AnnaWaiting" application page
+    Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     When I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
     And I wait for all ajax requests to complete
     And I fill in "custom_reason_text" with "This is my reason"
@@ -87,13 +87,13 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     And I set "member_app_waiting_reasons" to "waiting for payment"
     And I wait for all ajax requests to complete
     And I am on the list applications page
-    And I am on "AnnaWaiting" application page
+    And I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     And "member_app_waiting_reasons" should have "waiting for payment" selected
 
 
   @javascript @admin
   Scenario: When selected reason is not 'custom other,' the custom text is saved as blank (empty string)
-    Given I am on "AnnaWaiting" application page
+    Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     When I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
     And I wait for all ajax requests to complete
     And I fill in "custom_reason_text" with "This is my reason"
@@ -109,6 +109,6 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
   @javascript @member
   Scenario: owner cannot see the fields for changing the reason
     Given I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
-    And I am on the application page for "AnnaWaiting"
+    And I am on the application page for "anna_waiting_for_info@nosnarkybarky.se"
     Then I should not see t("membership_applications.need_info.reason_title")
 

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -9,9 +9,9 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
 
   Background:
     Given the following users exists
-      | first_name  | email                                  | admin |
-      | AnnaWaiting | anna_waiting_for_info@nosnarkybarky.se |       |
-      | admin       | admin@shf.com                          | true  |
+      | email                                  | admin |
+      | anna_waiting_for_info@nosnarkybarky.se |       |
+      | admin@shf.com                          | true  |
 
     Given the following business categories exist
       | name  | description           |

--- a/features/search_applications.feature
+++ b/features/search_applications.feature
@@ -6,7 +6,6 @@ I want to search for applications by various criteria
 
 Background:
   Given the following users exists
-    #TODO-Robert keep names!
     | first_name | last_name  | email                | admin |
     | Fred       | Fransson   | fred@barkyboys.com   |       |
     | John       | Johanssen  | john@happymutts.com  |       |

--- a/features/search_applications.feature
+++ b/features/search_applications.feature
@@ -6,6 +6,7 @@ I want to search for applications by various criteria
 
 Background:
   Given the following users exists
+    #TODO-Robert keep names!
     | first_name | last_name  | email                | admin |
     | Fred       | Fransson   | fred@barkyboys.com   |       |
     | John       | Johanssen  | john@happymutts.com  |       |

--- a/features/search_companies.feature
+++ b/features/search_companies.feature
@@ -6,11 +6,11 @@ I want to search for available companies by various criteria
 
 Background:
   Given the following users exists
-    | first_name | email                | admin |
-    | Fred       | fred@barkyboys.com   |       |
-    | John       | john@happymutts.com  |       |
-    | Anna       | anna@dogsrus.com     |       |
-    | Emma       | emma@weluvdogs.com   |       |
+    | email                | admin |
+    | fred@barkyboys.com   |       |
+    | john@happymutts.com  |       |
+    | anna@dogsrus.com     |       |
+    | emma@weluvdogs.com   |       |
 
   And the following business categories exist
     | name         |

--- a/features/shf-documents/admin-deletes-shf-document.feature
+++ b/features/shf-documents/admin-deletes-shf-document.feature
@@ -9,10 +9,10 @@ Feature: Admin can delete uploaded SHF Documents
 
 
     Given the following users exists
-      | first_name | email              | admin |
-      | Emma       | emma@happymutts.se |       |
-      | Bob        | bob@snarkybarky.se |       |
-      | admin      | admin@shf.se       | true  |
+      | email              | admin |
+      | emma@happymutts.se |       |
+      | bob@snarkybarky.se |       |
+      | admin@shf.se       | true  |
 
     And the following companies exist:
       | name        | company_number | email               |

--- a/features/shf-documents/admin-edits-shf-document.feature
+++ b/features/shf-documents/admin-edits-shf-document.feature
@@ -9,10 +9,10 @@ Feature: Admin can edit details about an uploaded SHF Document
 
 
     Given the following users exists
-      | first_name | email               | admin |
-      | Emma       | emma@happymutts.se  |       |
-      | Bob        | bob@snarkybarky.se  |       |
-      | admin      | admin@shf.se        | true  |
+      | email               | admin |
+      | emma@happymutts.se  |       |
+      | bob@snarkybarky.se  |       |
+      | admin@shf.se        | true  |
 
     And the following companies exist:
       | name        | company_number | email               |

--- a/features/shf-documents/admin-uploads-shf-documents.feature
+++ b/features/shf-documents/admin-uploads-shf-documents.feature
@@ -7,10 +7,10 @@ Feature: Admin uploads meeting PDFs
   Background:
 
     Given the following users exists
-      | first_name | email               | admin |
-      | Emma       | emma@happymutts.se |       |
-      | Bob        | bob@snarkybarky.se  |       |
-      | admin      | admin@shf.se        | true  |
+      | email               | admin |
+      | emma@happymutts.se  |       |
+      | bob@snarkybarky.se  |       |
+      | admin@shf.se        | true  |
 
     And the following companies exist:
       | name        | company_number | email               |

--- a/features/shf-documents/admin-views-shf-document-details.feature
+++ b/features/shf-documents/admin-views-shf-document-details.feature
@@ -9,10 +9,10 @@ Feature: Admin can edit details about an uploaded SHF Document
 
 
     Given the following users exists
-      | first_name | email               | admin |
-      | Emma       | emma@happymutts.se  |       |
-      | Bob        | bob@snarkybarky.se  |       |
-      | admin      | admin@shf.se        | true  |
+      | email               | admin |
+      | emma@happymutts.se  |       |
+      | bob@snarkybarky.se  |       |
+      | admin@shf.se        | true  |
 
     And the following companies exist:
       | name        | company_number | email               |

--- a/features/shf-documents/view-all-shf-documents.feature
+++ b/features/shf-documents/view-all-shf-documents.feature
@@ -11,10 +11,10 @@ Feature: SHF members (and admins) can views board meeting minutes (SHF documents
   Background:
 
     Given the following users exists
-      | first_name | email              | admin |
-      | Emma       | emma@happymutts.se |       |
-      | Bob        | bob@snarkybarky.se |       |
-      | admin      | admin@shf.se       | true  |
+      | email              | admin |
+      | emma@happymutts.se |       |
+      | bob@snarkybarky.se |       |
+      | admin@shf.se       | true  |
 
     And the following companies exist:
       | name        | company_number | email               |

--- a/features/show-company-map.feature
+++ b/features/show-company-map.feature
@@ -8,8 +8,8 @@ Feature: As a visitor
   Background:
 
     Given the following users exist
-      | first_name | email               | admin |
-      | Emma       | emma@happymutts.com |       |
+      | email               | admin |
+      | emma@happymutts.com |       |
 
 
     And the following regions exist:

--- a/features/show-company.feature
+++ b/features/show-company.feature
@@ -32,11 +32,11 @@ Feature: As a visitor,
       | Company6             | 6914762726     | cmpy6@mail.com         | Stockholm    | Alingsås | none               |
 
     And the following users exists
-      | first_name | email               | admin |
-      | Emma       | emma@happymutts.com |       |
-      | Anna       | a@happymutts.com    |       |
-      | Anna       | member@cmpy6.com    |       |
-      | admin      | admin@shf.se        | true  |
+      | email               | admin |
+      | emma@happymutts.com |       |
+      | a@happymutts.com    |       |
+      | member@cmpy6.com    |       |
+      | admin@shf.se        | true  |
 
     And the following business categories exist
       | name         |

--- a/features/show-user-details.feature
+++ b/features/show-user-details.feature
@@ -7,16 +7,16 @@ Feature: As an admin
   Background:
 
     Given the following users exists
-      | first_name | email                   | admin |
-      | Emma       | emma@personal.com       |       |
-      | Lars       | lars@personal.com       |       |
-      | Hannah     | hannah@personal.com     |       |
-      | Nils       | nils@personal.se        |       |
-      | Anna       | anna@personal.se        |       |
-      | Sam        | sam@personal.se         |       |
-      | admin      | admin@shf.se            | true  |
-      | admin      | yesterday_admin@shf.se  | true  |
-      | admin      | lazy_admin@shf.se       | true  |
+      | email                   | admin |
+      | emma@personal.com       |       |
+      | lars@personal.com       |       |
+      | hannah@personal.com     |       |
+      | nils@personal.se        |       |
+      | anna@personal.se        |       |
+      | sam@personal.se         |       |
+      | admin@shf.se            | true  |
+      | yesterday_admin@shf.se  | true  |
+      | lazy_admin@shf.se       | true  |
 
     And the following regions exist:
       | name         |

--- a/features/show_membership_application.feature
+++ b/features/show_membership_application.feature
@@ -14,6 +14,7 @@ Feature: As an Admin
     Given the following users exists
       | first_name         | email                               | admin |
       | Emma               | emma@personal.com                   |       |
+      | Emma               | emma@random.com                     |       |
       | Hans               | hans@random.com                     |       |
       | Anna               | anna_needs_info@random.com          |       |
       | LarsRejected       | lars_rejected@snarkybark.se         |       |
@@ -57,7 +58,7 @@ Feature: As an Admin
     And I should see 3 t("membership_applications.waiting_for_applicant")
     And I should see 1 t("membership_applications.rejected")
     And I click on "Lastname, Emma"
-    Then I should be on the application page for "Emma"
+    Then I should be on the application page for "emma@personal.com"
     And I should see "Emma Lastname"
     And I should see "5562252998"
     And I should see status line with status t("membership_applications.waiting_for_applicant")
@@ -69,7 +70,7 @@ Feature: As an Admin
     And I am on the list applications page
     Then I should see "7" applications
     And I click on "Lastname, Hans"
-    Then I should be on the application page for "Hans"
+    Then I should be on the application page for "hans@random.com"
     And I should see "Hans Lastname"
     And I should see "5560360793"
     And I should see t("membership_applications.new_status")
@@ -90,7 +91,7 @@ Feature: As an Admin
     And I am on the list applications page
     Then I should see "7" applications
     And I click on "Lastname, Emma"
-    Then I should be on the application page for "Emma"
+    Then I should be on the application page for "emma@personal.com"
     And I should see "Emma Lastname"
     And I should see "5562252998"
     And I should see "Trainer"
@@ -116,39 +117,40 @@ Feature: As an Admin
   @admin
   Scenario: Clicking the edit button on show page
     Given I am logged in as "admin@shf.com"
-    When I am on the application page for "NilsApproved"
+    When I am on the application page for "nils_member@bowwowwow.se"
     Then I should see t("membership_applications.accepted")
     And I click on t("membership_applications.edit_membership_application")
-    Then I should be on the edit application page for "NilsApproved"
+    Then I should be on the edit application page for "nils_member@bowwowwow.se"
 
   @user
   Scenario: User does not see edit-link
     Given I am logged in as "emma@random.com"
-    When I am on the application page for "Emma"
-    Then I should not see t("membership_applications.edit_membership_application")
+    When I am on the "Landing" page
+    Then I should see t("menus.nav.users.apply_for_membership")
+    And I should not see t("menus.nav.users.my_application")
 
 
   @admin
   Scenario: Admin sees business categories for user under_review
     Given I am logged in as "admin@shf.se"
-    When I am on the application page for "EmmaUnderReview"
+    When I am on the application page for "emma_under_review@happymutts.se"
     Then I should see "rehab"
 
   @admin
   Scenario: Admin sees business categories for user that is ready_for_review
     Given I am logged in as "admin@shf.se"
-    When I am on the application page for "HansReadyForReview"
+    When I am on the application page for "hans_ready_for_review@happymutts.se"
     Then I should see "dog grooming"
 
   @admin
   Scenario: Admin sees business categories for user that is waiting_for_applicant
     Given I am logged in as "admin@shf.se"
-    When I am on the application page for "Emma"
+    When I am on the application page for "emma@personal.com"
     Then I should see "Psychologist"
 
 
   @admin
   Scenario: Admin sees business categories for user that is accepted
     Given I am logged in as "admin@shf.se"
-    When I am on the application page for "NilsApproved"
+    When I am on the application page for "nils_member@bowwowwow.se"
     Then I should see "Groomer"

--- a/features/show_membership_application.feature
+++ b/features/show_membership_application.feature
@@ -12,6 +12,7 @@ Feature: As an Admin
 
   Background:
     Given the following users exists
+      #TODO-Robert keep names!
       | first_name         | email                               | admin |
       | Emma               | emma@personal.com                   |       |
       | Emma               | emma@random.com                     |       |

--- a/features/show_membership_application.feature
+++ b/features/show_membership_application.feature
@@ -12,7 +12,6 @@ Feature: As an Admin
 
   Background:
     Given the following users exists
-      #TODO-Robert keep names!
       | first_name         | email                               | admin |
       | Emma               | emma@personal.com                   |       |
       | Emma               | emma@random.com                     |       |

--- a/features/show_only_complete_companies.feature
+++ b/features/show_only_complete_companies.feature
@@ -29,15 +29,15 @@ Feature: So that I do not get frustrated by trying to find out more
       |              | 5906055081     | hello@noName.se        | Stockholm             | Alingsås |
 
     And the following users exists
-      | first_name  | email                        | admin |
-      | EmmaGroomer | emmaGroomer@happymutts.com   |       |
-      | AnnaTrainer | annaTrainer@bowsers.com      |       |
-      | Ole         | ole@noOldRegion.se           |       |
-      | Maja        | maja@onlyNoRegion.se         |       |
-      | Kikki       | kikki@noName.se              |       |
-      | LarsGroomer | larsGroomer@noRegionOrOld.se |       |
-      | LarsTrainer | larsTrainer@noRegionOrOld.se |       |
-      | admin       | admin@shf.se                 | true  |
+      | email                        | admin |
+      | emmaGroomer@happymutts.com   |       |
+      | annaTrainer@bowsers.com      |       |
+      | ole@noOldRegion.se           |       |
+      | maja@onlyNoRegion.se         |       |
+      | kikki@noName.se              |       |
+      | larsGroomer@noRegionOrOld.se |       |
+      | larsTrainer@noRegionOrOld.se |       |
+      | admin@shf.se                 | true  |
 
 
     And the following applications exist:

--- a/features/size_validation.feature
+++ b/features/size_validation.feature
@@ -5,9 +5,9 @@ Feature: As an applicant
 
   Background:
     Given the following users exists
-      | first_name | email                 | admin |
-      | Hans       | hans@new_applicant.se |       |
-      | Emma       | emma@happymutts.se    |       |
+      | email                 | admin |
+      | hans@new_applicant.se |       |
+      | emma@happymutts.se    |       |
 
     And the following applications exist:
       | user_email         | company_number | state        |

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -159,14 +159,14 @@ And(/^t\("([^"]*)"\) should be set in "([^"]*)"$/) do |status, list|
 end
 
 
-Then(/^I should be on the application page for "([^"]*)"$/) do |first_name|
-  user = User.find_by(first_name: first_name)
+Then(/^I should be on the application page for "([^"]*)"$/) do |email|
+  user = User.find_by(email: email)
   membership_application = user.membership_application
   expect(current_path_without_locale(current_path)).to eq membership_application_path(membership_application)
 end
 
-Then(/^I should be on the edit application page for "([^"]*)"$/) do |first_name|
-  user = User.find_by(first_name: first_name)
+Then(/^I should be on the edit application page for "([^"]*)"$/) do |email|
+  user = User.find_by(email: email)
   membership_application = user.membership_application
   expect(current_path_without_locale(current_path)).to eq edit_membership_application_path(membership_application)
 end

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -37,14 +37,14 @@ end
 
 
 
-And(/^I navigate to the edit page for "([^"]*)"$/) do |first_name|
-  user = User.find_by(first_name: first_name)
+And(/^I navigate to the edit page for "([^"]*)"$/) do |email|
+  user = User.find_by(email: email)
   membership_application = user.membership_application
   visit path_with_locale(edit_membership_application_path(membership_application))
 end
 
-Given(/^I am on "([^"]*)" application page$/) do |first_name|
-  user = User.find_by(first_name: first_name)
+Given(/^I am on "([^"]*)" application page$/) do |email|
+  user = User.find_by(email: email)
   membership_application = user.membership_application
   visit path_with_locale(membership_application_path(membership_application))
 end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -107,8 +107,8 @@ When(/^I fail to visit the "([^"]*)" page$/) do |page|
 end
 
 
-When(/^I am on the application page for "([^"]*)"$/) do |first_name|
-  user = User.find_by(first_name: first_name)
+When(/^I am on the application page for "([^"]*)"$/) do |email|
+  user = User.find_by(email: email)
   membership_application = user.membership_application
   visit path_with_locale(membership_application_path(membership_application))
 end

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -45,7 +45,7 @@ Feature: As an Admin
   Scenario: Application submitter can see but not update the Application status
     Given I am Logged out
     And I am logged in as "emma_under_review@happymutts.se"
-    Given I am on "EmmaUnderReview" application page
+    Given I am on "emma_under_review@happymutts.se" application page
     And I should see status line with status t("membership_applications.under_review")
     And I should not see button t("membership_applications.accept_btn")
     And I should not see button t("membership_applications.reject_btn")
@@ -55,7 +55,7 @@ Feature: As an Admin
 
   @admin @user
   Scenario: Admin requests more info from user (from under_review to 'waiting for applicant')
-    Given I am on "EmmaUnderReview" application page
+    Given I am on "emma_under_review@happymutts.se" application page
     Then I should see "rehab"
     When I click on t("membership_applications.ask_applicant_for_info_btn")
     Then I should see t("membership_applications.need_info.success")
@@ -74,7 +74,7 @@ Feature: As an Admin
 
   @admin
   Scenario: Admin changed from under_review to accepted
-    Given I am on "EmmaUnderReview" application page
+    Given I am on "emma_under_review@happymutts.se" application page
     Then I should see "rehab"
     When I click on t("membership_applications.accept_btn")
     Then I should see t("membership_applications.accept.success")
@@ -88,7 +88,7 @@ Feature: As an Admin
 
   @admin
   Scenario: Admin changed from under_review to rejected
-    Given I am on "EmmaUnderReview" application page
+    Given I am on "emma_under_review@happymutts.se" application page
     Then I should see "rehab"
     When I click on t("membership_applications.reject_btn")
     Then I should see t("membership_applications.reject.success")
@@ -103,12 +103,12 @@ Feature: As an Admin
 
   @admin
   Scenario: Admin cannot change from under_review to 'cancel waiting for applicant'
-    Given I am on "EmmaUnderReview" application page
+    Given I am on "emma_under_review@happymutts.se" application page
     Then I should not see button t("membership_applications.cancel_waiting_for_applicant_btn")
 
   @admin
   Scenario: Admin rejects an application (under_review to rejected)
-    Given I am on "EmmaUnderReview" application page
+    Given I am on "emma_under_review@happymutts.se" application page
     Then I should see "rehab"
     When I click on t("membership_applications.reject_btn")
     Then I should see t("membership_applications.reject.success")
@@ -129,7 +129,7 @@ Feature: As an Admin
     And I click on t("membership_applications.edit.submit_button_label")
     And I am Logged out
     And I am logged in as "admin@shf.se"
-    And I am on "AnnaWaiting" application page
+    And I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     And I should see "rehab"
     Then I click on t("membership_applications.ask_applicant_for_info_btn")
     And  I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
@@ -138,7 +138,7 @@ Feature: As an Admin
     And I click on t("membership_applications.edit.submit_button_label")
     And I am Logged out
     And I am logged in as "admin@shf.se"
-    And I am on "AnnaWaiting" application page
+    And I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     When I click on t("membership_applications.reject_btn")
     Then I should see t("membership_applications.reject.success")
     And I should see status line with status t("membership_applications.rejected")
@@ -149,7 +149,7 @@ Feature: As an Admin
 
   @admin
   Scenario: Admin changed from under_review to waiting_for_payment
-    Given I am on "EmmaUnderReview" application page
+    Given I am on "emma_under_review@happymutts.se" application page
     Then I should see "rehab"
     When I click on t("membership_applications.ask_applicant_for_payment_btn")
     Then I should see t("membership_applications.need_payment.success")
@@ -187,7 +187,7 @@ Feature: As an Admin
     And I should see status line with status t("membership_applications.ready_for_review")
     And I am Logged out
     And I am logged in as "admin@shf.se"
-    And I am on "AnnaWaiting" application page
+    And I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     Then I should see status line with status t("membership_applications.ready_for_review")
     And I should see "rehab"
     And I am on the "landing" page
@@ -198,7 +198,7 @@ Feature: As an Admin
 
   @admin
   Scenario: Admin changed from 'waiting for applicant' to 'under review'
-    Given I am on "AnnaWaiting" application page
+    Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     And I should see "rehab"
     When I click on t("membership_applications.cancel_waiting_for_applicant_btn")
     Then I should see t("membership_applications.cancel_need_info.success")
@@ -214,23 +214,23 @@ Feature: As an Admin
 
   @admin
   Scenario: Admin cannot change from 'waiting for applicant' to rejected
-    Given I am on "AnnaWaiting" application page
+    Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     Then I should not see button t("membership_applications.reject_btn")
 
   @admin
   Scenario: Admin cannot change from 'waiting for applicant' to accepted
-    Given I am on "AnnaWaiting" application page
+    Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     Then I should not see button t("membership_applications.accept_btn")
 
   @admin
   Scenario: Admin cannot change from 'waiting for applicant' to 'waiting for applicant'
-    Given I am on "AnnaWaiting" application page
+    Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     Then I should not see t("membership_applications.ask_applicant_for_info_btn")
 
 
   @admin
   Scenario: 'Waiting for applicant' status is not changed if admin edits the application
-    Given I am on "AnnaWaiting" application page
+    Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
     And I click on t("membership_applications.edit_membership_application")
     And I fill in t("membership_applications.show.last_name") with "AdminUpdated"
     And I click on t("membership_applications.edit.submit_button_label")
@@ -241,7 +241,7 @@ Feature: As an Admin
 
   # From waiting_for_payment to...
   Scenario: Admin changed waiting_for_payment to under_review
-    Given I am on "LarsWaitingForPayment" application page
+    Given I am on "lars_waiting_for_payment@happymutts.se" application page
     And I click on t("membership_applications.cancel_waiting_for_payment_btn")
     Then I should see t("membership_applications.cancel_need_payment.success")
     And I should see status line with status t("membership_applications.under_review")
@@ -252,7 +252,7 @@ Feature: As an Admin
     And I should see 1 t("membership_applications.accepted")
 
   Scenario: Admin changed waiting_for_payment to accepted
-    Given I am on "LarsWaitingForPayment" application page
+    Given I am on "lars_waiting_for_payment@happymutts.se" application page
     And I click on t("membership_applications.received_payment_btn")
     Then I should see t("membership_applications.received_payment.success")
     And I should see status line with status t("membership_applications.accepted")
@@ -266,7 +266,7 @@ Feature: As an Admin
   # From accepted to...
   @admin
   Scenario: Admin changed from accepted to rejected
-    Given I am on "NilsAccepted" application page
+    Given I am on "nils_member@bowwowwow.se" application page
     And I should see "dog crooning"
     When I click on t("membership_applications.reject_btn")
     Then I should see t("membership_applications.reject.success")
@@ -280,12 +280,12 @@ Feature: As an Admin
 
   @admin
   Scenario: Admin cannot change from accepted to accepted
-    Given I am on "NilsAccepted" application page
+    Given I am on "nils_member@bowwowwow.se" application page
     Then I should not see button t("membership_applications.accept_btn")
 
   @admin
   Scenario: Admin cannot change from accepted to 'waiting for applicant'
-    Given I am on "NilsAccepted" application page
+    Given I am on "nils_member@bowwowwow.se" application page
     Then I should not see button t("membership_applications.ask_applicant_for_info_btn")
     Then I should not see button t("membership_applications.accept_btn")
     And I should not see button t("membership_applications.ask_applicant_for_info_btn")
@@ -294,7 +294,7 @@ Feature: As an Admin
 
   @admin
   Scenario: Admin cannot change from accepted to cancel waiting for applicant
-    Given I am on "NilsAccepted" application page
+    Given I am on "nils_member@bowwowwow.se" application page
     Then I should not see button t("membership_applications.cancel_waiting_for_applicant_btn")
 
 
@@ -302,14 +302,14 @@ Feature: As an Admin
   @user
   Scenario: User can only view application if it's rejected, they cannot edit it
     Given I am logged in as "lars_rejected@snarkybark.se"
-    And I am on "LarsRejected" application page
+    And I am on "lars_rejected@snarkybark.se" application page
     Then I should see t("membership_applications.show.title", member_full_name: "LarsRejected Lastname")
     And I should not see t("membership_applications.edit.title")
     And I should see "rehab"
 
   @admin
   Scenario: Admin cannot edit an application if it is rejected
-    Given I am on "LarsRejected" application page
+    Given I am on "lars_rejected@snarkybark.se" application page
     And I should see "rehab"
     When I click on t("membership_applications.edit_membership_application")
     And I fill in t("membership_applications.show.last_name") with "BadBadLars"
@@ -325,12 +325,12 @@ Feature: As an Admin
 
   @admin
   Scenario: Admin cannot change from rejected to 'waiting for applicant'
-    Given I am on "LarsRejected" application page
+    Given I am on "lars_rejected@snarkybark.se" application page
     Then I should not see button t("membership_applications.ask_applicant_for_info_btn")
 
   @admin
   Scenario: Admin changed from rejected to accepted
-    Given I am on "LarsRejected" application page
+    Given I am on "lars_rejected@snarkybark.se" application page
     And I should see "rehab"
     When I click on t("membership_applications.accept_btn")
     Then I should see t("membership_applications.accept.success")
@@ -344,10 +344,10 @@ Feature: As an Admin
 
   @admin
   Scenario: Admin cannot change from rejected to rejected
-    Given I am on "LarsRejected" application page
+    Given I am on "lars_rejected@snarkybark.se" application page
     Then I should not see button t("membership_applications.reject_btn")
 
   @admin
   Scenario: Admin cannot change from rejected to cancel needs info
-    Given I am on "LarsRejected" application page
+    Given I am on "lars_rejected@snarkybark.se" application page
     Then I should not see button t("membership_applications.cancel_waiting_for_applicant_btn")

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -5,7 +5,6 @@ Feature: As an Admin
 
   Background:
     Given the following users exists
-      #TODO-Robert keep names!
       | first_name            | email                                  | admin |
       | EmmaUnderReview       | emma_under_review@happymutts.se        |       |
       | HansUnderReview       | hans_under_review@happymutts.se        |       |

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -5,6 +5,7 @@ Feature: As an Admin
 
   Background:
     Given the following users exists
+      #TODO-Robert keep names!
       | first_name            | email                                  | admin |
       | EmmaUnderReview       | emma_under_review@happymutts.se        |       |
       | HansUnderReview       | hans_under_review@happymutts.se        |       |

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -5,10 +5,10 @@ Feature: As an applicant
 
   Background:
     Given the following users exists
-      | first_name | email                  | admin |
-      | Emma       | applicant_1@random.com |       |
-      | Applicant2 | applicant_2@random.com |       |
-      | admin      | admin@shf.com          | true  |
+      | email                  | admin |
+      | applicant_1@random.com |       |
+      | applicant_2@random.com |       |
+      | admin@shf.com          | true  |
 
 
     And the following applications exist:

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -51,7 +51,7 @@ Feature: As an applicant
     And I click on t("membership_applications.edit.submit_button_label")
     And I am Logged out
     And I am logged in as "admin@shf.com"
-    And I am on "Emma" application page
+    And I am on "applicant_1@random.com" application page
     Then I click on t("membership_applications.ask_applicant_for_info_btn")
     And  I am logged in as "applicant_1@random.com"
     And I am on the "edit my application" page
@@ -91,7 +91,7 @@ Feature: As an applicant
     And I click on t("membership_applications.edit.submit_button_label")
     And I am Logged out
     And I am logged in as "admin@shf.com"
-    And I am on "Emma" application page
+    And I am on "applicant_1@random.com" application page
     Then I click on t("membership_applications.ask_applicant_for_info_btn")
     And  I am logged in as "applicant_1@random.com"
     And I am on the "edit my application" page

--- a/features/user_profile/admin-resets-users-password.feature
+++ b/features/user_profile/admin-resets-users-password.feature
@@ -6,10 +6,10 @@ Feature: As an admin
   Background:
 
     Given the following users exists
-      | first_name | email               | admin |
-      | Emma       | emma@happymutts.com |       |
-      | Bob        | bob@snarkybarky.se  |       |
-      | admin      | admin@shf.se        | true  |
+      | email               | admin |
+      | emma@happymutts.com |       |
+      | bob@snarkybarky.se  |       |
+      | admin@shf.se        | true  |
 
     And the following companies exist:
       | name        | company_number | email               |

--- a/features/view_hidden_pages.feature
+++ b/features/view_hidden_pages.feature
@@ -3,10 +3,10 @@ Feature: Only members and admins can see members only (hidden) pages
   Background:
 
     Given the following users exists
-      | first_name | email                    | admin | is_member |
-      | Emma       | emma@happymutts.com      |       | true      |
-      | NoMember   | not_a_member@bowsers.com |       | false     |
-      | admin      | admin@shf.se             | true  | true      |
+      | email                    | admin | is_member |
+      | emma@happymutts.com      |       | true      |
+      | not_a_member@bowsers.com |       | false     |
+      | admin@shf.se             | true  | true      |
 
     And the following business categories exist
       | name  |


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/149113469

**Changes proposed in this pull request:**

1.  Change all steps finding a user by first_name to steps finding a user by e-mail
2. Remove first_name column from background datatables in feature tests where they are no longer needed.

Ready for review:
@patmbolger @weedySeaDragon 