### PR TITLE
Bugfix: allow blank membership numbers.

### DIFF
--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -34,7 +34,7 @@ class MembershipApplication < ApplicationRecord
   validates_length_of :company_number, is: 10
   validates_format_of :contact_email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: [:create, :update]
   validates_uniqueness_of :user_id, scope: :company_number
-  validates_uniqueness_of :membership_number
+  validates_uniqueness_of :membership_number, allow_blank: true
   validate :swedish_organisationsnummer
 
   accepts_nested_attributes_for :uploaded_files, allow_destroy: true

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -14,6 +14,7 @@ Feature: As a user
     Given the following users exists
       | email                  |
       | applicant_1@random.com |
+      | applicant_2@random.com |
 
     And the following business categories exist
       | name         |
@@ -77,6 +78,25 @@ Feature: As a user
     And the field t("membership_applications.new.contact_email") should have a required field indicator
     And the field t("membership_applications.new.phone_number") should not have a required field indicator
     And I should see t("is_required_field")
+
+
+  Scenario: Two users can submit a new Membership Application (with empty membershipnumbers)
+    Given I am logged in as "applicant_1@random.com"
+    And I am on the "landing" page
+    And I click on t("menus.nav.users.apply_for_membership")
+    And I fill in the translated form with data:
+      | membership_applications.new.first_name | membership_applications.new.last_name | membership_applications.new.company_number | membership_applications.new.phone_number | membership_applications.new.contact_email |
+      | Applicant1                             | Andersson                             | 5562252998                                 | 031-1234567                              | applicant_1@random.com                    |
+    And I click on t("membership_applications.new.submit_button_label")
+    Then I should see t("membership_applications.create.success")
+    Given I am logged in as "applicant_2@random.com"
+    And I am on the "landing" page
+    And I click on t("menus.nav.users.apply_for_membership")
+    And I fill in the translated form with data:
+      | membership_applications.new.first_name | membership_applications.new.last_name | membership_applications.new.company_number | membership_applications.new.phone_number | membership_applications.new.contact_email |
+      | Applicant2                             | Andersson                             | 2120000142                                 | 031-1234567                              | applicant_2@random.com                    |
+    And I click on t("membership_applications.new.submit_button_label")
+    Then I should see t("membership_applications.create.success")
 
 
   Scenario Outline: Apply for membership - when things go wrong

--- a/spec/factories/membership_applications.rb
+++ b/spec/factories/membership_applications.rb
@@ -1,7 +1,6 @@
 FactoryGirl.define do
 
   sequence(:cat_name_seq, "Business Category", 1) { |name, num| "#{name} #{num}" }
-  sequence(:membership_number_seq, 1) { |num| "#{num}" }
 
   factory :membership_application do
     company_number '5562252998'
@@ -25,8 +24,6 @@ FactoryGirl.define do
     end
 
     after(:build) do |membership_app, evaluator|
-
-      membership_app.membership_number = generate :membership_number_seq
 
       if evaluator.num_categories == 1
         membership_app.business_categories << build(:business_category, name: evaluator.category_name)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/151262154

**Changes proposed in this pull request:**

1. Fix the bug I introduced with PR 354 that prevented inserting or updating membership applications with blank membershipnumbers by adding `allow_blank: true` to the `validates_uniqueness_of :membership_number` clause

Ready for review:
@patmbolger @weedySeaDragon