### PR TITLE
Add eager loading to #has_company?

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
 
 
   def has_company?
-    has_membership_application? && (membership_applications.select { |app| app.company }).count > 0
+    has_membership_application? && (membership_applications.includes(:company).select { |app| app.company }).count > 0
   end
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
 
 
   def has_company?
-    has_membership_application? && (membership_applications.includes(:company).select { |app| app.company }).count > 0
+    membership_applications.where.not(company_id: nil).count > 0
   end
 
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/150544703

Changes proposed in this pull request:

To get rid of the "eager loading" warning when logging in as a member with multiple applications, add eager loading to `User#has_company? `

Ready for review:
@patmbolger @weedySeaDragon 