### PR TITLE
Fixed XHR pagination bug

### DIFF
--- a/app/helpers/remote_link_pagination_helper.rb
+++ b/app/helpers/remote_link_pagination_helper.rb
@@ -1,0 +1,8 @@
+module RemoteLinkPaginationHelper
+  class BootstrapLinkRenderer < WillPaginate::ActionView::BootstrapLinkRenderer
+    def link(text, target, attributes = {})
+      attributes['data-remote'] = true
+      super
+    end
+  end
+end

--- a/app/views/application/_paginate_footer.html.haml
+++ b/app/views/application/_paginate_footer.html.haml
@@ -2,9 +2,8 @@
 
   .col-sm-8.col-sm-offset-2{ style: 'text-align: center;' }
     = will_paginate entities,
-                    renderer: WillPaginate::ActionView::LinkRenderer,
-                    link_options: { 'data-remote': true,
-                                    class: paginate_class }
+                    renderer: RemoteLinkPaginationHelper::BootstrapLinkRenderer,
+                    class: paginate_class
 
   .col-sm-2{ style: 'text-align: right;' }
     -# override min-width from 'custom.css' - too wide
@@ -18,5 +17,7 @@
                                        data: {toggle: 'tooltip'} }
 -#
   for background on will_paginate method args, see:
-  https://gist.github.com/jeroenr/3142686, and
-  https://github.com/bootstrap-ruby/will_paginate-bootstrap
+  https://github.com/yrgoldteeth/bootstrap-will_paginate (adds bootstrap-style
+    to pagination links),
+  https://gist.github.com/jeroenr/3142686 (how to add data-remote attribute to
+    pagination links)

--- a/spec/views/application/_paginate_footer.html.haml_spec.rb
+++ b/spec/views/application/_paginate_footer.html.haml_spec.rb
@@ -20,17 +20,19 @@ RSpec.describe 'companies/index' do
   it 'renders paginate links with data-remote attributes' do
     # should have 8 links for specific pages
     rx = /<a .*data-remote="true" href="\/hundforetag\?page=\d{1}"/
-    
-    expect(rendered).to match rx
-    expect(rendered).to match /page=1/
-    expect(rendered).to match /page=8/
-    expect(rendered).to_not match /page=9/
 
-    # should have link for "next"
-    rx = /<a .*data-remote="true" href="#">« Föregående"/
+    expect(rendered).to match rx
+    expect(rendered).to match(/page=1/)
+    expect(rendered).to match(/page=8/)
+    expect(rendered).to_not match(/page=9/)
 
     # should have link for "previous"
-    rx = /<a .*data-remote="true" href="\/hundforetag?page=2">Nästa »"/
+    rx = /<a data-remote="true" href="#">« Föregående/
+    expect(rendered).to match rx
+
+    # should have link for "next"
+    rx = /<a data-remote="true" rel="next" href="\/hundforetag\?page=2">Nästa »/
+    expect(rendered).to match rx
   end
 
 end

--- a/spec/views/application/_paginate_footer.html.haml_spec.rb
+++ b/spec/views/application/_paginate_footer.html.haml_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'companies/index' do
+  let(:paginate_class) { 'companies_pagination' }
+  let(:companies)      { Company.ransack.result.page('1').per_page(10) }
+  let(:items_count)    { 10 }
+  let(:url)            { companies_path }
+
+  before(:each) do
+    75.times do |n|
+      company = FactoryGirl.build(:company, company_number: "#{n}")
+      company.save!(validate: false)
+    end
+
+    render partial: 'application/paginate_footer',
+           locals: { entities: companies, paginate_class: paginate_class,
+                     items_count: items_count, url: url }
+  end
+
+  it 'renders paginate links with data-remote attributes' do
+    # should have 8 links for specific pages
+    rx = /<a .*data-remote="true" href="\/hundforetag\?page=\d{1}"/
+    
+    expect(rendered).to match rx
+    expect(rendered).to match /page=1/
+    expect(rendered).to match /page=8/
+    expect(rendered).to_not match /page=9/
+
+    # should have link for "next"
+    rx = /<a .*data-remote="true" href="#">« Föregående"/
+
+    # should have link for "previous"
+    rx = /<a .*data-remote="true" href="\/hundforetag?page=2">Nästa »"/
+  end
+
+end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/151086585

When we switched from gem `will_paginate-bootstrap` to `bootstrap-will_paginate` we broke the XHR component of pagination links. This means that pagination links (next, previous, etc.) cause a complete page reload rather than just replacing the pagination table in the DOM.
(the cause is that we are using the argument `link_options` in the call to `will_paginate` in order to specify the data-remote HTML attribute. However, that argument option was added by the `will_paginate-bootstrap` gem, and is not provided by the `bootstrap-will_paginate` gem.)

Changes proposed in this pull request:
1. Create remote-pagination helper class, which defines a custom `will_paginate` renderer, that adds HTML attribute `data-remote` to all pagination links.
2. Use the custom renderer in the call to `will_paginate`.

This fixed the bug (and also restores bootstrap styling for the links).

Ready for review:
@AgileVentures/shf-project-team 