### PR TITLE
Sorting on user lastname not working in manage applications view

### DIFF
--- a/app/views/membership_applications/_membership_applications_list.html.haml
+++ b/app/views/membership_applications/_membership_applications_list.html.haml
@@ -3,7 +3,7 @@
     %thead
       %tr
         %th
-          = sort_link(@search_params, :last_name,
+          = sort_link(@search_params, :user_last_name,
                       t('membership_applications.index.name'), {},
                       { class: 'applications_pagination', remote: true })
         %th

--- a/features/search_applications.feature
+++ b/features/search_applications.feature
@@ -100,3 +100,15 @@ Scenario: Search by status and company number
   And I should not see "John"
   And I should not see "Anna"
   And I should not see "Fred"
+
+@javascript
+Scenario: Can sort by user lastname
+  Then I click on t("membership_applications.index.name") link
+  And I should see "Anderson" before "Eriksson"
+  And I should see "Eriksson" before "Fransson"
+  And I should see "Fransson" before "Johanssen"
+  Then I click on t("membership_applications.index.name") link
+  And I should see "Johanssen" before "Fransson"
+  And I should see "Fransson" before "Eriksson"
+  And I should see "Eriksson" before "Anderson"
+


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/150570637

**Changes proposed in this pull request:**

1. Add cucumber feature to test sorting on lastname in the "manage applications" view

2. change the `sort_link` header parameter from `last_name` to `user_last_name` to make the sorting in the "manage applications" view work again.

Ready for review:
@patmbolger @weedySeaDragon 