### PR TITLE
Limit the context for validating the presence of first- and lastname.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,12 +6,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
 
   validates_presence_of :first_name, :last_name, on: :create
-  validates_presence_of :first_name, :last_name, on: :update, unless: :password_change?
+  validates_presence_of :first_name, :last_name, on: :update, unless: Proc.new {encrypted_password != encrypted_password_was}
 
-
-  def password_change?
-    encrypted_password != encrypted_password_was
-  end
 
   def has_membership_application?
     membership_applications.size > 0

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,8 +5,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  validates_presence_of :first_name, :last_name, on: :create
-  validates_presence_of :first_name, :last_name, on: :update, unless: Proc.new {encrypted_password != encrypted_password_was}
+  validates_presence_of :first_name, :last_name, unless: Proc.new {!new_record? && !(first_name_changed? || last_name_changed?)}
 
 
   def has_membership_application?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,13 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  validates_presence_of :first_name, :last_name
+  validates_presence_of :first_name, :last_name, on: :create
+  validates_presence_of :first_name, :last_name, on: :update, unless: :password_change?
+
+
+  def password_change?
+    encrypted_password != encrypted_password_was
+  end
 
   def has_membership_application?
     membership_applications.size > 0

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -2,11 +2,14 @@ Given(/^the following users exist(?:s|)$/) do |table|
   table.hashes.each do |user|
 
     is_member = user.delete('is_member')
+    is_legacy = user.delete('is_legacy')
 
     if user['admin'] == 'true'
       FactoryGirl.create(:user, user)
     else
-      if is_member == 'true'
+      if is_legacy == 'true'
+        FactoryGirl.create(:user_without_first_and_lastname, user)
+      elsif is_member == 'true'
         FactoryGirl.create(:member_with_membership_app, user)
       else
         if ! user['company_number'].nil?

--- a/features/user_profile/user-resets-password.feature
+++ b/features/user_profile/user-resets-password.feature
@@ -6,8 +6,8 @@ Feature: As a user
   Background:
 
     Given the following users exists
-      | email               |
-      | emma@happymutts.com |
+      | email               | is_legacy |
+      | emma@happymutts.com | true      |
 
   @user
   Scenario: User resets password

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,6 +12,15 @@ FactoryGirl.define do
       company_number 5712213304
     end
 
+    factory :user_without_first_and_lastname do
+
+      after(:create) do |user|
+        user.first_name = nil
+        user.last_name = nil
+        user.save(validate: false)
+      end
+    end
+
     factory :user_with_membership_app do
 
       after(:create) do |user, evaluator|


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/150895867

**Changes proposed in this pull request:**

Change the validation for the presence of the first- and lastname of a user so that it does not validate in the case where the `encrypted_password` is changed (I checked that the encrypted password changes even if the new password is the same as the old password).

My first idea to make an exception for the administrator doesn't work because we shouldn't use the concept of `current_user` in a model. (We can know if a saved user is an administrator, but we can't know if the user is saved by an administrator)

The proposed changed makes it possible for the administrator to change a users password, but it also enables the user to use the Reset Password functionality as intended.

Ready for review:
@patmbolger @weedySeaDragon @thesuss 