### PR TITLE
Delete uploaded files before deleting a membershipapplication

### DIFF
--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -151,9 +151,11 @@ class MembershipApplication < ApplicationRecord
   end
 
 
-  # if this is the only application associated with a company, delete the company
   def before_destroy_checks
 
+    delete_uploaded_files
+
+    # if this is the only application associated with a company, delete the company
     unless company.nil?
       company.membership_applications.reload
       company.delete if (company.membership_applications.count == 1)

--- a/spec/models/membership_application_spec.rb
+++ b/spec/models/membership_application_spec.rb
@@ -128,7 +128,8 @@ RSpec.describe MembershipApplication, type: :model do
     let(:membership_application) {create(:membership_application, user: application_owner, uploaded_files: [uploaded_file])}
 
     it 'destroys a membershipapplication' do
-      expect {membership_application.destroy}.not_to raise_exception
+      membership_application.destroy
+      expect(membership_application.destroyed?).to be_truthy
     end
 
     it 'destroys the uploaded file' do

--- a/spec/models/membership_application_spec.rb
+++ b/spec/models/membership_application_spec.rb
@@ -121,6 +121,17 @@ RSpec.describe MembershipApplication, type: :model do
 
   end
 
+  describe "#destroy" do
+
+    let(:application_owner) {create(:user, email: 'user_1@random.com')}
+    let(:membership_application) {create(:membership_application, user: application_owner, uploaded_files: [create(:uploaded_file, actual_file: (File.new(File.join(FIXTURE_DIR, 'image.jpg'))))])}
+
+    it 'destroys a membershipapplication' do
+      expect {membership_application.destroy}.not_to raise_exception
+    end
+
+  end
+
   describe '#is_accepted?' do
     let!(:states) {MembershipApplication.aasm.states.map(&:name)}
     let(:states_not_accepted) {states.reject {|s| s == :accepted}}

--- a/spec/models/membership_application_spec.rb
+++ b/spec/models/membership_application_spec.rb
@@ -124,10 +124,16 @@ RSpec.describe MembershipApplication, type: :model do
   describe "#destroy" do
 
     let(:application_owner) {create(:user, email: 'user_1@random.com')}
-    let(:membership_application) {create(:membership_application, user: application_owner, uploaded_files: [create(:uploaded_file, actual_file: (File.new(File.join(FIXTURE_DIR, 'image.jpg'))))])}
+    let(:uploaded_file) {create(:uploaded_file, actual_file: (File.new(File.join(FIXTURE_DIR, 'image.jpg'))))}
+    let(:membership_application) {create(:membership_application, user: application_owner, uploaded_files: [uploaded_file])}
 
     it 'destroys a membershipapplication' do
       expect {membership_application.destroy}.not_to raise_exception
+    end
+
+    it 'destroys the uploaded file' do
+      membership_application.destroy
+      expect(uploaded_file.destroyed?).to be_truthy
     end
 
   end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/149853131

**Changes proposed in this pull request:**

1) Add a failing test for the bug 
2) Make the test pass by deleting uploaded files before deleting a membership application


Ready for review:
@patmbolger @weedySeaDragon @thesuss 