### PR TITLE
Address is shown/instantiated for a newly approved member (company edit page)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,8 @@ HEROKU_STAGING            # (used in db/seeds.rb)
 MAILGUN_API_KEY=app-account-key
 MAILGUN_DOMAIN=app-email-domain
 
+#SHF_SEED_USERS=4         # The number of users to create during seeding (Takes precedence of the default number in seeds.db). Seed with a minimum of 4 users to cover: admin, no application, single application, double application
+
 
 # -------------------------------------------
 # Keys and values required for backups to AWS:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This project runs on a Ruby on Rails stack with postgreSQL as the repository.
 - ruby version - check Gemfile (2.4.1 as of July 04, 2017)
 - rails 5.1.0 (5.1.0 as of July 04, 2017)
 - Postgresql DB
+- imagemagik https://www.imagemagick.org
+- phantomjs (required for integration tests [cucumber tests])
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project runs on a Ruby on Rails stack with postgreSQL as the repository.
 - rails 5.1.0 (5.1.0 as of July 04, 2017)
 - Postgresql DB
 - imagemagik https://www.imagemagick.org
-- phantomjs (required for integration tests [cucumber tests])
+- phantomjs (required for integration tests [cucumber tests]) http://phantomjs.org/
 
 ## Installation
 

--- a/app/assets/stylesheets/companies.scss
+++ b/app/assets/stylesheets/companies.scss
@@ -8,9 +8,9 @@ $btn-success-color: #00ff00;
 .edit_company {
 
   .main-address {
-    margin-top: 2rem;
-    font-weight: bold;
     font-size: larger;
+    font-weight: bold;
+    margin-top: 2rem;
   }
 
 }

--- a/app/assets/stylesheets/companies.scss
+++ b/app/assets/stylesheets/companies.scss
@@ -5,6 +5,17 @@ $btn-success-color: #00ff00;
 }
 
 
+.edit_company {
+
+  .main-address {
+    margin-top: 2rem;
+    font-weight: bold;
+    font-size: larger;
+  }
+
+}
+
+
 .company {
 
   margin-bottom: 0;

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -275,6 +275,3 @@ select {
     padding:0 !important;
     margin:0 !important;
 }
-.admin {
-    padding-top:80px;
-}

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -925,7 +925,31 @@ mobile nav 1200px
 }
 
 /*-----------------------
-social nav
+login nav
+-----------------------*/
+.login-nav {
+    position:fixed;
+    top: 0;
+    right: 0;
+    z-index:999;
+    min-width: 240px;
+}
+
+.login-nav a {
+    margin: 0 5px;
+    padding-left:5px;
+}
+
+a.link-no-styling {
+  text-decoration: none;
+}
+
+.tall-line {
+  line-height: 60px;
+}
+
+/*-----------------------
+login nav
 -----------------------*/
 .social-nav {
     position:absolute;
@@ -2437,6 +2461,7 @@ fixed nav padding
 
 #masthead {
     position:relative;
+    padding-bottom: 100px;
 }
 
 #primary {

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -56,7 +56,6 @@ class CompaniesController < ApplicationController
     Ckeditor::Picture.images_category = 'company_' + @company.id.to_s
     Ckeditor::Picture.for_company_id  = @company.id
 
-    @company.main_address # this will create one if it's nil ( == lazy initialization)
   end
 
 

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -55,6 +55,8 @@ class CompaniesController < ApplicationController
 
     Ckeditor::Picture.images_category = 'company_' + @company.id.to_s
     Ckeditor::Picture.for_company_id  = @company.id
+
+    @company.main_address # this will create one if it's nil ( == lazy initialization)
   end
 
 

--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -90,7 +90,7 @@ class MembershipApplicationsController < ApplicationController
 
           format.html do
             helpers.flash_message(:notice, t('.success'))
-            render :show
+            redirect_to membership_application_path(@membership_application)
           end
 
         end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -2,10 +2,11 @@ class Address < ApplicationRecord
 
   belongs_to :addressable, polymorphic: true
 
+  # When an address is initially created, it may not have a kommun or region assigned,
+  # for example when an admin creates a company but doesn't have all of the info for the main address.
   belongs_to :region, optional: true
 
-  belongs_to :kommun
-
+  belongs_to :kommun, optional: true
 
   validates_presence_of :addressable
 
@@ -21,7 +22,6 @@ class Address < ApplicationRecord
 
   after_validation :geocode_best_possible,
                    :if => lambda { |obj| obj.changed? }
-
 
   # geocode all of the addresses that need it
   #
@@ -44,6 +44,7 @@ class Address < ApplicationRecord
 
   end
 
+
   def address_array
     # This should only be called for address associated with a company
 
@@ -63,18 +64,20 @@ class Address < ApplicationRecord
     return [] unless start_index
 
     if kommun
-      ary = [ street_address, post_code, city, kommun.name,
-              sverige_if_nil][start_index..pattern_length ]
+      ary = [street_address, post_code, city, kommun.name,
+             sverige_if_nil][start_index..pattern_length]
     else
-      ary = [ street_address, post_code, city,
-              sverige_if_nil][start_index..(pattern_length-1) ]
+      ary = [street_address, post_code, city,
+             sverige_if_nil][start_index..(pattern_length-1)]
     end
-    ary.delete_if {|f| f.blank?}
+    ary.delete_if { |f| f.blank? }
   end
+
 
   def entire_address
     address_array.compact.join(', ')
   end
+
 
   # Geocode the address, starting with all of the data.
   #  If we don't get a geocoded result, then keep trying,

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -75,7 +75,12 @@ class Company < ApplicationRecord
 
   end
 
+
   def main_address
+    if addresses.empty?
+      addresses << Address.new
+    end
+
     addresses.first
   end
 

--- a/app/views/application/_login_items.html.haml
+++ b/app/views/application/_login_items.html.haml
@@ -1,5 +1,17 @@
 - if user_signed_in?
-  = link_to(t('devise.sessions.destroy.log_out'), destroy_user_session_path, method: :delete)
+  %a.dropdown-toggle.link-no-styling.tall-line{ href: '#',
+     'data-toggle' => 'dropdown', role: 'button' }
+    = t('hello', name: current_user.first_name)
+    %span.caret
+
+  %ul.dropdown-menu
+    %li
+      = link_to(t('devise.registrations.edit.title'),
+                edit_user_registration_path)
+    %li
+      = link_to(t('devise.sessions.destroy.log_out'),
+                destroy_user_session_path, method: :delete)
+
 - else
-  = link_to(t('devise.sessions.new.log_in'), new_user_session_path)
-= render 'select_language'
+  = link_to(t('devise.sessions.new.log_in'), new_user_session_path,
+            { class: 'tall-line' })

--- a/app/views/application/_login_nav.html.haml
+++ b/app/views/application/_login_nav.html.haml
@@ -1,4 +1,3 @@
-.social-nav
-  .tb
-    .tb-cell
-      = render 'login_items'
+.login-nav
+  = render 'login_items'
+  = render 'select_language'

--- a/app/views/application/_navigation.html.haml
+++ b/app/views/application/_navigation.html.haml
@@ -2,25 +2,28 @@
   %a{ href: '#' }
     = icon('angle-up')
 .container-fluid.hfeed.site
-  %header.site-header#masthead{role: 'banner'}
-    %a.skip-link.screen-reader-text{href: '#content'} Skip to content
+  %header.site-header#masthead{ role: 'banner' }
+    %a.skip-link.screen-reader-text{ href: '#content' } Skip to content
     / main navigation
-    %nav.main-navigation.fixed-nav#site-navigation{role: 'navigation'}
-      .nav-wrapper
-        %a.menu-toggle{href: '#'}
-          %span.bars
-            %span.bar.bar-1
-            %span.bar.bar-2
-            %span.bar.bar-3
+    %nav.main-navigation.fixed-nav#site-navigation{ role: 'navigation' }
+      %a.menu-toggle{ href: '#' }
+        %span.bars
+          %span.bar.bar-1
+          %span.bar.bar-2
+          %span.bar.bar-3
 
-        = render 'login_nav'
+      .nav-wrapper
 
         - if user_signed_in?
 
           - if current_user.admin?
 
             .menu#menu-menu-3-container
+
               %ul.menu#menu-menu-3
+                %li.menu-item
+                  = link_to t('menus.nav.shf_main_site'), 'http://sverigeshundforetagare.se/'
+
                 = render 'navigation_member_pages'
 
                 = render 'navigation_admin'
@@ -28,6 +31,7 @@
           - else
 
             .menu#menu-menu-2-container
+
               %ul.menu#menu-menu-2
                 %li.menu-item
                   = link_to t('menus.nav.shf_main_site'), 'http://sverigeshundforetagare.se/'
@@ -67,3 +71,5 @@
           -# Visitor navigation
           .menu#menu-menu-1-container
             = render 'navigation_visitor'
+
+        = render 'login_nav'

--- a/app/views/application/_navigation_admin.html.haml
+++ b/app/views/application/_navigation_admin.html.haml
@@ -1,33 +1,32 @@
-%li.menu-item
-  = link_to t('menus.nav.admin.shf_main_site'), 'http://sverigeshundforetagare.se/'
-
-%li.menu-item
-  = link_to t('menus.nav.admin.manage_applications'), membership_applications_path
-
 %li.menu-item.menu-item-has-children
-  = link_to t('menus.nav.admin.categories.submenu_title'), business_categories_path
+  %a.link-no-styling{ href: '#' }= t('menus.nav.admin.administration.submenu_title')
   %ul.sub-menu
-    %li.menu-item
-      = link_to t('menus.nav.admin.categories.list_categories'), business_categories_path
-    %li.menu-item
-      = link_to t('menus.nav.admin.categories.new_category'), new_business_category_path
+    %li.menu-item.menu-item-has-children
+      %a.link-no-styling{ href: '#' }= t('menus.nav.admin.applications.submenu_title')
+      %ul.sub-menu
+        %li.menu-item
+          = link_to t('menus.nav.admin.manage_applications'),
+                    membership_applications_path
+        %li.menu-item
+          = link_to t('menus.nav.admin.applications.waiting_reasons'),
+                    admin_only_member_app_waiting_reasons_path
 
-%li.menu-item.menu-item-has-children
-  = link_to t('menus.nav.admin.companies.submenu_title'), companies_path
-  %ul.sub-menu
-    %li.menu-item
-      = link_to t('menus.nav.admin.companies.list_companies'), companies_path
-    %li.menu-item
-      = link_to t('menus.nav.admin.companies.new_company'), new_company_path
+    %li.menu-item.menu-item-has-children
+      %a.link-no-styling{ href: '#' }= t('menus.nav.admin.companies.submenu_title')
+      %ul.sub-menu
+        %li.menu-item
+          = link_to t('menus.nav.admin.companies.manage_companies'), companies_path
+        %li.menu-item
+          = link_to t('menus.nav.admin.companies.new_company'), new_company_path
+
+    %li.menu-item.menu-item-has-children
+      %a.link-no-styling{ href: '#' }= t('menus.nav.admin.categories.submenu_title')
+      %ul.sub-menu
+        %li.menu-item
+          = link_to t('menus.nav.admin.categories.manage_categories'),
+                    business_categories_path
+        %li.menu-item
+          = link_to t('menus.nav.admin.categories.new_category'), new_business_category_path
 
 %li.menu-item
   = link_to t('menus.nav.admin.users.list_users'), users_path
-
-%li.menu-item.menu-item-has-children
-  = link_to t('menus.nav.admin.member_app_waiting_reasons.submenu_title'), admin_only_member_app_waiting_reasons_path
-  %ul.sub-menu
-    %li.menu-item
-      = link_to t('menus.nav.admin.member_app_waiting_reasons.list_member_app_waiting_reasons'), admin_only_member_app_waiting_reasons_path
-    %li.menu-item
-      = link_to t('menus.nav.admin.member_app_waiting_reasons.new_member_app_waiting_reasons'), new_admin_only_member_app_waiting_reason_path
-

--- a/app/views/application/_navigation_visitor.html.haml
+++ b/app/views/application/_navigation_visitor.html.haml
@@ -20,6 +20,8 @@
         = link_to t('menus.nav.visitor.dog_owners.become_supporter'), 'http://sverigeshundforetagare.se/agare/bli-stodmedlem/'
       %li.menu-item
         = link_to t('menus.nav.visitor.dog_owners.being_dog_owners'), 'http://sverigeshundforetagare.se/agare/att-vara-hundagare/'
+      %li.menu-item
+        = link_to t('menus.nav.visitor.find_dog_businesses'), root_path
 
   %li.menu-item.menu-item-has-children
     = link_to t('menus.nav.visitor.entrepreneurs.submenu_title'), 'http://sverigeshundforetagare.se/foretag/'
@@ -40,7 +42,7 @@
         = link_to t('menus.nav.visitor.entrepreneurs.knowledge_bank'), 'http://sverigeshundforetagare.se/category/kunskapsbank-foretagare/'
 
   %li.menu-item.menu-item-has-children
-    = link_to t('menus.nav.visitor.knowledge_bank.submenu_title'), '#'
+    %a.link-no-styling{ href: '#' }= t('menus.nav.visitor.knowledge_bank.submenu_title')
     %ul.sub-menu
       %li.menu-item
         = link_to 'Bloggar', 'http://sverigeshundforetagare.se/category/bloggar/'
@@ -57,6 +59,3 @@
 
   %li.menu-item
     = link_to t('menus.nav.visitor.contact'), 'http://sverigeshundforetagare.se/kontakt/'
-
-  %li.menu-item
-    = link_to t('menus.nav.visitor.find_dog_businesses'), root_path

--- a/app/views/application/_top.html.haml
+++ b/app/views/application/_top.html.haml
@@ -1,5 +1,1 @@
 = render 'navigation'
-#site-logo
-  %p.admin
-    - if current_user.admin?
-      = t('info.logged_in_as_admin')

--- a/app/views/companies/_address_fields.html.haml
+++ b/app/views/companies/_address_fields.html.haml
@@ -1,0 +1,42 @@
+= f.fields_for :addresses  do |address_form|
+
+  = address_form.label :street_address, "#{t('companies.show.street')}", class: 'required'
+  = address_form.text_field :street_address, class: 'wpcf7-form-control'
+
+  = address_form.label :post_code, "#{t('companies.show.post_code')}", class: 'required'
+  = address_form.text_field :post_code, class: 'wpcf7-form-control'
+
+  = address_form.label :city, "#{t('companies.show.city')}", class: 'required'
+  = address_form.text_field :city, class: 'wpcf7-form-control'
+
+  .form-group
+    .col-sm-4
+
+      = address_form.label :kommun_id, "#{t('companies.show.kommun')}"
+      %br
+      = address_form.collection_select(:kommun_id, Kommun.all, :id, :name)
+
+    .col-sm-4
+
+      = address_form.label :region_id, "#{t('companies.operations_region')}",
+                           class: 'wpcf7-form-control'
+
+      %span.glyphicon.glyphicon-info-sign{ title: "#{t('companies.form.region_tooltip')}",
+                                           data: {toggle: 'tooltip'} }
+
+      %br
+      = address_form.collection_select(:region_id, Region.all, :id, :name)
+
+    .col-sm-4
+
+      = f.label :address_visibility, "#{t('companies.address_visibility')}"
+
+      %span.glyphicon.glyphicon-info-sign{ title: "#{t('companies.form.visibility_tooltip')}",
+                                           data: {toggle: 'tooltip'} }
+
+      %br
+      = f.select(:address_visibility, address_visibility_array)
+
+  %br
+  %br
+  %br

--- a/app/views/companies/_form.html.haml
+++ b/app/views/companies/_form.html.haml
@@ -17,51 +17,16 @@
   = f.label :email, "#{t('companies.show.email')}", class: 'required'
   = f.text_field :email, class: 'wpcf7-form-control'
 
-  %p #{t('companies.show.address')}:
+  - if @company.addresses.count > 1
+    %p.main-address #{t('companies.show.main_address')}:
 
+  = render 'address_fields', {f: f, addresses: [ @company.main_address ]}
 
-  = f.fields_for :addresses  do |address_form|
+  - other_addresses = @company.addresses - [ @company.main_address ]
+  - unless other_addresses.empty?
+    %p.other_addresses #{t('companies.show.other_addresses')}:
+    = render 'address_fields', {f: f, addresses: other_addresses}
 
-    = address_form.label :street_address, "#{t('companies.show.street')}", class: 'required'
-    = address_form.text_field :street_address, class: 'wpcf7-form-control'
-
-    = address_form.label :post_code, "#{t('companies.show.post_code')}", class: 'required'
-    = address_form.text_field :post_code, class: 'wpcf7-form-control'
-
-    = address_form.label :city, "#{t('companies.show.city')}", class: 'required'
-    = address_form.text_field :city, class: 'wpcf7-form-control'
-
-    .form-group
-      .col-sm-4
-
-        = address_form.label :kommun_id, "#{t('companies.show.kommun')}"
-        %br
-        = address_form.collection_select(:kommun_id, Kommun.all, :id, :name)
-
-      .col-sm-4
-
-        = address_form.label :region_id, "#{t('companies.operations_region')}",
-                             class: 'wpcf7-form-control'
-
-        %span.glyphicon.glyphicon-info-sign{ title: "#{t('.region_tooltip')}",
-                                             data: {toggle: 'tooltip'} }
-
-        %br
-        = address_form.collection_select(:region_id, Region.all, :id, :name)
-
-      .col-sm-4
-
-        = f.label :address_visibility, "#{t('companies.address_visibility')}"
-
-        %span.glyphicon.glyphicon-info-sign{ title: "#{t('.visibility_tooltip')}",
-                                             data: {toggle: 'tooltip'} }
-
-        %br
-        = f.select(:address_visibility, address_visibility_array)
-
-  %br
-  %br
-  %br
 
   = f.label :website, "#{t('companies.website_include_http')}", class: 'required'
   = f.text_field :website, class: 'wpcf7-form-control'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,8 @@ en:
 
   confirm_are_you_sure: &are_you_sure_confirm Are you sure
 
+  hello: 'Hello, %{name}'
+
   info:
     logged_in_as_admin: You are logged in as an admin.
     under_construction: This page is under construction.  More information and features are coming.
@@ -710,7 +712,7 @@ en:
         submit_button_label: Sign up
         success: You have signed up successfully
       edit:
-        title: Edit your login information
+        title: Edit your profile
         unconfirmed_email_for: 'Unconfirmed email address for: %{unconfirmed_email}'
         confirm_password: *confirm_password
         current_password: Current password
@@ -804,7 +806,7 @@ en:
         member_pages: *member_pages
         shf_meeting_minutes: *member_pages_board_meetings
         manage_company:
-          submenu_title: Manage my company
+          submenu_title: My company
           view_company: View Company
           edit_company: Edit My Company
         my_application: *my_application
@@ -816,19 +818,21 @@ en:
         manage_applications: Manage Applications
         categories:
           submenu_title: Categories
-          list_categories: List Categories
+          manage_categories: Manage Categories
           new_category: New Category
         companies:
           submenu_title: Companies
-          list_companies: List Companies
+          manage_companies: Manage Companies
           new_company: New Company
+        applications:
+          submenu_title: Applications
+          manage_applications: Manage Applications
+          waiting_reasons: Waiting Reasons
         users:
           list_users: Users
 
-        member_app_waiting_reasons:
-          submenu_title: "Waiting for Information reasons"
-          list_member_app_waiting_reasons: "All reasons"
-          new_member_app_waiting_reasons: "New reason"
+        administration:
+          submenu_title: Administration
 
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -431,6 +431,8 @@ en:
       name: *name
       phone_number: Phone Number
       email: Company email
+      main_address: Main Address
+      other_addresses: Other Addresses
       address: Address
       street: *street
       post_code: *post_code

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -42,6 +42,8 @@ sv:
 
   confirm_are_you_sure: &are_you_sure_confirm Är du säker
 
+  hello: Hallå, %{name}
+
   info:
     logged_in_as_admin: Du är inloggad som admin
     under_construction: Sidan är under uppbyggnad, mer information och funktioner kommer att komma efterhand.
@@ -712,7 +714,7 @@ sv:
         submit_button_label: Skapa användare
         success: Ett nytt konto har skapats
       edit:
-        title: Redigera användare
+        title: Redigera din profil
         unconfirmed_email_for: 'Obekräftad mailadress för: %{unconfirmed_email}'
         leave_blank_if_no_change: lämna tomt om du inte vill byta
         confirm_password: *confirm_password
@@ -806,7 +808,7 @@ sv:
         member_pages: *member_pages
         shf_meeting_minutes: *member_pages_board_meetings
         manage_company:
-          submenu_title: Hantera företag
+          submenu_title: Mitt företag
           view_company: Visa företagssida
           edit_company: Redigera företag
         my_application: *my_application
@@ -818,19 +820,21 @@ sv:
         manage_applications: Hantera ansökningar
         categories:
           submenu_title: Kategorier
-          list_categories: Lista kategorier
+          manage_categories: Hantera kategorier
           new_category: Ny kategori
         companies:
           submenu_title: Företag
-          list_companies: Lista företag
+          manage_companies: Hantera företag
           new_company: Nytt företag
+        applications:
+          submenu_title: *applications
+          manage_applications: Hantera ansökningar
+          waiting_reasons: "Väntar på information skäl"
         users:
           list_users: Användare
 
-        member_app_waiting_reasons:
-          submenu_title: "Orsaker"
-          list_member_app_waiting_reasons: "Alla orsaker"
-          new_member_app_waiting_reasons: "Ny orsak"
+        administration:
+          submenu_title: Administrering
 
 
   #----------

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -432,6 +432,8 @@ sv:
       phone_number: *company_phone
       email: &company_email Företagets e-postadress
       address: &address Adress
+      main_address: Huvudadress
+      other_addresses: Andra adresser
       street: *street
       post_code: *post_code
       city: *city

--- a/db/seed_helpers.rb
+++ b/db/seed_helpers.rb
@@ -44,7 +44,14 @@ module SeedHelper
   end
 
 
-  def make_applications(users, users_with_single_application, users_with_double_application)
+  def make_applications(users)
+
+    small_number_of_users = users.count < 3 ? 0 : [1, (0.1 * users.count).round].max
+
+    users_with_no_application = small_number_of_users
+    users_with_double_application = small_number_of_users
+
+    users_with_single_application = users.count - users_with_no_application - users_with_double_application
 
     users_with_application = users_with_single_application + users_with_double_application
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,10 +14,7 @@ SEED_STOP_MSG = '<<< SEEDING STOPPED' unless defined?(SEED_STOP_MSG)
 
 SEED_COMPLETE_MSG = '<<< SEEDING COMPLETED' unless defined?(SEED_COMPLETE_MSG)
 
-NUM_USERS = 100 unless defined?(NUM_USERS)
-
-NUM_USERS_WITH_SINGLE_APPLICATION =  80 unless defined?(NUM_USERS_WITH_SINGLE_APPLICATION)
-NUM_USERS_WITH_DOUBLE_APPLICATION = 20 unless defined?(NUM_USERS_WITH_DOUBLE_APPLICATION)
+SEED_USERS = 100 unless defined?(SEED_USERS)
 
 DEFAULT_PASSWORD = 'whatever' unless defined?(DEFAULT_PASSWORD)
 
@@ -70,8 +67,10 @@ if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_STAGING']
 
   puts 'Creating additional users ...'
 
+  number_of_users = (ENV['SHF_SEED_USERS'] || SEED_USERS).to_i
+
   users = {}
-  while users.length < NUM_USERS-1 do
+  while users.length < number_of_users-1 do
     email = FFaker::InternetSE.free_email
     first_name = FFaker::NameSE.first_name
     last_name = FFaker::NameSE.last_name
@@ -86,7 +85,7 @@ if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_STAGING']
   puts "  As companies are created for accepted applications, their address has to be geocoded/located."
   puts "  This takes time to do. Be patient. (You can look at the /log/development.log to be sure that things are happening and this is not stuck.)"
 
-  make_applications(users.values, NUM_USERS_WITH_SINGLE_APPLICATION, NUM_USERS_WITH_DOUBLE_APPLICATION)
+  make_applications(users.values)
 
   puts "\n  Membership applications created: #{MembershipApplication.count}"
   puts "  Membership Applications by state:"

--- a/features/landing_page_for_admin.feature
+++ b/features/landing_page_for_admin.feature
@@ -17,7 +17,6 @@ Feature: As an Admin
     Given I am logged in as "admin@shf.se"
     When I am on the "landing" page
     Then I should see t("admin.index.title")
-    And I should see t("info.logged_in_as_admin")
 
   Scenario: After login, User sees instructions about applying for membership
     Given I am logged in as "hans@bowsers.com"
@@ -37,4 +36,3 @@ Feature: As an Admin
     When I am on the "landing" page
     Then I should not see t("admin.index.title")
     And I should not see t("info.logged_in_as_admin")
-

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -71,7 +71,6 @@ Feature: As a registered user
     And I fill in t("activerecord.attributes.user.password") with "password"
     And I click on t("devise.sessions.new.log_in") button
     Then I should see t("devise.sessions.signed_in")
-    And I should see t("info.logged_in_as_admin")
 
 
   Scenario: Logging in as a member

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -223,14 +223,9 @@ Then(/^I should see translated error (.*) (.*)$/) do |model_attribute, error|
   expect(page).to have_content("#{i18n_content(model_attribute)} #{i18n_content(error)}")
 end
 
-Then(/^I should see t\("([^"]*)", member_full_name: '([^']*)'\)$/) do |i18n_key, name_value|
- expect(page).to have_content(I18n.t(i18n_key, member_full_name: name_value))
+And(/^I should see t\("([^"]*)", (\S*): '([^']*)'\)$/) do |i18n_key, attr_label, attr_value|
+  expect(page).to have_content(I18n.t(i18n_key, attr_label.to_sym => attr_value))
 end
-
-And(/^I should see t\("([^"]*)", filename: '([^']*)'\)$/) do |i18n_key, filename_value|
-  expect(page).to have_content(I18n.t(i18n_key, filename: filename_value))
-end
-
 
 And(/^I should see status line with status "([^"]*)" and date "([^"]*)"$/) do |status, date_string|
   expect(page).to have_content("#{status} - #{date_string}")
@@ -266,10 +261,6 @@ And(/^I should not see t\("([^"]*)", ([^:]*): "([^"]*)", ([^:]*): "([^"]*)"\)$/)
   expect(page).not_to have_content I18n.t("#{content}", key1.to_sym => value1, key2.to_sym => value2)
 end
 
-
-Then(/^I should see t\("([^"]*)", authentication_keys: '([^']*)'\)$/) do |error, auth_key|
-  expect(page).to have_content I18n.t("#{error}", authentication_keys: auth_key)
-end
 
 And(/^I should see (\d+) t\("([^"]*)"\)$/) do |n, content |
   n = n.to_i

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -82,11 +82,11 @@ And(/^I click the t\("([^"]*)"\) action for the row with "([^"]*)"$/) do |action
   find(:xpath, "//tr[contains(.,'#{row_content}')]/td/a", :text => "#{i18n_content(action)}").click
 end
 
-When(/^I click on "([^"]*)" link$/) do |element|
+When(/^I click on(?: the)? "([^"]*)" link$/) do |element|
   click_link element
 end
 
-And(/^I click on t\("([^"]*)"\) link$/) do |element|
+And(/^I click on(?: the)? t\("([^"]*)"\) link$/) do |element|
   click_link i18n_content("#{element}")
 end
 

--- a/features/user-applies-approved-edits-co.feature
+++ b/features/user-applies-approved-edits-co.feature
@@ -1,0 +1,67 @@
+Feature: Whole process of a new user creating a login, applying, being approved, editing their company
+  This exercises the entire process to ensure that data we are creating in the features and/or factories is not somehow masking any problems.
+
+  Background:
+    Given the following users exists
+      | email                | admin | is_member |
+      | new_user@example.com |       | false     |
+      | admin@shf.se         | true  | true      |
+
+    Given the following regions exist:
+      | name         |
+      | Stockholm    |
+      | Västerbotten |
+
+    Given the following kommuns exist:
+      | name     |
+      | Alingsås |
+
+    And the following business categories exist
+      | name         |
+      | Groomer      |
+      | Psychologist |
+
+
+  @admin, @user, @member
+  Scenario: User creates login, admin approves, user edits company, blank main address is displayed
+    Given I am logged in as "new_user@example.com"
+    And I am on the "landing" page
+    And I click on t("menus.nav.users.apply_for_membership")
+    And I fill in the translated form with data:
+      | membership_applications.new.first_name | membership_applications.new.last_name | membership_applications.new.company_number | membership_applications.new.phone_number | membership_applications.new.contact_email |
+      | NewUser1                               | NewLastName                           | 5562252998                                 | 031-1234567                              | new_user@example.com                      |
+    And I select "Groomer" Category
+    And I click on t("membership_applications.new.submit_button_label")
+    Then I should be on the landing page
+    And I should see t("membership_applications.create.success")
+    And I am logged out
+    And I am logged in as "admin@shf.se"
+    And I am on the "landing" page
+    And I click on t("menus.nav.admin.manage_applications")
+    Then I should see "NewUser1"
+    And I am on the application page for "new_user@example.com"
+    And I click on t("membership_applications.start_review_btn")
+    And I click on t("membership_applications.accept_btn")
+    And I should be on the edit application page for "new_user@example.com"
+    And I should see t("membership_applications.update.enter_member_number")
+    And I fill in t("membership_applications.show.membership_number") with "10101"
+    And I click on t("membership_applications.edit.submit_button_label")
+    Then I should see t("membership_applications.update.success")
+    And I should see t("membership_applications.accepted")
+    And I should see "10101"
+    And I am logged out
+    And I am logged in as "new_user@example.com"
+    And I am on the "landing" page
+    And I click on t("menus.nav.members.manage_company.edit_company")
+    Then I should see t("companies.edit.title", company_name: "")
+    And I should see t("companies.company_name")
+    And I should see t("companies.show.company_number")
+    And I should see t("companies.telephone_number")
+    And I should see t("companies.show.email")
+    And I should see t("companies.show.street")
+    And I should see t("companies.show.post_code")
+    And I should see t("companies.show.city")
+    And I should see t("companies.show.kommun")
+    And I should see t("companies.show.region")
+    And I should see t("companies.show.website")
+

--- a/features/user_profile/user-edits-profile.feature
+++ b/features/user_profile/user-edits-profile.feature
@@ -1,0 +1,65 @@
+Feature: As a registered user
+  I want to be able to edit my profile
+  Including my first name, last name, email and password
+
+  Background:
+    Given the following users exists
+      | email             | password | admin | is_member | first_name | last_name |
+      | admin@random.com  | password | true  | false     | emma       | admin     |
+      | member@random.com | password | false | true      | mary       | member    |
+      | user@random.com   | password | false | false     | ulysses    | user      |
+
+  Scenario: Admin edits profile
+    Given I am on the "landing" page
+    When I click on t("devise.sessions.new.log_in") link
+    Then I should be on "login" page
+    And I fill in t("activerecord.attributes.user.email") with "admin@random.com"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I click on t("devise.sessions.new.log_in") button
+    And I should see t("hello", name: 'emma')
+    Then I click on the t("devise.registrations.edit.title") link
+    And I fill in t("activerecord.attributes.user.first_name") with "NewEmma"
+    And I fill in t("activerecord.attributes.user.last_name") with "NewAdmin"
+    And I fill in t("devise.registrations.edit.current_password") with "password"
+    And I click on t("devise.registrations.edit.submit_button_label") button
+    And I should see t("hello", name: 'NewEmma')
+    Then I click on the t("devise.registrations.edit.title") link
+    And the t("activerecord.attributes.user.last_name") field should be set to "NewAdmin"
+    And I fill in t("activerecord.attributes.user.password") with "NewPassword"
+    And I fill in t("devise.registrations.edit.confirm_password") with "password"
+    And I fill in t("devise.registrations.edit.current_password") with "password"
+    And I click on t("devise.registrations.edit.submit_button_label") button
+    And I should see t("activerecord.errors.models.user.attributes.password_confirmation.confirmation")
+    Then I fill in t("activerecord.attributes.user.password") with "NewPassword"
+    And I fill in t("devise.registrations.edit.confirm_password") with "NewPassword"
+    And I fill in t("devise.registrations.edit.current_password") with "password"
+    And I click on t("devise.registrations.edit.submit_button_label") button
+    Then I should see t("devise.registrations.edit.success")
+
+  Scenario: Member edits profile
+    Given I am on the "landing" page
+    When I click on t("devise.sessions.new.log_in") link
+    Then I should be on "login" page
+    And I fill in t("activerecord.attributes.user.email") with "member@random.com"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I click on t("devise.sessions.new.log_in") button
+    And I should see t("hello", name: 'mary')
+    Then I click on the t("devise.registrations.edit.title") link
+    And I fill in t("activerecord.attributes.user.first_name") with "NewMary"
+    And I fill in t("devise.registrations.edit.current_password") with "password"
+    And I click on t("devise.registrations.edit.submit_button_label") button
+    And I should see t("hello", name: 'NewMary')
+
+  Scenario: User edits profile
+    Given I am on the "landing" page
+    When I click on t("devise.sessions.new.log_in") link
+    Then I should be on "login" page
+    And I fill in t("activerecord.attributes.user.email") with "user@random.com"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I click on t("devise.sessions.new.log_in") button
+    And I should see t("hello", name: 'ulysses')
+    Then I click on the t("devise.registrations.edit.title") link
+    And I fill in t("activerecord.attributes.user.first_name") with "NewUlysses"
+    And I fill in t("devise.registrations.edit.current_password") with "password"
+    And I click on t("devise.registrations.edit.submit_button_label") button
+    And I should see t("hello", name: 'NewUlysses')

--- a/spec/db/seed_development_spec.rb
+++ b/spec/db/seed_development_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe 'load business categories, regions, kommuns, users and membershipapplications from ENV in production' do
+
+  env_seed_users = 'SHF_SEED_USERS'
+
+  # seed with a minimum of 4 users to cover: admin, no application, single application, double application
+  seed_users = 4
+
+  before(:all) do
+    DatabaseCleaner.start
+    RSpec::Mocks.with_temporary_scope do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('development'))
+      stub_const('ENV', {env_seed_users => seed_users.to_s})
+      SHFProject::Application.load_tasks
+      SHFProject::Application.load_seed
+    end
+  end
+
+  after(:all) do
+    DatabaseCleaner.clean
+    Rake::Task['shf:load_regions'].reenable
+    Rake::Task['shf:load_kommuns'].reenable
+  end
+
+  it "business categories are in the db" do
+    expect(BusinessCategory.all.size).to eq(11)
+  end
+
+  it "regions are in the db" do
+    expect(Region.all.size).to eq(23)
+  end
+
+  it "kommuns are in the db" do
+    expect(Kommun.all.size).to eq(290)
+  end
+
+  it "users are in the db" do
+    expect(User.all.size).to eq(seed_users)
+  end
+
+  it "addresses are in the db" do
+    expect(Address.all.size).to eq(seed_users-1)
+  end
+
+  it "companies are in the db" do
+    expect(Company.all.size).to eq(seed_users-1)
+  end
+
+  it "memberships applications are in the db" do
+    expect(MembershipApplication.all.size).to eq(seed_users-1)
+  end
+
+end

--- a/spec/db/seed_production_spec.rb
+++ b/spec/db/seed_production_spec.rb
@@ -13,12 +13,19 @@ RSpec.describe 'load admin.email, admin.password, business categories, regions a
   describe 'happy path - all is valid' do
 
     before(:all) do
+      DatabaseCleaner.start
       RSpec::Mocks.with_temporary_scope do
         allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
         stub_const('ENV', {env_shf_email => admin_email, env_shf_pwd => admin_pwd})
         SHFProject::Application.load_tasks
         SHFProject::Application.load_seed
       end
+    end
+
+    after(:all) do
+      DatabaseCleaner.clean
+      Rake::Task['shf:load_regions'].reenable
+      Rake::Task['shf:load_kommuns'].reenable
     end
 
     let(:admin_in_db) { User.find_by_email(admin_email) }

--- a/spec/helpers/companies_helper_spec.rb
+++ b/spec/helpers/companies_helper_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe CompaniesHelper, type: :helper do
     end
 
     before(:all) do
-      Company.delete_all
-      MembershipApplication.delete_all
-      User.delete_all
+      expect(Company.count).to eq(0)
+      expect(MembershipApplication.count).to eq(0)
+      expect(User.count).to eq(0)
     end
 
     it '#last_category_name' do

--- a/spec/helpers/membership_applications_helper_spec.rb
+++ b/spec/helpers/membership_applications_helper_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe MembershipApplicationsHelper, type: :helper do
 
   before(:all) do
     # ensure MembershipAppWaitingReason.all is empty
-    AdminOnly::MemberAppWaitingReason.delete_all
+    expect(AdminOnly::MemberAppWaitingReason.count).to be(0)
   end
 
 

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -171,9 +171,19 @@ RSpec.describe Company, type: :model do
 
   describe '#main_address' do
 
-    let(:company) { create(:company, num_addresses: 3) }
+    it 'creates a blank address if none exists' do
+      company = create(:company, num_addresses: 0)
+
+      expect(company.addresses.count).to eq 0
+
+      # calling .main_address should instantiate an Address
+      expect(company.main_address).to be_an_instance_of Address
+      expect(company.addresses.count).to eq 1
+
+    end
 
     it 'returns the first address for the company' do
+      company = create(:company, num_addresses: 3)
       expect(company.addresses.count).to eq 3
       expect(company.main_address).to eq(company.addresses.first)
     end
@@ -188,7 +198,7 @@ RSpec.describe Company, type: :model do
 
       company.addresses.delete_all
 
-      expected_str = AddressExporter.se_mailing_csv_str(nil)
+      expected_str = AddressExporter.se_mailing_csv_str(Address.new)
 
       expect(company.se_mailing_csv_str).to eq expected_str
 

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -141,9 +141,9 @@ RSpec.describe Company, type: :model do
     end
 
     before(:all) do
-      Company.delete_all
-      MembershipApplication.delete_all
-      User.delete_all
+      expect(Company.count).to eq(0)
+      expect(MembershipApplication.count).to eq(0)
+      expect(User.count).to eq(0)
     end
 
     it '3 employees, each with 1 unique category' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
 
   before(:all) do
-    BusinessCategory.delete_all
-    Company.delete_all
-    MembershipApplication.delete_all
-    User.delete_all
+    expect(BusinessCategory.count).to eq(0)
+    expect(Company.count).to eq(0)
+    expect(MembershipApplication.count).to eq(0)
+    expect(User.count).to eq(0)
   end
 
   describe 'Factory' do

--- a/spec/views/application/_navigation.html.haml_spec.rb
+++ b/spec/views/application/_navigation.html.haml_spec.rb
@@ -66,8 +66,7 @@ RSpec.describe 'companies/index' do
 
       it 'renders default menu link == view-my-company' do
         text = t('menus.nav.members.manage_company.submenu_title')
-        expect(rendered)
-          .to match %r{<a href=\"\/hundforetag\/#{cmpy_id}\">#{text}}
+        expect(rendered).to match %r{<a href=\"\/hundforetag\/#{cmpy_id}\">#{text}}
       end
 
       it 'renders view-my-company link' do
@@ -80,6 +79,20 @@ RSpec.describe 'companies/index' do
         text = t('menus.nav.members.manage_company.edit_company')
         expect(rendered)
           .to match %r{<a href=\"\/hundforetag\/#{cmpy_id}\/redigera\">#{text}}
+      end
+    end
+
+    context 'logged-in menu' do
+      it 'renders logged-in greeting' do
+        expect(rendered).to match %r{#{t('hello', name: member.first_name)}}
+      end
+
+      it 'renders log-off link' do
+        expect(rendered).to match %r{#{t('devise.sessions.destroy.log_out')}}
+      end
+
+      it 'renders edit-profile link' do
+        expect(rendered).to match %r{#{t('devise.registrations.edit.title')}}
       end
     end
   end
@@ -111,6 +124,22 @@ RSpec.describe 'companies/index' do
       text = t('menus.nav.users.my_application')
       expect(rendered).to match %r{<a href=\"\/ansokan\/#{user_app_id}\/redigera\">#{text}}
     end
+
+    context 'logged-in menu' do
+      it 'renders logged-in greeting' do
+        expect(rendered).to match %r{#{t('hello', name: user.first_name)}}
+      end
+
+      it 'renders log-off link' do
+        text = t('devise.sessions.destroy.log_out')
+        expect(rendered).to match %r{<a.*href=\"\/users\/sign_out\">#{text}}
+      end
+
+      it 'renders edit-profile link' do
+        text = t('devise.registrations.edit.title')
+        expect(rendered).to match %r{<a.*href=\"\/users\/edit\">#{text}}
+      end
+    end
   end
 
 
@@ -141,20 +170,34 @@ RSpec.describe 'companies/index' do
       expect(rendered).to match %r{<a href=\"#{shf_site}\">#{text}}
     end
 
-    it 'renders link to manage applications' do
-      text = t('menus.nav.admin.manage_applications')
-      expect(rendered).to match %r{<a href=\"\/ansokan\">#{text}}
+    context 'membership applications' do
+
+      it 'renders submenu title' do
+        text = t('menus.nav.admin.applications.submenu_title')
+        expect(rendered).to match %r{#{text}}
+      end
+
+      it 'renders manage-applications link' do
+        text = t('menus.nav.admin.applications.manage_applications')
+        expect(rendered).to match %r{<a href=\"\/ansokan\">#{text}}
+      end
+
+      it 'renders waiting-reasons link' do
+        text = t('menus.nav.admin.applications.waiting_reasons')
+        expect(rendered).to match %r{<a href=\"\/admin\/member_app_waiting_reasons\">#{text}}
+      end
+
     end
 
     context 'business categories' do
 
-      it 'renders default menu link == list categories' do
+      it 'renders submenu title' do
         text = t('menus.nav.admin.categories.submenu_title')
-        expect(rendered).to match %r{<a href=\"\/kategori\">#{text}}
+        expect(rendered).to match %r{#{text}}
       end
 
-      it 'renders list-categories link' do
-        text = t('menus.nav.admin.categories.list_categories')
+      it 'renders manage-categories link' do
+        text = t('menus.nav.admin.categories.manage_categories')
         expect(rendered).to match %r{<a href=\"\/kategori\">#{text}}
       end
 
@@ -166,13 +209,13 @@ RSpec.describe 'companies/index' do
 
     context 'companies' do
 
-      it 'renders default menu link == list companies' do
+      it 'renders submenu title' do
         text = t('menus.nav.admin.companies.submenu_title')
-        expect(rendered).to match %r{<a href=\"\/hundforetag\">#{text}}
+        expect(rendered).to match %r{#{text}}
       end
 
-      it 'renders list-companies link' do
-        text = t('menus.nav.admin.companies.list_companies')
+      it 'renders manage-companies link' do
+        text = t('menus.nav.admin.companies.manage_companies')
         expect(rendered).to match %r{<a href=\"\/hundforetag\">#{text}}
       end
 
@@ -187,26 +230,20 @@ RSpec.describe 'companies/index' do
       expect(rendered).to match %r{<a href=\"\/anvandare\">#{text}}
     end
 
-    context 'waiting-for-info-reasons menu' do
-
-      it 'renders default menu link == all-reasons list' do
-        text = t('menus.nav.admin.member_app_waiting_reasons.submenu_title')
-        expect(rendered)
-          .to match %r{<a href=\"\/admin\/member_app_waiting_reasons">#{text}}
+    context 'logged-in menu' do
+      it 'renders logged-in greeting' do
+        expect(rendered).to match %r{#{t('hello', name: admin.first_name)}}
       end
 
-      it 'renders all-reasons link' do
-        text = t('menus.nav.admin.member_app_waiting_reasons.list_member_app_waiting_reasons')
-        expect(rendered)
-          .to match %r{<a href=\"\/admin\/member_app_waiting_reasons">#{text}}
+      it 'renders log-off link' do
+        expect(rendered).to match %r{#{t('devise.sessions.destroy.log_out')}}
       end
 
-      it 'renders new-reason link' do
-        text = t('menus.nav.admin.member_app_waiting_reasons.new_member_app_waiting_reasons')
-        expect(rendered)
-          .to match %r{<a href=\"\/admin\/member_app_waiting_reasons\/new">#{text}}
+      it 'renders edit-profile link' do
+        expect(rendered).to match %r{#{t('devise.registrations.edit.title')}}
       end
     end
+
   end
 
   describe 'visitor' do
@@ -265,9 +302,8 @@ RSpec.describe 'companies/index' do
       end
 
       it 'renders being-dog-owners link' do
-        text = t('menus.nav.visitor.dog_owners.being_dog_owners')
-        expect(rendered)
-          .to match %r{<a href=\"#{shf_site}agare\/att-vara-hundagare\/\">#{text}}
+        text = t('menus.nav.visitor.find_dog_businesses')
+        expect(rendered).to match %r{<a href=\"\/">#{text}}
       end
     end
 
@@ -325,7 +361,7 @@ RSpec.describe 'companies/index' do
 
       it 'renders menu link to empty anchor' do
         text = t('menus.nav.visitor.knowledge_bank.submenu_title')
-        expect(rendered).to match %r{<a href=\"\#\">#{text}}
+        expect(rendered).to match %r{<a.*href=\'\#\'>#{text}}
       end
 
       it 'renders Bloggar link' do
@@ -369,9 +405,9 @@ RSpec.describe 'companies/index' do
       expect(rendered).to match %r{<a href=\"#{shf_site}kontakt\/\">#{text}}
     end
 
-    it 'renders find-dog-company link' do
-      text = t('menus.nav.visitor.find_dog_businesses')
-      expect(rendered).to match %r{<a href=\"\/\">#{text}}
+    it 'renders log-in link' do
+      text = t('devise.sessions.new.log_in')
+      expect(rendered).to match %r{<a .* href=\"\/users\/sign_in">#{text}}
     end
   end
 end


### PR DESCRIPTION
PT Story:  New Member: editing their company -address fields not shown
https://www.pivotaltracker.com/story/show/148622121

When a newly approved member went to edit his/her company page, the address fields were not being shown because no address was instantiated. 

## Changes proposed in this pull request:
1.  Created a feature that goes through the entire process of a user applying for membership, an admin approving it, and the user (now a member) logging in and editing their company information.   (We didn't have a feature that went through the entire process, so this error was not being caught. )
1.  `kommun` is optional for an Address (since when the admin approves the application and the company is created, we need to have a `main_address,` but the kommun might not be known at that point.  [Otherwise we'll need to have a default kommun to assign to new, empty addresses.]
2.  Company.`main_address` will instantiate an Address when called
3.  Pull 'address' part of the company form view into a partial (first step toward being able to show multiple addresses

Ready for review:
@thesuss @RobertCram @patmbolger 
