### PR TITLE
Consolidate cucumber steps

### DIFF
--- a/features/admin_creates_company.feature
+++ b/features/admin_creates_company.feature
@@ -117,13 +117,13 @@ Feature: As an admin
       | <name>                 | <org_number>                  | <email>              | <phone>                    | <street>              | <post_code>              | <city>              | <website>                      |
     And I select "<region>" in select list t("companies.operations_region")
     When I click on t("submit")
-    Then I should see translated error <model_attribute> <error>
+    Then I should see error <model_attribute> <error>
     And I should see t("companies.update.error")
 
     Scenarios:
-      | name        | org_number | phone | street         | post_code | city   | region     | email        | website                   | model_attribute                       | error                   |
-      | Happy Mutts | 5560360793 |       | Ålstensgatan 4 | 123 45    | Bromma | Stockholm  | kickiimmi.nu | http://www.gladajyckar.se | activerecord.attributes.company.email | errors.messages.invalid |
-      | Happy Mutts | 5560360793 |       | Ålstensgatan 4 | 123 45    | Bromma | Norrbotten | kicki@imminu | http://www.gladajyckar.se | activerecord.attributes.company.email | errors.messages.invalid |
+      | name        | org_number | phone | street         | post_code | city   | region     | email        | website                   | model_attribute                            | error                        |
+      | Happy Mutts | 5560360793 |       | Ålstensgatan 4 | 123 45    | Bromma | Stockholm  | kickiimmi.nu | http://www.gladajyckar.se | t("activerecord.attributes.company.email") | t("errors.messages.invalid") |
+      | Happy Mutts | 5560360793 |       | Ålstensgatan 4 | 123 45    | Bromma | Norrbotten | kicki@imminu | http://www.gladajyckar.se | t("activerecord.attributes.company.email") | t("errors.messages.invalid") |
 
 
   Scenario Outline: Admin edits a company: company number is wrong length

--- a/features/approve-member.feature
+++ b/features/approve-member.feature
@@ -40,7 +40,7 @@ Feature: As an admin
   Scenario: Admin approves, no company exists so one is created
     Given I am on "emma@happymutts.se" application page
     When I click on t("membership_applications.accept_btn")
-    And I should be on the edit application page for "emma@happymutts.se"
+    And I should be on the "edit application" page for "emma@happymutts.se"
     And I should see t("membership_applications.accept.success")
     And I should see t("membership_applications.update.enter_member_number")
     And I fill in t("membership_applications.show.membership_number") with "901"
@@ -54,7 +54,7 @@ Feature: As an admin
   Scenario: Admin approves, member is added to existing company
     Given I am on "anna@nosnarkybarky.se" application page
     When I click on t("membership_applications.accept_btn")
-    And I should be on the edit application page for "anna@nosnarkybarky.se"
+    And I should be on the "edit application" page for "anna@nosnarkybarky.se"
     And I should see t("membership_applications.update.enter_member_number")
     And I fill in t("membership_applications.show.membership_number") with "902"
     And I click on t("membership_applications.edit.submit_button_label")
@@ -79,7 +79,7 @@ Feature: As an admin
   Scenario: Admin approves, but then rejects it
     Given I am on "emma@happymutts.se" application page
     When I click on t("membership_applications.accept_btn")
-    And I should be on the edit application page for "emma@happymutts.se"
+    And I should be on the "edit application" page for "emma@happymutts.se"
     And I should see t("membership_applications.update.enter_member_number")
     And I fill in t("membership_applications.show.membership_number") with "901"
     And I click on t("membership_applications.edit.submit_button_label")

--- a/features/create_account.feature
+++ b/features/create_account.feature
@@ -24,7 +24,7 @@ Feature: As a visitor
     And I fill in t("activerecord.attributes.user.password") with "password"
     And I fill in t("devise.registrations.new.confirm_password") with "password"
     And I click on t("devise.registrations.new.submit_button_label")
-    Then I should see translated error activerecord.attributes.user.first_name errors.messages.blank
+    Then I should see error t("activerecord.attributes.user.first_name") t("errors.messages.blank")
     And I should not see t("devise.registrations.new.success")
     When I am on the "edit registration for a user" page
     Then I should be on the "login" page
@@ -36,7 +36,7 @@ Feature: As a visitor
     And I fill in t("activerecord.attributes.user.password") with "password"
     And I fill in t("devise.registrations.new.confirm_password") with "password"
     And I click on t("devise.registrations.new.submit_button_label")
-    Then I should see translated error activerecord.attributes.user.last_name errors.messages.blank
+    Then I should see error t("activerecord.attributes.user.last_name") t("errors.messages.blank")
     And I should not see t("devise.registrations.new.success")
     When I am on the "edit registration for a user" page
     Then I should be on the "login" page

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -31,7 +31,7 @@ Feature: As a user
       | Kicki                                  | Andersson                             | 5562252998                                 | 031-1234567                              | info@craft.se                             |
     And I select "Groomer" Category
     And I click on t("membership_applications.new.submit_button_label")
-    Then I should be on the landing page
+    Then I should be on the "landing" page
     And I should see t("membership_applications.create.success")
     When I click on t("menus.nav.users.my_application")
     Then the t("membership_applications.new.first_name") field should be set to "Kicki"
@@ -47,7 +47,7 @@ Feature: As a user
     And I select "Trainer" Category
     And I select "Psychologist" Category
     And I click on t("membership_applications.new.submit_button_label")
-    Then I should be on the landing page
+    Then I should be on the "landing" page
     And I should see t("membership_applications.create.success")
 
 
@@ -58,7 +58,7 @@ Feature: As a user
       | membership_applications.new.first_name | membership_applications.new.last_name | membership_applications.new.company_number | membership_applications.new.phone_number | membership_applications.new.contact_email |
       | Kicki                                  | Andersson                             | 5562252998                                 | 031-1234567                              | info@craft.se                             |
     And I click on t("membership_applications.new.submit_button_label")
-    Then I should be on the landing page
+    Then I should be on the "landing" page
     And I should see t("membership_applications.create.success")
 
 
@@ -87,16 +87,16 @@ Feature: As a user
       | <f_name>                               | <l_name>                              | <c_number>                                 | <c_email>                                 | <phone>                                  |
 
     When I click on t("membership_applications.new.submit_button_label")
-    Then I should see translated error <model_attribute> <error>
+    Then I should see error <model_attribute> <error>
 
     Scenarios:
-      | f_name | c_number   | l_name    | c_email       | phone      | model_attribute                                               | error                   |
-      | Kicki  |            | Andersson | kicki@immi.nu | 0706898525 | activerecord.attributes.membership_application.company_number | errors.messages.blank   |
-      | Kicki  | 5562252998 |           | kicki@immi.nu | 0706898525 | activerecord.attributes.membership_application.last_name      | errors.messages.blank   |
-      | Kicki  | 5562252998 | Andersson |               | 0706898525 | activerecord.attributes.membership_application.contact_email  | errors.messages.blank   |
-      |        | 5562252998 | Andersson | kicki@immi.nu | 0706898525 | activerecord.attributes.membership_application.first_name     | errors.messages.blank   |
-      | Kicki  | 5562252998 | Andersson | kicki@imminu  | 0706898525 | activerecord.attributes.membership_application.contact_email  | errors.messages.invalid |
-      | Kicki  | 5562252998 | Andersson | kickiimmi.nu  | 0706898525 | activerecord.attributes.membership_application.contact_email  | errors.messages.invalid |
+      | f_name | c_number   | l_name    | c_email       | phone      | model_attribute                                                    | error                        |
+      | Kicki  |            | Andersson | kicki@immi.nu | 0706898525 | t("activerecord.attributes.membership_application.company_number") | t("errors.messages.blank")   |
+      | Kicki  | 5562252998 |           | kicki@immi.nu | 0706898525 | t("activerecord.attributes.membership_application.last_name")      | t("errors.messages.blank")   |
+      | Kicki  | 5562252998 | Andersson |               | 0706898525 | t("activerecord.attributes.membership_application.contact_email")  | t("errors.messages.blank")   |
+      |        | 5562252998 | Andersson | kicki@immi.nu | 0706898525 | t("activerecord.attributes.membership_application.first_name")     | t("errors.messages.blank")   |
+      | Kicki  | 5562252998 | Andersson | kicki@imminu  | 0706898525 | t("activerecord.attributes.membership_application.contact_email")  | t("errors.messages.invalid") |
+      | Kicki  | 5562252998 | Andersson | kickiimmi.nu  | 0706898525 | t("activerecord.attributes.membership_application.contact_email")  | t("errors.messages.invalid") |
 
 
   Scenario Outline: Apply for membership: company number wrong length

--- a/features/delete_membership_application.feature
+++ b/features/delete_membership_application.feature
@@ -46,27 +46,27 @@ Feature: As an admin
 
   Scenario: Admin should see the 'delete' button
     Given I am logged in as "admin@shf.se"
-    And I am on the application page for "emma@random.com"
+    And I am on the "application" page for "emma@random.com"
     Then I should not see t("errors.not_permitted")
     And I should see t("membership_applications.show.delete")
 
 
   Scenario: Member should not see the 'delete' button on their own application
     Given I am logged in as "emma@random.com"
-    And I am on the application page for "emma@random.com"
+    And I am on the "application" page for "emma@random.com"
     Then I should not see t("errors.not_permitted")
     And I should not see t("membership_applications.show.delete")
 
   Scenario: Visitor should not see the 'delete' button
     Given I am Logged out
-    And I am on the application page for "emma@random.com"
+    And I am on the "application" page for "emma@random.com"
     Then I should see t("errors.not_permitted")
     And I should not see t("membership_applications.show.delete")
 
 
   Scenario: Admin wants to delete a membership application
     Given I am logged in as "admin@shf.se"
-    And I am on the application page for "emma@random.com"
+    And I am on the "application" page for "emma@random.com"
     And I click on t("membership_applications.show.delete")
     Then I should see t("membership_applications.application_deleted")
     And I should not see "Emma"
@@ -74,7 +74,7 @@ Feature: As an admin
 
   Scenario: Admin deletes a membership application; company should still exist (has another application assoc.)
     Given I am logged in as "admin@shf.se"
-    And I am on the application page for "hans@bowsers.com"
+    And I am on the "application" page for "hans@bowsers.com"
     And I click on t("membership_applications.show.delete")
     Then I should see t("membership_applications.application_deleted")
     And I should not see "Hans"
@@ -87,7 +87,7 @@ Feature: As an admin
     And I am on the "all companies" page
     Then I should see "3" companies
     And I should see "WOOF"
-    And I am on the application page for "wils@woof.com"
+    And I am on the "application" page for "wils@woof.com"
     And I click on t("membership_applications.show.delete")
     Then I should see t("membership_applications.application_deleted")
     And I should not see "Wils"

--- a/features/edit_account.feature
+++ b/features/edit_account.feature
@@ -31,7 +31,7 @@ Feature: As a registered user
     When I fill in t("activerecord.attributes.user.first_name") with ""
     And I fill in t("devise.registrations.edit.current_password") with "password"
     And I click on t("devise.registrations.edit.submit_button_label")
-    Then I should see translated error activerecord.attributes.user.first_name errors.messages.blank
+    Then I should see error t("activerecord.attributes.user.first_name") t("errors.messages.blank")
     And I should not see t("devise.registrations.edit.success")
     When I am on the "edit registration for a user" page
     Then the t("activerecord.attributes.user.first_name") field should be set to "emma"
@@ -44,7 +44,7 @@ Feature: As a registered user
     When I fill in t("activerecord.attributes.user.last_name") with ""
     And I fill in t("devise.registrations.edit.current_password") with "password"
     And I click on t("devise.registrations.edit.submit_button_label")
-    Then I should see translated error activerecord.attributes.user.last_name errors.messages.blank
+    Then I should see error t("activerecord.attributes.user.last_name") t("errors.messages.blank")
     And I should not see t("devise.registrations.edit.success")
     When I am on the "edit registration for a user" page
     Then the t("activerecord.attributes.user.last_name") field should be set to "andersson"

--- a/features/edit_business_category.feature
+++ b/features/edit_business_category.feature
@@ -37,7 +37,7 @@ Feature: As an admin
     Then I should see t("business_categories.edit.title", category_name: "dog crooning")
     And I fill in t("activerecord.attributes.business_category.name") with ""
     And I click on t("business_categories.edit.submit_button_label")
-    Then I should see translated error activerecord.attributes.business_category.name errors.messages.blank
+    Then I should see error t("activerecord.attributes.business_category.name") t("errors.messages.blank")
 
   Scenario: A non-admin user cannot edit business categories
     Given I am logged in as "applicant_1@random.com"

--- a/features/edit_membership_application.feature
+++ b/features/edit_membership_application.feature
@@ -29,7 +29,7 @@ Feature: As an applicant
     And I fill in t("membership_applications.show.first_name") with "Anna"
     And I click on t("membership_applications.edit.submit_button_label")
     Then I should see t("membership_applications.update.success")
-    And I should be on the application page for "emma@random.com"
+    And I should be on the "application" page for "emma@random.com"
     And I should see "Anna Lastname"
 
   Scenario: Applicant makes mistake when editing his own application
@@ -41,7 +41,7 @@ Feature: As an applicant
     And I fill in t("membership_applications.show.company_number") with ""
     And I click on t("membership_applications.edit.submit_button_label")
     Then I should see t("membership_applications.update.error")
-    And I should see translated error membership_applications.show.company_number errors.messages.blank
+    And I should see error t("membership_applications.show.company_number") t("errors.messages.blank")
     And I should see button t("membership_applications.edit.submit_button_label")
 
   Scenario: Applicant can not edit applications not created by him

--- a/features/list_companies_of_category.feature
+++ b/features/list_companies_of_category.feature
@@ -4,13 +4,6 @@ Feature: As any type of visitor
   PT: https://www.pivotaltracker.com/story/show/135684057
 
   Background:
-#    Given the following users exists
-#      | email               | admin | is_member |
-#      | emma@happymutts.com |       | true      |
-#      | ernt@mutts.com      |       | true      |
-#      | anna@sadmutts.com   |       | true      |
-#      | admin@shf.se        | true  | true      |
-
     Given the following users exists
       | email               | admin |
       | emma@happymutts.com |       |

--- a/features/list_companies_of_category.feature
+++ b/features/list_companies_of_category.feature
@@ -4,12 +4,19 @@ Feature: As any type of visitor
   PT: https://www.pivotaltracker.com/story/show/135684057
 
   Background:
+#    Given the following users exists
+#      | email               | admin | is_member |
+#      | emma@happymutts.com |       | true      |
+#      | ernt@mutts.com      |       | true      |
+#      | anna@sadmutts.com   |       | true      |
+#      | admin@shf.se        | true  | true      |
+
     Given the following users exists
-      | email               | admin | is_member |
-      | emma@happymutts.com |       | true      |
-      | ernt@mutts.com      |       | true      |
-      | anna@sadmutts.com   |       | true      |
-      | admin@shf.se        | true  | true      |
+      | email               | admin |
+      | emma@happymutts.com |       |
+      | ernt@mutts.com      |       |
+      | anna@sadmutts.com   |       |
+      | admin@shf.se        | true  |
 
     Given the following regions exist:
       | name         |

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -35,13 +35,13 @@ Feature: As a registered user
 
   Scenario: No input of email
     Given I am on the "login" page
-    When I leave the t("activerecord.attributes.user.password") field empty
+    And I fill in t("activerecord.attributes.user.password") with "password"
     And I click on t("devise.sessions.new.log_in") button
     Then I should see t("devise.failure.invalid", authentication_keys: 'Email')
 
   Scenario: No input of password
     Given I am on the "login" page
-    When I leave the t("activerecord.attributes.user.password") field empty
+    When I fill in t("activerecord.attributes.user.email") with "emma@random.com"
     And I click on t("devise.sessions.new.log_in") button
     Then I should see t("devise.failure.invalid", authentication_keys: 'Email')
 

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -58,7 +58,7 @@ Feature: As a registered user
     And I fill in t("activerecord.attributes.user.password") with "password"
     And I click on t("devise.sessions.new.log_in") button
     Then I should see t("devise.failure.invalid", authentication_keys: 'Email')
-    When I fail to visit the "applications index" page
+    When I fail to visit the "membership applications" page
     Then I should see t("errors.not_permitted")
     And I should be on "landing" page
 

--- a/features/member_edits_company_page.feature
+++ b/features/member_edits_company_page.feature
@@ -60,12 +60,12 @@ Feature: As a member
     And I am Logged out
     And I am logged in as "applicant_2@random.com"
     And I am on the "edit my company" page for "emma@happymutts.com"
-    Then I should be on the landing page
+    Then I should be on the "landing" page
     And I should see t("errors.not_permitted")
 
 
   Scenario: User tries to go do company page (gets rerouted)
     Given I am logged in as "applicant_2@random.com"
     And I am on the "edit my company" page for "emma@happymutts.com"
-    Then I should be on the landing page
+    Then I should be on the "landing" page
     And I should see t("errors.not_permitted")

--- a/features/membership-application-status/admin-manage-reasons-waiting-for-info.feature
+++ b/features/membership-application-status/admin-manage-reasons-waiting-for-info.feature
@@ -189,7 +189,7 @@ Feature: Admin manages the list of reasons why SHF is waiting for info from an a
     And I should see "name 2"
     And I click on t("delete")
     Then I should see t("admin_only.member_app_waiting_reasons.destroy.success")
-    And I should be on the all member app waiting reasons page
+    And I should be on the "all member app waiting reasons" page
     And I should see 1 reasons listed
     And I should not see "namn 2"
 

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -109,6 +109,6 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
   @javascript @member
   Scenario: owner cannot see the fields for changing the reason
     Given I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
-    And I am on the application page for "anna_waiting_for_info@nosnarkybarky.se"
+    And I am on the "application" page for "anna_waiting_for_info@nosnarkybarky.se"
     Then I should not see t("membership_applications.need_info.reason_title")
 

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -45,7 +45,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
   @javascript @admin
   Scenario: Admin selects 'need more documentation' as the reason SHF is waiting_for_applicant
     Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
-    When I set "member_app_waiting_reasons" to "need doc"
+    When I select "need doc" in select list "member_app_waiting_reasons"
     Then "member_app_waiting_reasons" should have "need doc" selected
     And I am on the list applications page
     And I am on "anna_waiting_for_info@nosnarkybarky.se" application page
@@ -54,7 +54,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
   @javascript @admin
   Scenario: Admin selects 'waiting for payment' as the reason SHF is waiting_for_applicant
     Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
-    When I set "member_app_waiting_reasons" to "waiting for payment"
+    When I select "waiting for payment" in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
     And I am on the list applications page
     And I am on "anna_waiting_for_info@nosnarkybarky.se" application page
@@ -64,7 +64,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
   @javascript @admin
   Scenario: Admin selects 'other' and enters text as the reason SHF is waiting_for_applicant
     Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
-    When I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
+    When I select t("admin_only.member_app_waiting_reasons.other_custom_reason") in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
     When I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
@@ -79,12 +79,12 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
   @javascript @admin
   Scenario: Admin selects 'other' and fills in custom text but then changes reason to something else
     Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
-    When I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
+    When I select t("admin_only.member_app_waiting_reasons.other_custom_reason") in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
     And I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
     And I wait for all ajax requests to complete
-    And I set "member_app_waiting_reasons" to "waiting for payment"
+    And I select "waiting for payment" in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
     And I am on the list applications page
     And I am on "anna_waiting_for_info@nosnarkybarky.se" application page
@@ -94,14 +94,14 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
   @javascript @admin
   Scenario: When selected reason is not 'custom other,' the custom text is saved as blank (empty string)
     Given I am on "anna_waiting_for_info@nosnarkybarky.se" application page
-    When I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
+    When I select t("admin_only.member_app_waiting_reasons.other_custom_reason") in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
     And I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
-    And I set "member_app_waiting_reasons" to "need doc"
+    And I select "need doc" in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
     # change back so the custom reason field shows. it should be blank
-    And I set "member_app_waiting_reasons" to t("admin_only.member_app_waiting_reasons.other_custom_reason")
+    And I select t("admin_only.member_app_waiting_reasons.other_custom_reason") in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
     Then I should not see "This is my reason"
 

--- a/features/show_membership_application.feature
+++ b/features/show_membership_application.feature
@@ -58,7 +58,7 @@ Feature: As an Admin
     And I should see 3 t("membership_applications.waiting_for_applicant")
     And I should see 1 t("membership_applications.rejected")
     And I click on "Lastname, Emma"
-    Then I should be on the application page for "emma@personal.com"
+    Then I should be on the "application" page for "emma@personal.com"
     And I should see "Emma Lastname"
     And I should see "5562252998"
     And I should see status line with status t("membership_applications.waiting_for_applicant")
@@ -70,7 +70,7 @@ Feature: As an Admin
     And I am on the list applications page
     Then I should see "7" applications
     And I click on "Lastname, Hans"
-    Then I should be on the application page for "hans@random.com"
+    Then I should be on the "application" page for "hans@random.com"
     And I should see "Hans Lastname"
     And I should see "5560360793"
     And I should see t("membership_applications.new_status")
@@ -91,7 +91,7 @@ Feature: As an Admin
     And I am on the list applications page
     Then I should see "7" applications
     And I click on "Lastname, Emma"
-    Then I should be on the application page for "emma@personal.com"
+    Then I should be on the "application" page for "emma@personal.com"
     And I should see "Emma Lastname"
     And I should see "5562252998"
     And I should see "Trainer"
@@ -117,10 +117,10 @@ Feature: As an Admin
   @admin
   Scenario: Clicking the edit button on show page
     Given I am logged in as "admin@shf.com"
-    When I am on the application page for "nils_member@bowwowwow.se"
+    When I am on the "application" page for "nils_member@bowwowwow.se"
     Then I should see t("membership_applications.accepted")
     And I click on t("membership_applications.edit_membership_application")
-    Then I should be on the edit application page for "nils_member@bowwowwow.se"
+    Then I should be on the "edit application" page for "nils_member@bowwowwow.se"
 
   @user
   Scenario: User does not see edit-link
@@ -133,24 +133,24 @@ Feature: As an Admin
   @admin
   Scenario: Admin sees business categories for user under_review
     Given I am logged in as "admin@shf.se"
-    When I am on the application page for "emma_under_review@happymutts.se"
+    When I am on the "application" page for "emma_under_review@happymutts.se"
     Then I should see "rehab"
 
   @admin
   Scenario: Admin sees business categories for user that is ready_for_review
     Given I am logged in as "admin@shf.se"
-    When I am on the application page for "hans_ready_for_review@happymutts.se"
+    When I am on the "application" page for "hans_ready_for_review@happymutts.se"
     Then I should see "dog grooming"
 
   @admin
   Scenario: Admin sees business categories for user that is waiting_for_applicant
     Given I am logged in as "admin@shf.se"
-    When I am on the application page for "emma@personal.com"
+    When I am on the "application" page for "emma@personal.com"
     Then I should see "Psychologist"
 
 
   @admin
   Scenario: Admin sees business categories for user that is accepted
     Given I am logged in as "admin@shf.se"
-    When I am on the application page for "nils_member@bowwowwow.se"
+    When I am on the "application" page for "nils_member@bowwowwow.se"
     Then I should see "Groomer"

--- a/features/size_validation.feature
+++ b/features/size_validation.feature
@@ -62,8 +62,8 @@ Feature: As an applicant
     And I am on the "edit my application" page
     And I choose a file named "diploma_huge.pdf" to upload
     When I click on t("membership_applications.edit.submit_button_label")
-    Then I should not see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large"), locale: :sv
-    And I should see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large"), locale: :en
+    Then I should not see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large", locale: :sv)
+    And I should see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large", locale: :en)
     And I set the locale to "sv"
 
 
@@ -73,7 +73,7 @@ Feature: As an applicant
     And I am on the "edit my application" page
     And I choose a file named "diploma_huge.pdf" to upload
     When I click on t("membership_applications.edit.submit_button_label")
-    Then I should see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large"), locale: :sv
+    Then I should see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large", locale: :sv)
 
 
   Scenario: Switching locales - Size error message in the right language
@@ -82,12 +82,12 @@ Feature: As an applicant
     And I am on the "edit my application" page
     And I choose a file named "diploma_huge.pdf" to upload
     When I click on t("membership_applications.edit.submit_button_label")
-    Then I should see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large"), locale: :sv
+    Then I should see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large", locale: :sv)
     And I set the locale to "en"
     And I am on the "edit my application" page
     And I choose a file named "diploma_huge.pdf" to upload
     When I click on t("membership_applications.edit.submit_button_label")
-    Then I should not see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large"), locale: :sv
+    Then I should not see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large", locale: :sv)
     And I set the locale to "sv"
 
 

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -1,12 +1,64 @@
-module PathHelper
+module PathHelpers
   # remove any leading locale path info
   def current_path_without_locale(path)
     locale_pattern =  /^(\/)(en|sv)?(\/)?(.*)$/
     path.gsub(locale_pattern, '\1\4')
   end
+
+  def get_path(pagename, user = @user)
+    case pagename.downcase
+      when  'login'
+        path = new_user_session_path
+      when 'landing'
+        path = root_path
+      when 'edit application', 'edit my application'
+        user.membership_applications.reload
+        path = edit_membership_application_path(user.membership_application)
+      when 'application', 'show my application'
+        path = membership_application_path(user.membership_application)
+      when 'user instructions'
+        path = information_path
+      when 'member instructions'
+        path = information_path
+      when 'all waiting for info reasons'
+        path = admin_only_member_app_waiting_reasons_path
+      when 'new waiting for info reason'
+        path = new_admin_only_member_app_waiting_reason_path
+      when 'register as a new user'
+        path = new_user_registration_path
+      when 'edit registration for a user'
+        path = edit_user_registration_path
+      when 'new password'
+        path = new_user_password_path
+      when 'all member app waiting reasons'
+        path = admin_only_member_app_waiting_reasons_path
+      when 'business categories'
+        path = business_categories_path
+      when 'membership applications'
+        path = membership_applications_path
+      when 'all companies'
+        path = companies_path
+      when 'create a new company'
+        path = new_company_path
+      when 'submit new membership application'
+        path = new_membership_application_path
+      when 'edit my company'
+        path = edit_company_path(user.membership_application.company)
+      when 'all users'
+        path = users_path
+      when 'all shf documents'
+        path = shf_documents_path
+      when 'new shf document'
+        path = new_shf_document_path
+      when 'user details'
+        path = user_path(user)
+      else
+        fail("no path defined for \"#{pagename}\"")
+    end
+  end
 end
 
-World(PathHelper)
+World(PathHelpers)
 
 
 Then(/^I should( not)? see #{CAPTURE_STRING}$/) do |negate, content|
@@ -36,34 +88,7 @@ end
 
 Then(/^I should be on (?:the )*"([^"]*)" page(?: for "([^"]*)")?$/) do |page, email|
   user = email == nil ? @user :  User.find_by(email: email)
-  case page.downcase
-    when  'login'
-      path = new_user_session_path
-    when 'landing'
-      path = root_path
-    when 'edit application', 'edit my application'
-      path = edit_membership_application_path(user.membership_application)
-    when 'application', 'show my application'
-      path = membership_application_path(user.membership_application)
-    when 'user instructions'
-      path = information_path
-    when 'member instructions'
-      path = information_path
-    when 'all waiting for info reasons'
-      path = admin_only_member_app_waiting_reasons_path
-    when 'new waiting for info reason'
-      path = new_admin_only_member_app_waiting_reason_path
-    when 'new waiting for info reason'
-      path = new_admin_only_member_app_waiting_reason_path
-    when 'register as a new user'
-      path = new_user_registration_path
-    when 'edit registration for a user'
-      path = edit_user_registration_path
-    when 'all member app waiting reasons'
-      path = admin_only_member_app_waiting_reasons_path
-  end
-
-  expect(current_path_without_locale(current_path)).to eq path
+  expect(current_path_without_locale(current_path)).to eq get_path(page, user)
 end
 
 
@@ -173,7 +198,7 @@ end
 
 
 Then(/^I should be on the SHF document page for "([^"]*)"$/)  do | doc_title |
-    shf_doc = ShfDocument.find_by_title(doc_title)
+  shf_doc = ShfDocument.find_by_title(doc_title)
   expect(current_path_without_locale(current_path)).to eq shf_document_path(shf_doc)
 end
 

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -55,6 +55,7 @@ module PathHelpers
       else
         fail("no path defined for \"#{pagename}\"")
     end
+    path
   end
 end
 

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -1,133 +1,50 @@
-
-# remove any leading locale path info
-def current_path_without_locale(path)
-  locale_pattern =  /^(\/)(en|sv)?(\/)?(.*)$/
-  path.gsub(locale_pattern, '\1\4')
-end
-
-Then(/^I should be on the landing page$/) do
-  expect(current_path_without_locale(current_path)).to eq root_path
-end
-
-And(/^I should see "([^"]*)"$/) do |content|
-  expect(page).to have_content content
-end
-
-And(/^I should not see "([^"]*)"$/) do |content|
-  expect(page).not_to have_content content
-end
-
-And(/^I should not see "([^"]*)" image$/) do |alt_text|
-  expect(page).not_to have_xpath("//img[contains(@alt,'#{alt_text}')]")
-end
-
-And(/^I should see "([^"]*)" image$/) do |alt_text|
-  expect(page).to have_xpath("//img[contains(@alt,'#{alt_text}')]")
-end
-
-And(/^I should( not)? see t\("([^"]*)"\) image$/) do |not_see, alt_text|
-  if not_see
-    expect(page).not_to have_xpath("//img[contains(@alt,'#{i18n_content(alt_text)}')]")
-  else
-    expect(page).to have_xpath("//img[contains(@alt,'#{i18n_content(alt_text)}')]")
+module PathHelper
+  # remove any leading locale path info
+  def current_path_without_locale(path)
+    locale_pattern =  /^(\/)(en|sv)?(\/)?(.*)$/
+    path.gsub(locale_pattern, '\1\4')
   end
 end
 
-And(/^I should see t\("([^"]*)"\)$/) do |content|
-  expect(page).to have_content i18n_content(content)
-end
+World(PathHelper)
 
-And(/^I should not see t\("([^"]*)"\)$/) do |content|
-  expect(page).not_to have_content i18n_content(content)
-end
 
-And(/^I should see t\("([^"]*)", locale: :(.*)\)$/) do |content, l|
-  expect(page).to have_content i18n_content(content, l)
-end
-
-And(/^I should not see t\("([^"]*)", locale: :(.*)\)$/) do |content, l|
-  expect(page).not_to have_content i18n_content(content, l)
-end
-
-And(/^I should see t\("([^"]*)", ([^:]*): ([^)]*)\), locale: :(.*)\)$/) do |content, key, value, l|
-  expect(page).to have_content I18n.t("#{content}", key.to_sym => value, locale: l.to_sym)
-end
-
-And(/^I should not see t\("([^"]*)", ([^:]*): ([^)]*)\), locale: :(.*)\)$/) do |content, key, value, l|
-  expect(page).not_to have_content I18n.t("#{content}", key.to_sym => value, locale: l.to_sym)
-end
-
-And(/^I should see t\("([^"]*)", ([^:]*): (\d+)\), locale: :(.*)$/) do |content, key, value, locale|
-  expect(page).to have_content I18n.t("#{content}", key.to_sym => value, locale: locale.to_sym)
-end
-
-Then(/^I should see t\("([^"]*)", ([^:]*): "([^"]*)"\), locale: :(.*)$/) do |content, key, value, l|
-  expect(page).to have_content I18n.t("#{content}", key.to_sym => value, locale: l.to_sym)
-end
-
-And(/^I should not see t\("([^"]*)", ([^:]*): (\d+)\), locale: :(.*)$/) do |content, key, value, locale|
-  expect(page).not_to have_content I18n.t("#{content}", key.to_sym => value, locale: locale.to_sym)
-end
-
-And(/^I should see button "([^"]*)"$/) do |button|
-  expect(page).to have_button button
-end
-
-And(/^I should not see button "([^"]*)"$/) do |button|
-  expect(page).not_to have_button button
-end
-
-And(/^I should see button t\("([^"]*)"\)$/) do |button|
-  expect(page).to have_button i18n_content(button)
-end
-
-And(/^I should not see button t\("([^"]*)"\)$/) do |button|
-  expect(page).not_to have_button i18n_content(button)
-end
-
-And(/^I should see the checkbox with id "([^"]*)" unchecked$/) do |checkbox_id|
-  expect(page).to have_unchecked_field checkbox_id
-end
-
-And(/^I should not see the checkbox with id "([^"]*)" unchecked$/) do |checkbox_id|
-  expect(page).not_to have_unchecked_field checkbox_id
-end
-
-And(/^I should see the checkbox with id "([^"]*)" checked/) do |checkbox_id|
-  expect(page).to have_unchecked_field checkbox_id
-end
-
-And(/^I should not see the checkbox with id "([^"]*)" checked/) do |checkbox_id|
-  expect(page).not_to have_unchecked_field checkbox_id
-end
-
-And(/^I should see "([^"]*)" link$/) do |link_label|
-  expect(page).to have_link link_label
-end
-
-And(/^I should see t\("([^"]*)"\) link$/) do |link_label|
-  expect(page).to have_link i18n_content(link_label)
-end
-
-And(/^I should not see "([^"]*)" link$/) do |link_label|
-  expect(page).not_to have_link link_label
-end
-
-And(/^I should not see t\("([^"]*)"\) link$/) do |link_label|
-  expect(page).not_to have_link i18n_content(link_label)
+Then(/^I should( not)? see #{CAPTURE_STRING}$/) do |negate, content|
+  expect(page).send (negate ? :not_to : :to), have_content(content)
 end
 
 
-Then(/^I should be on (?:the )*"([^"]*)" page$/) do |page|
+Then(/^I should( not)? see #{CAPTURE_STRING} image$/) do |negate, alt_text|
+  expect(page).send (negate ? :not_to : :to),  have_xpath("//img[contains(@alt,'#{alt_text}')]")
+end
+
+
+Then(/^I should( not)? see button #{CAPTURE_STRING}$/) do |negate, button|
+  expect(page).send (negate ? :not_to : :to),  have_button(button)
+end
+
+
+Then(/^I should( not)? see #{CAPTURE_STRING} link$/) do |negate, link_label|
+  expect(page).send (negate ? :not_to : :to),  have_link(link_label)
+end
+
+
+Then(/^I should( not)? see the checkbox with id "([^"]*)" unchecked$/) do |negate, checkbox_id|
+  expect(page).send (negate ? :not_to : :to),  have_unchecked_field(checkbox_id)
+end
+
+
+Then(/^I should be on (?:the )*"([^"]*)" page(?: for "([^"]*)")?$/) do |page, email|
+  user = email == nil ? @user :  User.find_by(email: email)
   case page.downcase
     when  'login'
       path = new_user_session_path
     when 'landing'
       path = root_path
-    when 'edit my application'
-      path = edit_membership_application_path(@user.membership_applications.last)
-    when 'show my application'
-      path = membership_application_path(@user.membership_applications.last)
+    when 'edit application', 'edit my application'
+      path = edit_membership_application_path(user.membership_application)
+    when 'application', 'show my application'
+      path = membership_application_path(user.membership_application)
     when 'user instructions'
       path = information_path
     when 'member instructions'
@@ -142,6 +59,8 @@ Then(/^I should be on (?:the )*"([^"]*)" page$/) do |page|
       path = new_user_registration_path
     when 'edit registration for a user'
       path = edit_user_registration_path
+    when 'all member app waiting reasons'
+      path = admin_only_member_app_waiting_reasons_path
   end
 
   expect(current_path_without_locale(current_path)).to eq path
@@ -154,59 +73,26 @@ Then(/^I should see:$/) do |table|
   end
 end
 
-And(/^"([^"]*)" should be set in "([^"]*)"$/) do |status, list|
-  dropdown = page.find("##{list}")
-  selected_option = dropdown.find('option[selected]').text
-  expect(selected_option).to eql status
-end
-
-And(/^t\("([^"]*)"\) should be set in "([^"]*)"$/) do |status, list|
-  dropdown = page.find("##{list}")
-  selected_option = dropdown.find('option[selected]').text
-  expect(selected_option).to eql i18n_content(status)
-end
-
-
-Then(/^I should be on the application page for "([^"]*)"$/) do |email|
-  user = User.find_by(email: email)
-  membership_application = user.membership_application
-  expect(current_path_without_locale(current_path)).to eq membership_application_path(membership_application)
-end
-
-Then(/^I should be on the edit application page for "([^"]*)"$/) do |email|
-  user = User.find_by(email: email)
-  membership_application = user.membership_application
-  expect(current_path_without_locale(current_path)).to eq edit_membership_application_path(membership_application)
-end
-
 
 Then(/^I should see "([^"]*)" applications$/) do |number|
   expect(page).to have_selector('tr.applicant', count: number)
 end
 
+
 Then(/^I should see "([^"]*)" companies/) do |number|
   expect(page).to have_selector('tr.company', count: number)
 end
+
 
 Then(/^I should see "([^"]*)" business categories/) do |number|
   expect(page).to have_selector('tr.business_category', count: number)
 end
 
-Then(/^the field "([^"]*)" should have a required field indicator$/) do |label_text|
-  expect(page.find('label', text: label_text)[:class].include?('required')).to be true
+
+Then(/^the field #{CAPTURE_STRING} should( not)? have a required field indicator$/) do |label_text, negate|
+  expect(page).send ( negate ? :not_to : :to), have_xpath("//label[@class='required'][text()='#{label_text}']")
 end
 
-And(/^the field "([^"]*)" should not have a required field indicator$/) do |label_text|
-  expect(page.find('label', text: label_text)[:class]).not_to have_css 'required'
-end
-
-Then(/^the field t\("([^"]*)"\) should have a required field indicator$/) do |label_text|
-  expect(page.find('label', text: i18n_content(label_text))[:class].include?('required')).to be true
-end
-
-And(/^the field t\("([^"]*)"\) should not have a required field indicator$/) do |label_text|
-  expect(page.find('label', text: i18n_content(label_text))[:class]).not_to have_css 'required'
-end
 
 Then(/^I should see (\d+) (.*?) rows$/) do |n, css_class_name|
   n = n.to_i
@@ -215,104 +101,35 @@ Then(/^I should see (\d+) (.*?) rows$/) do |n, css_class_name|
 end
 
 
-And(/^I should be on the applications page$/) do
-  expect(current_path_without_locale(current_path)).to eq membership_applications_path
+Then(/^I should see(?: translated)? error #{CAPTURE_STRING} #{CAPTURE_STRING}$/) do |model_attribute, error|
+  expect(page).to have_content("#{model_attribute} #{error}")
 end
 
-Then(/^I should see translated error (.*) (.*)$/) do |model_attribute, error|
-  expect(page).to have_content("#{i18n_content(model_attribute)} #{i18n_content(error)}")
-end
 
-And(/^I should see t\("([^"]*)", (\S*): '([^']*)'\)$/) do |i18n_key, attr_label, attr_value|
-  expect(page).to have_content(I18n.t(i18n_key, attr_label.to_sym => attr_value))
-end
-
-And(/^I should see status line with status "([^"]*)" and date "([^"]*)"$/) do |status, date_string|
+Then(/^I should see status line with status #{CAPTURE_STRING} and date "([^"]*)"$/) do |status, date_string|
   expect(page).to have_content("#{status} - #{date_string}")
 end
 
-And(/^I should see status line with status t\("([^"]*)"\) and date "([^"]*)"$/) do |status, date_string|
-  expect(page).to have_content("#{i18n_content(status)} - #{date_string}")
-end
 
-And(/^I should see status line with status t\("([^"]*)"\)$/) do |status|
-  expect(page).to have_content("#{i18n_content(status)} - ")
-end
-
-And(/^I should not see status line with status t\("([^"]*)"\)$/) do |status|
-  expect(page).not_to have_content("#{i18n_content(status)} - ")
-end
-
-And(/^I should see t\("([^"]*)", ([^:]*): (\d+)\)$/) do |content, key, number|
-  expect(page).to have_content I18n.t("#{content}", key.to_sym => number)
+Then(/^I should( not)? see status line with status #{CAPTURE_STRING}$/) do |negate, status|
+  expect(page).send (negate ? :not_to : :to), have_content("#{status} - ")
 end
 
 
-And(/^I should see t\("([^"]*)", ([^:]*): "([^"]*)"\)$/) do |content, key, value|
-  expect(page).to have_content I18n.t("#{content}", key.to_sym => value)
-end
-
-
-And(/^I should see t\("([^"]*)", ([^:]*): "([^"]*)", ([^:]*): "([^"]*)"\)$/) do | content, key1, value1, key2, value2 |
-  expect(page).to have_content I18n.t("#{content}", key1.to_sym => value1, key2.to_sym => value2)
-end
-
-And(/^I should not see t\("([^"]*)", ([^:]*): "([^"]*)", ([^:]*): "([^"]*)"\)$/) do | content, key1, value1, key2, value2 |
-  expect(page).not_to have_content I18n.t("#{content}", key1.to_sym => value1, key2.to_sym => value2)
-end
-
-
-And(/^I should see (\d+) t\("([^"]*)"\)$/) do |n, content |
+Then(/^I should see (\d+) #{CAPTURE_STRING}$/) do |n, content |
   n = n.to_i
-  expect(page).to have_text("#{i18n_content(content)}", count: n)
-  expect(page).not_to have_text("#{i18n_content(content)}", count: n+1)
+  expect(page).to have_text("#{content}", count: n)
+  expect(page).not_to have_text("#{content}", count: n+1)
 end
 
-Then(/^t\("([^"]*)"\) should( not)? be visible$/) do |string, not_see|
-  unless not_see
-    expect(has_text?(:visible, "#{i18n_content(string)}")).to be true
-  else
-    expect(has_text?(:visible, "#{i18n_content(string)}")).to be false
-  end
-end
-
-
-# Have to be sure to wait for any javascript to execute since it may hide or show an item
-Then(/^item "([^"]*)" should( not)? be visible$/) do | item, negate|
-
-  if negate
-    expect(page).to have_field(item, visible: false)
-
-  else
-    expect( find_field(item).visible? ).to be_truthy
-  end
-
-end
-
-
-# Tests that an input or button with the given label is disabled.
-Then /^the "([^\"]*)" (field|button|item) should( not)? be disabled$/ do |label, kind, negate|
-
-  if kind == 'field'
-    element = find_field(label)
-  elsif kind == 'button'
-    element = find_button(label)
-  else
-    element = find(label)
-  end
-
-  expect(["false", "", nil]).send(negate ? :to : :not_to,  include(element[:disabled]) )
-
+Then(/^#{CAPTURE_STRING} should( not)? be visible$/) do |string, negate|
+  expect(has_text?(:visible, "#{string}")).to be negate == nil
 end
 
 
 # Tests that an input has a given value
-Then /^the t\("([^"]*)"\) field should be set to "([^\"]*)"$/ do |i18n_key, text_value|
-
-  element = find_field(I18n.t(i18n_key))
-
-  expect(element.value).to eq(text_value)
-
+Then /^the #{CAPTURE_STRING} field should be set to #{CAPTURE_STRING}$/ do |field, text_value|
+  expect(find_field(field).value).to eq(text_value)
 end
 
 
@@ -320,82 +137,29 @@ Then(/^I should see link "([^"]*)" with target = "([^"]*)"$/) do |link_identifie
   expect(find_link(link_identifier)[:target]).to eq(target_value)
 end
 
-And(/^I should see t\("([^"]*)"\), locale: :(\w\w)$/) do |i18n_key, locale|
-  expect(page).to have_content I18n.t(i18n_key, locale: locale)
+
+Then(/^I should see flash text #{CAPTURE_STRING}$/) do | text |
+  expect(page).to have_selector('#flashes', text: text )
 end
 
-
-And(/^I should not see t\("([^"]*)"\), locale: :(\w\w)$/) do |i18n_key, locale|
-  expect(page).not_to have_content I18n.t(i18n_key, locale: locale)
-end
-
-And(/^I should see the selector "([^"]*)"$/) do | s |
-  expect(page).to have_selector(s)
-end
-
-And(/^I should see flash text t\("([^"]*)"\)$/) do | i18n_key |
-  expect(page).to have_selector('#flashes', text: I18n.t(i18n_key) )
-end
-
-And(/^I should see "([^"]*)" in the row for user "([^"]*)"$/) do | expected_text, user_email |
+Then(/^I should( not)? see #{CAPTURE_STRING} in the row for user "([^"]*)"$/) do | negate, expected_text, user_email |
   td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
   tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
-  expect(tr.text).to match(Regexp.new(expected_text))
+  expect(tr.text).send (negate ? :not_to : :to), match(Regexp.new(expected_text))
 end
 
-And(/^I should see t\("([^"]*)"\) in the row for user "([^"]*)"$/) do | expected_text, user_email |
+
+Then(/^I should( not)? see #{CAPTURE_STRING} for class "([^"]*)" in the row for user "([^"]*)"$/) do |negate, expected_text, css_class, user_email |
   td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
   tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
-  expect(tr.text).to match(Regexp.new(I18n.t(expected_text)))
+  expect(tr).send (negate ? :not_to : :to), have_css(".#{css_class}", text: expected_text)
 end
 
 
-And(/^I should not see "([^"]*)" in the row for user "([^"]*)"$/)do | expected_text, user_email |
-  td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
-  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
-  expect(tr.text).not_to match(Regexp.new(expected_text))
-end
-
-
-And(/^I should not see t\("([^"]*)"\) in the row for user "([^"]*)"$/) do | expected_text, user_email |
-  td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
-  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
-  expect(tr.text).not_to match(Regexp.new(I18n.t(expected_text)))
-end
-
-And(/^I should see "([^"]*)" for class "([^"]*)" in the row for user "([^"]*)"$/) do |expected_text, css_class, user_email |
-  td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
-  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
-
-  expect(tr).to have_css(".#{css_class}", text: expected_text)
-end
-
-And(/^I should not see "([^"]*)" for class "([^"]*)" in the row for user "([^"]*)"$/) do |expected_text, css_class, user_email |
-  td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
-  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
-
-  expect(tr).not_to have_css(".#{css_class}", text: expected_text)
-end
-
-
-And(/^I should see t\("([^"]*)"\) for class "([^"]*)" in the row for user "([^"]*)"$/) do |expected_text, css_class, user_email |
-  td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
-  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
-
-  expect(tr).to have_css(".#{css_class}", text: I18n.t(expected_text))
-end
-
-And(/^I should not see t\("([^"]*)"\) for class "([^"]*)" in the row for user "([^"]*)"$/) do |expected_text, css_class, user_email |
-  td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
-  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
-
-  expect(tr).not_to have_css(".#{css_class}", text: I18n.t(expected_text))
-end
-
-
-And(/^I should see xpath "([^"]*)"$/) do | xp |
+Then(/^I should see xpath "([^"]*)"$/) do | xp |
   expect(page).to have_xpath(xp)
 end
+
 
 Then(/^I should( not)? see "([^"]*)" before "([^"]*)"$/) do |not_see, toSearch, last|
   assert_text toSearch
@@ -408,7 +172,7 @@ Then(/^I should( not)? see "([^"]*)" before "([^"]*)"$/) do |not_see, toSearch, 
 end
 
 
-And(/^I should be on the SHF document page for "([^"]*)"$/)  do | doc_title |
+Then(/^I should be on the SHF document page for "([^"]*)"$/)  do | doc_title |
     shf_doc = ShfDocument.find_by_title(doc_title)
   expect(current_path_without_locale(current_path)).to eq shf_document_path(shf_doc)
 end
@@ -427,32 +191,7 @@ end
 
 
 # Checks that a certain option is selected for a text field (from https://github.com/makandra/spreewald)
-Then /^"([^"]*)" should( not)? have t\("([^"]*)"\) selected$/ do |select_list, negate, expected_string |
-
-    field = find_field(select_list)
-
-    field_value = case field.tag_name
-                    when 'select'
-                      options = field.all('option')
-                      selected_option = options.detect(&:selected?) || options.first
-                      if selected_option && selected_option.text.present?
-                        selected_option.text.strip
-                      else
-                        ''
-                      end
-                    else
-                      field.value
-                  end
-
-
-    expect(field_value).send( (negate ? :not_to : :to),  eq(i18n_content(expected_string)) )
-
-end
-
-
-
-# Checks that a certain option is selected for a text field (from https://github.com/makandra/spreewald)
-Then /^"([^"]*)" should( not)? have "([^"]*)" selected$/ do | select_list, negate, expected_string |
+Then /^"([^"]*)" should( not)? have #{CAPTURE_STRING} selected$/ do | select_list, negate, expected_string |
 
   field = find_field(select_list)
 
@@ -476,7 +215,7 @@ end
 
 
 # Checks that a certain option does or does not exist in a select list
-Then /^"([^"]*)" should( not)? have t\("([^"]*)"\) as an option/ do | select_list, negate, expected_string |
+Then /^"([^"]*)" should( not)? have #{CAPTURE_STRING} as an option/ do | select_list, negate, expected_string |
 
   field = find_field(select_list)
 
@@ -484,11 +223,6 @@ Then /^"([^"]*)" should( not)? have t\("([^"]*)"\) as an option/ do | select_lis
                   when 'select'
                     options = field.all('option')
                 end
-  expect(select_options.map(&:text)).send( (negate ? :not_to : :to),  include( i18n_content expected_string) )
+  expect(select_options.map(&:text)).send( (negate ? :not_to : :to),  include( expected_string) )
 
-end
-
-
-Then(/^I should be on the all member app waiting reasons page$/) do
-  expect(current_path_without_locale(current_path)).to eq admin_only_member_app_waiting_reasons_path
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -1,9 +1,12 @@
-And(/^I click on "([^"]*)"$/) do |element|
-  click_link_or_button element
-end
-
-And(/^I click on t\("([^"]*)"\)$/) do |element|
-  click_link_or_button i18n_content("#{element}")
+When(/^I click on(?: the)? #{CAPTURE_STRING}[ ]?(link|button)?$/) do |element, type|
+  case type
+    when 'link'
+      click_link element
+    when 'button'
+      click_button element
+    else
+      click_link_or_button element
+  end
 end
 
 When /^I confirm popup$/ do
@@ -24,109 +27,44 @@ When /^I dismiss popup$/ do
   page.driver.dismiss_modal(:confirm)
 end
 
-And(/^I fill in "([^"]*)" with "([^"]*)"$/) do |field, value|
+When(/^I fill in #{CAPTURE_STRING} with #{CAPTURE_STRING}$/) do |field, value|
   fill_in field, with: value
 end
 
-And(/^I press enter in "([^"]*)"$/) do |field|
+When(/^I press enter in #{CAPTURE_STRING}$/) do |field|
   find_field(field).send_keys :enter
 end
 
-And(/^I fill in t\("([^"]*)"\) with "([^"]*)"$/) do |field, value|
-  fill_in i18n_content(field), with: value
-end
-
-When(/^I fill in the form with data :$/) do |table|
+When(/^I fill in the( translated)? form with data:$/) do |translated, table|
   data = table.hashes.first
   data.each do |label, value|
-    unless value.empty?
+    if translated
+      fill_in i18n_content("#{label}"), with: value
+    else
       fill_in label, with: value
     end
   end
 end
 
-When(/^I fill in the translated form with data:$/) do |table|
-  data = table.hashes.first
-  data.each do |label, value|
-    fill_in i18n_content("#{label}"), with: value
-  end
-end
-
-
-When(/^I set "([^"]*)" to "([^"]*)"$/) do |list, option|
+When(/^(?:I|they) select #{CAPTURE_STRING} in select list #{CAPTURE_STRING}$/) do |option, list|
   select option, from: list
 end
 
-When(/^I set "([^"]*)" to t\("([^"]*)"\)$/) do |list, option|
-  select i18n_content(option), from: list
-end
-
-
-Then(/^show me the page$/) do
-  save_and_open_page
-end
-
-When(/^I leave the "([^"]*)" field empty$/) do |field|
-  fill_in field, with: nil
-end
-
-When(/^I leave the t\("([^"]*)"\) field empty$/) do |field|
-  fill_in i18n_content(field), with: nil
-end
-
-And(/^I click the "([^"]*)" action for the row with "([^"]*)"$/) do |action, row_content|
+When(/^I click the #{CAPTURE_STRING} action for the row with #{CAPTURE_STRING}$/) do |action, row_content|
   find(:xpath, "//tr[contains(.,'#{row_content}')]/td/a", :text => "#{action}").click
 end
 
-And(/^I click the t\("([^"]*)"\) action for the row with "([^"]*)"$/) do |action, row_content|
-  find(:xpath, "//tr[contains(.,'#{row_content}')]/td/a", :text => "#{i18n_content(action)}").click
+When(/^I (check|uncheck) the checkbox with id #{CAPTURE_STRING}$/) do |action, element_id|
+  send action, element_id
 end
 
-When(/^I click on(?: the)? "([^"]*)" link$/) do |element|
-  click_link element
-end
-
-And(/^I click on(?: the)? t\("([^"]*)"\) link$/) do |element|
-  click_link i18n_content("#{element}")
-end
-
-And(/^I click on "([^"]*)" button$/) do |element|
-  click_button element
-end
-
-And(/^I click on(?: the)* t\("([^"]*)"\) button$/) do |element|
-  click_button i18n_content("#{element}")
-end
-
-And(/^I check the checkbox with id "([^"]*)"$/) do |element_id|
-  check element_id
-end
-
-And(/^I uncheck the checkbox with id "([^"]*)"$/) do |element_id|
-  uncheck element_id
-end
-
-When(/^(?:I|they) select "([^"]*)" in select list t\("([^"]*)"\)$/) do |item, lst|
-  lst = i18n_content("#{lst}")
-  find(:select, lst).find(:option, item).select_option
-end
-
-
-When(/^(?:I|they) select "([^"]*)" in select list "([^"]*)"$/) do |item, lst|
-  find(:select, lst).find(:option, item).select_option
-end
-
-Then(/^I wait(?: for)? (\d+) second(?:s)?$/) do |seconds|
+When(/^I wait(?: for)? (\d+) second(?:s)?$/) do |seconds|
   sleep seconds.to_i.seconds
 end
 
-And /^I wait for all ajax requests to complete$/ do
+When /^I wait for all ajax requests to complete$/ do
   Timeout.timeout(Capybara.default_max_wait_time) do
     loop until page.evaluate_script('window.jQuery ? jQuery.active : 0').zero?
   end
 end
 
-When(/^(?:I|they) select t\("([^"]*)"\) in select list "([^"]*)"$/) do |item, lst|
-  selected = i18n_content("#{item}")
-  find(:select, lst).find(:option, selected).select_option
-end

--- a/features/step_definitions/company_steps.rb
+++ b/features/step_definitions/company_steps.rb
@@ -38,12 +38,8 @@ Then(/^I can go to the company page for "([^"]*)"$/) do |company_number|
   visit path_with_locale(edit_company_path company)
 end
 
-And(/^the "([^"]*)" should go to "([^"]*)"$/) do |link, url|
-  expect(page).to have_link(link, href: url)
-end
-
-Then(/^the "([^"]*)" should not go to "([^"]*)"$/) do |link, url|
-  expect(page).not_to have_link(link, href: url)
+And(/^the "([^"]*)" should( not)? go to "([^"]*)"$/) do |link, negate, url|
+  expect(page).send (negate ? :not_to : :to), have_link(link, href: url)
 end
 
 And(/^the name for region "([^"]*)" is changed to "([^"]*)"$/) do | old_name, new_name |

--- a/features/step_definitions/member_app_waiting_reason_steps.rb
+++ b/features/step_definitions/member_app_waiting_reason_steps.rb
@@ -12,25 +12,13 @@ And(/^I should see (\d+) reasons? listed$/) do |number|
 end
 
 
-Given(/^I am on the edit member app waiting reason with name_sv "([^"]*)"$/) do | reason_name_sv |
+Given(/^I am on the edit member app waiting reason with name_sv #{CAPTURE_STRING}$/) do | reason_name_sv |
   reason = AdminOnly::MemberAppWaitingReason.find_by_name_sv(reason_name_sv)
   visit path_with_locale(edit_admin_only_member_app_waiting_reason_path reason)
 end
 
-Given(/^I am on the edit member app waiting reason with name_sv t\("([^"]*)"\)$/) do | locale_reason_name_sv |
-  reason = AdminOnly::MemberAppWaitingReason.find_by_name_sv(  i18n_content(locale_reason_name_sv) )
-  visit path_with_locale(edit_admin_only_member_app_waiting_reason_path reason)
-end
 
-
-Given(/^I am on the member app waiting reason page for name_sv "([^"]*)"$/) do | reason_name_sv |
+Given(/^I am on the member app waiting reason page for name_sv #{CAPTURE_STRING}$/) do | reason_name_sv |
   reason = AdminOnly::MemberAppWaitingReason.find_by_name_sv(reason_name_sv)
   visit path_with_locale(admin_only_member_app_waiting_reason_path reason)
 end
-
-
-Given(/^I am on the member app waiting reason with name_sv t\("([^"]*)"\)$/) do | locale_reason_name_sv |
-  reason = AdminOnly::MemberAppWaitingReason.find_by_name_sv(  i18n_content(locale_reason_name_sv) )
-  visit path_with_locale(admin_only_member_app_waiting_reason_path reason)
-end
-

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -1,63 +1,11 @@
 Given(/^I am on the "([^"]*)" page(?: for "([^"]*)")?$/) do |page, email|
   user = email == nil ? @user :  User.find_by(email: email)
-  case page.downcase
-    when 'landing'
-      path = root_path
-    when 'login'
-      path = new_user_session_path
-    when 'edit my application'
-      user.membership_applications.reload
-      path = edit_membership_application_path(user.membership_application)
-    when 'business categories'
-      path = business_categories_path
-    when 'membership applications'
-      path = membership_applications_path
-    when 'all companies'
-      path = companies_path
-    when 'create a new company'
-      path = new_company_path
-    when 'submit new membership application'
-      path = new_membership_application_path
-    when 'edit my company'
-      path = edit_company_path(user.membership_application.company)
-    when 'user instructions'
-      path = information_path
-    when 'member instructions'
-      path = information_path
-    when 'new password'
-      path = new_user_password_path
-    when 'register as a new user'
-      path = new_user_registration_path
-    when 'edit registration for a user'
-      path = edit_user_registration_path
-    when 'all users'
-      path = users_path
-    when 'all shf documents'
-      path = shf_documents_path
-    when 'new shf document'
-      path = new_shf_document_path
-    when 'all waiting for info reasons'
-      path = admin_only_member_app_waiting_reasons_path
-    when 'new waiting for info reason'
-      path = new_admin_only_member_app_waiting_reason_path
-    when 'application', 'show application'
-      path = membership_application_path(user.membership_application)
-    when 'user details'
-      path = user_path(user)
-    else
-      fail("no path defined for \"#{page}\"")
-  end
-  visit path_with_locale(path)
+  visit path_with_locale(get_path(page, user))
 end
 
 
 When(/^I fail to visit the "([^"]*)" page$/) do |page|
-  case page.downcase
-    when 'applications index'
-      path = membership_applications_path
-    else
-      path = 'path not set'
-  end
+  path = get_path(page)
   visit path_with_locale(path)
   expect(current_path).not_to be path
 end

--- a/features/step_definitions/upload_steps.rb
+++ b/features/step_definitions/upload_steps.rb
@@ -2,12 +2,8 @@ When(/^I choose a file named "([^"]*)" to upload$/) do | filename |
   page.attach_file "uploaded_file[actual_files][]", File.join(Rails.root, 'spec', 'fixtures','uploaded_files', filename)
 end
 
-And(/^I should see "([^"]*)" uploaded for this membership application$/) do |filename|
-  expect(page).to have_selector('.uploaded-file', text: filename)
-end
-
-And(/^I should not see "([^"]*)" uploaded for this membership application$/) do |filename|
-  expect(page).not_to have_selector('.uploaded-file', text: filename)
+And(/^I should( not)? see "([^"]*)" uploaded for this membership application$/) do |negate, filename|
+  expect(page).send (negate ? :not_to : :to), have_selector('.uploaded-file', text: filename)
 end
 
 And(/^I should see (\d+) uploaded files listed$/) do |number|
@@ -25,18 +21,6 @@ And(/^I click on trash icon for "([^"]*)"$/) do |filename|
   find(:xpath, "//tr[contains(.,'#{filename}')]/td/a[@class='action-delete']").click
 end
 
-Then(/^I should see t\("([^"]*)", max_size: '([^']*)'\)$/) do | error_message, size |
-  expect(page).to have_content I18n.t("#{error_message}", max_size: size)
-end
-
-Then(/^I should not see t\("([^"]*)", max_size: '([^']*)'\)$/) do | error_message, size |
-  expect(page).not_to have_content I18n.t("#{error_message}", max_size: size)
-end
-
-Then(/^I should see the file delete action$/) do
-  expect(page).to have_xpath("//th[contains(., #{I18n.t('delete')})][@class='action']")
-end
-
-Then(/^I should not see the file delete action$/) do
-  expect(page).not_to have_xpath("//th[contains(., #{I18n.t('delete')})][@class='action']")
+Then(/^I should( not)? see the file delete action$/) do | negate |
+  expect(page).send (negate ? :not_to : :to), have_xpath("//th[contains(., #{I18n.t('delete')})][@class='action']")
 end

--- a/features/support/translation_transform.rb
+++ b/features/support/translation_transform.rb
@@ -1,48 +1,34 @@
 
-CAPTURE_STRING = '((?:t\(".*\)|"[^"]*")'+'(?:, locale: :\w\w)?)'
+CAPTURE_STRING = '((?:t\(".*\)|"[^"]*"))'
 
 Transform /^#{CAPTURE_STRING}$/ do | content |
-  if content[0] != 't'
+  needs_translation = content[0] == 't'
+  unless needs_translation
     content[1..-2]
   else
-    matcher = content.tr("\"'", '').match('t\((.*)\)(?:, locale: :(\w\w))?')
-    key = matcher[1]
-    if key.include? ','
-      parameters = string_to_hash(key[key.index(',')+1..-1])
-      i18n_content(key[0..key.index(',')-1], parameters)
-    else
-      locale = matcher[2]
-      i18n_content(key, locale: locale)
+    cleaned_content = content.delete("\"'")[2..-2]
+    key, parameters = parse_i18n_string(cleaned_content)
+    i18n_content(key, parameters)
+  end
+end
+
+def parse_i18n_string(i18n_string)
+  i18n_key = i18n_string
+  parameters = {}
+
+  separator = i18n_string.index(',')
+  if separator
+    i18n_key = i18n_string[0..separator-1]
+    parameters_array = i18n_string[separator+1..-1].split(',')
+
+    parameters_array.each do |e|
+      keyvalue = e.sub(' :', ' ').split(':')
+      key = keyvalue[0].strip.to_sym
+      value = keyvalue[1].strip
+      parameters[key] = value
     end
   end
+
+  return i18n_key, parameters
 end
-
-def string_to_hash(str, arr_sep=',', key_sep=':')
-  array = str.split(arr_sep)
-  hash = {}
-
-  array.each do |e|
-    key_value = e.split(key_sep)
-    hash[key_value[0].strip.to_sym] = key_value[1].strip
-  end
-
-  return hash
-end
-
-module StepHelpers
-
-  # remove any leading locale path info
-  def current_path_without_locale(path)
-    locale_pattern =  /^(\/)(en|sv)?(\/)?(.*)$/
-    path.gsub(locale_pattern, '\1\4')
-  end
-end
-
-World(StepHelpers)
-
-# Transform /^#{CAPTURE_STRING_WITH_LOCALE}$/ do | content |
-#   key = content.match(CAPTURE_STRING)[1][3..-3]
-#   locale = content.match('.*, locale: :(.*)')[1]
-#   i18n_content(key, locale: locale)
-# end
 

--- a/features/support/translation_transform.rb
+++ b/features/support/translation_transform.rb
@@ -1,0 +1,7 @@
+CAPTURE_STRING = '((?:t\()?"(?:[^"]*)"(?:\))?)'
+
+Transform /^#{CAPTURE_STRING}$/ do | content |
+  content[0] == 't' ? i18n_content(content[3..-3]) : content[1..-2]
+end
+
+

--- a/features/support/translation_transform.rb
+++ b/features/support/translation_transform.rb
@@ -1,7 +1,7 @@
 
 CAPTURE_STRING = '((?:t\(".*\)|"[^"]*"))'
 
-Transform /^#{CAPTURE_STRING}$/ do | content |
+Transform (/^#{CAPTURE_STRING}$/) do | content |
   needs_translation = content[0] == 't'
   unless needs_translation
     content[1..-2]

--- a/features/support/translation_transform.rb
+++ b/features/support/translation_transform.rb
@@ -1,7 +1,48 @@
-CAPTURE_STRING = '((?:t\()?"(?:[^"]*)"(?:\))?)'
+
+CAPTURE_STRING = '((?:t\(".*\)|"[^"]*")'+'(?:, locale: :\w\w)?)'
 
 Transform /^#{CAPTURE_STRING}$/ do | content |
-  content[0] == 't' ? i18n_content(content[3..-3]) : content[1..-2]
+  if content[0] != 't'
+    content[1..-2]
+  else
+    matcher = content.tr("\"'", '').match('t\((.*)\)(?:, locale: :(\w\w))?')
+    key = matcher[1]
+    if key.include? ','
+      parameters = string_to_hash(key[key.index(',')+1..-1])
+      i18n_content(key[0..key.index(',')-1], parameters)
+    else
+      locale = matcher[2]
+      i18n_content(key, locale: locale)
+    end
+  end
 end
 
+def string_to_hash(str, arr_sep=',', key_sep=':')
+  array = str.split(arr_sep)
+  hash = {}
+
+  array.each do |e|
+    key_value = e.split(key_sep)
+    hash[key_value[0].strip.to_sym] = key_value[1].strip
+  end
+
+  return hash
+end
+
+module StepHelpers
+
+  # remove any leading locale path info
+  def current_path_without_locale(path)
+    locale_pattern =  /^(\/)(en|sv)?(\/)?(.*)$/
+    path.gsub(locale_pattern, '\1\4')
+  end
+end
+
+World(StepHelpers)
+
+# Transform /^#{CAPTURE_STRING_WITH_LOCALE}$/ do | content |
+#   key = content.match(CAPTURE_STRING)[1][3..-3]
+#   locale = content.match('.*, locale: :(.*)')[1]
+#   i18n_content(key, locale: locale)
+# end
 

--- a/features/user-applies-approved-edits-co.feature
+++ b/features/user-applies-approved-edits-co.feature
@@ -32,17 +32,17 @@ Feature: Whole process of a new user creating a login, applying, being approved,
       | NewUser1                               | NewLastName                           | 5562252998                                 | 031-1234567                              | new_user@example.com                      |
     And I select "Groomer" Category
     And I click on t("membership_applications.new.submit_button_label")
-    Then I should be on the landing page
+    Then I should be on the "landing" page
     And I should see t("membership_applications.create.success")
     And I am logged out
     And I am logged in as "admin@shf.se"
     And I am on the "landing" page
     And I click on t("menus.nav.admin.manage_applications")
     Then I should see "NewUser1"
-    And I am on the application page for "new_user@example.com"
+    And I am on the "application" page for "new_user@example.com"
     And I click on t("membership_applications.start_review_btn")
     And I click on t("membership_applications.accept_btn")
-    And I should be on the edit application page for "new_user@example.com"
+    And I should be on the "edit application" page for "new_user@example.com"
     And I should see t("membership_applications.update.enter_member_number")
     And I fill in t("membership_applications.show.membership_number") with "10101"
     And I click on t("membership_applications.edit.submit_button_label")

--- a/features/view-site-in-lang-i18n-l10n.feature
+++ b/features/view-site-in-lang-i18n-l10n.feature
@@ -17,7 +17,7 @@ Feature: As a visitor
     Then I should see t("companies.index.title")
     And I should not see t("show_in_swedish") image
     And I should see t("show_in_english") image
-    And I should see t("theme_copyright"), locale: :sv
+    And I should see t("theme_copyright", locale: :sv)
 
 
   Scenario: Visitor switches the site language from English to Swedish
@@ -28,7 +28,7 @@ Feature: As a visitor
     Then I should see t("companies.index.title")
     And I should not see t("show_in_swedish") image
     And I should see t("show_in_english") image
-    And I should see t("theme_copyright"), locale: :sv
+    And I should see t("theme_copyright", locale: :sv)
 
 
   Scenario: Visitor switches the site language from Swedish to English
@@ -37,5 +37,5 @@ Feature: As a visitor
     When I click on "change-lang-to-english"
     Then I should see t("show_in_swedish") image
     And I should not see t("show_in_english") image
-    And I should see t("theme_copyright"), locale: :en
+    And I should see t("theme_copyright", locale: :en)
 

--- a/features/view-site-in-lang-i18n-l10n.feature
+++ b/features/view-site-in-lang-i18n-l10n.feature
@@ -17,7 +17,7 @@ Feature: As a visitor
     Then I should see t("companies.index.title")
     And I should not see t("show_in_swedish") image
     And I should see t("show_in_english") image
-    And I should see t("theme_copyright", locale: :sv)
+    And I should see t("theme_copyright"), locale: :sv
 
 
   Scenario: Visitor switches the site language from English to Swedish
@@ -28,7 +28,7 @@ Feature: As a visitor
     Then I should see t("companies.index.title")
     And I should not see t("show_in_swedish") image
     And I should see t("show_in_english") image
-    And I should see t("theme_copyright", locale: :sv)
+    And I should see t("theme_copyright"), locale: :sv
 
 
   Scenario: Visitor switches the site language from Swedish to English
@@ -37,5 +37,5 @@ Feature: As a visitor
     When I click on "change-lang-to-english"
     Then I should see t("show_in_swedish") image
     And I should not see t("show_in_english") image
-    And I should see t("theme_copyright", locale: :en)
+    And I should see t("theme_copyright"), locale: :en
 

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -116,7 +116,7 @@ Feature: As a visitor,
     And I should see "Company10"
     And I should not see "Company11"
     And I should not see "Company26"
-    Then I set "items_count" to "25"
+    Then I select "25" in select list "items_count"
     And I wait for all ajax requests to complete
     Then I should see "25" companies
     And "items_count" should have "25" selected
@@ -124,7 +124,7 @@ Feature: As a visitor,
     And I should see "Company11"
     And I should see "Company25"
     And I should not see "Company26"
-    Then I set "items_count" to "All"
+    Then I select "All" in select list "items_count"
     And I wait for all ajax requests to complete
     Then I should see "27" companies
     And I should see "Company26"

--- a/features/view_membership_applications.feature
+++ b/features/view_membership_applications.feature
@@ -63,13 +63,13 @@ Feature: As an admin,
     And I should see "10" applications
     And I should see "0000000010"
     And I should not see "0000000025"
-    Then I set "items_count" to "25"
+    Then I select "25" in select list "items_count"
     And I should see "25" applications
     And "items_count" should have "25" selected
     And I should see "0000000010"
     And I should see "0000000025"
     And I should not see "0000000026"
-    Then I set "items_count" to "All"
+    Then I select "All" in select list "items_count"
     And I should see "28" applications
     And I should see "0000000026"
     And I should see "0000000028"


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/148538387

Although this story was only about consolidating translation steps, I've gone a bit overboard and also consolidated "should" and "should not" steps, and refactored some steps to introduce more conformity in the way the steps are used. In some case this meant slight changes in the features themselves, but I've tried to keep that to a minimum.

Changes proposed in this pull request:

1. Introduce a `CAPTURE_STRING` variable that holds a regular expression to capture these variants:

```
"string"                    # normal string without translation
t("i18n.key")               # i18n key that should be translated with current locale
t("i18n.key", name: "name") # i18n key that should be translated using one or more parameters
```

2. Use a [Cucumber Step Argument Transform](https://github.com/cucumber/cucumber/wiki/Step-Argument-Transforms) to transform the captured argument to its translation (if needed). This means we can now use the following step variants with only one step definition.

```
And(/^I should see #{CAPTURE_STRING}$/) do | content|
  expect(page).to have_content(content)
end
```

```
And I should see "string"
And I should see t("i18n.key")
And I should see t("i18n.key", name: "name", locale: :sv) 
```

3. Consolidate "should" and "should not" steps. Both the consolidated and the non consolidated variants were used in the step definitions. I've refactored the step definitions to the consolidated form:

```
Then(/^I should( not)? see xpath "([^"]*)"$/) do | negate, xp |
  expect(page).send (negate ? :not_to : :to), have_xpath(xp)
end
```

4. Introduce a PathHelpers object to promote more conformity when using the "Then I should be on a page" and "Given I am on a page" steps: e.g. In most steps referring to a page, the pagename was enclosed in parantheses and then the path was found using a lookup, but there were a few step definitions where the  pagename was hardcoded into the stepdefinition. I've refactored these stepdefinitons away and when needed added parentheses in the steps:

```
Then I should be on the landing page #refactored away
Then I should be on the "landing" page
```

5. Consolidate differently worded stepdefinitions for selecting an item from a list:

```
And I set "member_app_waiting_reasons" to "need doc" # refactored away
And I select "need doc" in select list "member_app_waiting_reasons" 
```


Ready for review:
@patmbolger @weedySeaDragon 