### PR TITLE
DatabaseCleaner.clean after (:all)

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,6 +79,16 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
+  config.before(:all) do
+    DatabaseCleaner.start
+  end
+
+
+  config.append_after(:all) do
+    DatabaseCleaner.clean
+    # @see http://renderedtext.com/blog/2012/10/10/cleaning-up-after-before-all-blocks/
+  end
+
 end
 
 


### PR DESCRIPTION
### PT Story:  **DatabaseCleaner: not cleaning before/after all**
https://www.pivotaltracker.com/story/show/151366118

Intermittent failures were showing up because the db state was being not totally reset because data created in an RSpec `before(:all)` block is _not_ part of a database transaction, so that data is not rolled back at the end of the test.


### Changes proposed in this pull request:

1.   Started a DatabaseCleaner block before any RSpec `:all` block.   Do a `DatabaseCleaner.clean` as the last thing when cleaning up after a RSpec  that used an `:all` block

Ready for review:
@AgileVentures/shf-project-team 
