### PR TITLE
Optimize js for "back-button" scenario when editing custom-reason (waiting for applicant state)

### DIFF
--- a/app/views/membership_applications/_reason_waiting.html.haml
+++ b/app/views/membership_applications/_reason_waiting.html.haml
@@ -31,7 +31,11 @@
 :javascript
 
   let ChangeStatus = {
-    unsaved_changes: false
+    unsaved_changes: false,
+    watch_for_input: function(e) {
+      ChangeStatus.unsaved_changes = true;
+      '#custom_reason_text').off('input');
+    }
   }
 
   $(document).ready(function () {
@@ -44,12 +48,11 @@
       }
     });
 
-    $('#custom_reason_text').on('input', function (e) {
-      ChangeStatus.unsaved_changes = true;
-    });
+    $('#custom_reason_text').on('input', ChangeStatus.watch_for_input);
 
     $('#custom_reason_text').on('change', function (e) {
       ChangeStatus.unsaved_changes = false;
+      $('#custom_reason_text').on('input', ChangeStatus.watch_for_input);
     });
 
     $(window).on('beforeunload', function (e) {

--- a/app/views/membership_applications/_reason_waiting.html.haml
+++ b/app/views/membership_applications/_reason_waiting.html.haml
@@ -33,8 +33,9 @@
   let ChangeStatus = {
     unsaved_changes: false,
     watch_for_input: function(e) {
+      console.log('In watch_for_input');
       ChangeStatus.unsaved_changes = true;
-      '#custom_reason_text').off('input');
+      $('#custom_reason_text').off('input');
     }
   }
 
@@ -51,6 +52,7 @@
     $('#custom_reason_text').on('input', ChangeStatus.watch_for_input);
 
     $('#custom_reason_text').on('change', function (e) {
+      console.log('In change event handler');
       ChangeStatus.unsaved_changes = false;
       $('#custom_reason_text').on('input', ChangeStatus.watch_for_input);
     });

--- a/app/views/membership_applications/_reason_waiting.html.haml
+++ b/app/views/membership_applications/_reason_waiting.html.haml
@@ -32,8 +32,7 @@
 
   let ChangeStatus = {
     unsaved_changes: false,
-    watch_for_input: function(e) {
-      console.log('In watch_for_input');
+    received_input: function(e) {
       ChangeStatus.unsaved_changes = true;
       $('#custom_reason_text').off('input');
     }
@@ -49,12 +48,11 @@
       }
     });
 
-    $('#custom_reason_text').on('input', ChangeStatus.watch_for_input);
+    $('#custom_reason_text').on('input', ChangeStatus.received_input);
 
     $('#custom_reason_text').on('change', function (e) {
-      console.log('In change event handler');
       ChangeStatus.unsaved_changes = false;
-      $('#custom_reason_text').on('input', ChangeStatus.watch_for_input);
+      $('#custom_reason_text').on('input', ChangeStatus.received_input);
     });
 
     $(window).on('beforeunload', function (e) {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/150386511

Changes proposed in this pull request:

1. We detect unsaved changes by using a callback that is fired when any key is pressed while focus is in the custom-reason field.  Previously, that callback was fired for _every_ keystroke.  This change turns off the callback when the first keystroke is received (then, the callback is turned back on after the changes have been saved).


Ready for review:
@AgileVentures/shf-project-team 