### PR TITLE
Really fail a cucumber step if an unknown path is used

### DIFF
--- a/features/search_and_sort_users.feature
+++ b/features/search_and_sort_users.feature
@@ -20,26 +20,26 @@ Feature:
     And I am logged in as "admin@sverigeshundforetagare.se"
 
   Scenario: Admin searches for luke
-    Given I am on the "users" page
+    Given I am on the "all users" page
     When I fill in t("users.search_form.profile_email") with "luke"
     And I click on t("search")
     Then I should see "luke@force.net"
     And I should not see "sconnor@example.com"
 
   Scenario: Admin searches for @sverigeshundföretagare.se
-    Given I am on the "users" page
+    Given I am on the "all users" page
     When I fill in t("users.search_form.profile_email") with "@sverigeshundföretagare.se"
     And I click on t("search")
     Then I should not see "admin@sverigeshundforetagare.se"
     And I should see t("users.index.no_search_results")
 
   Scenario: Admin sorts users by email
-    Given I am on the "users" page
+    Given I am on the "all users" page
     When I click on t("users.users_list.email")
     Then I should see "luke@force.net" before "sconnor@example.com"
 
   Scenario: Admin filters users by membership status
-    Given I am on the "users" page
+    Given I am on the "all users" page
 
     When I select radio button t("users.search_form.all_users")
     And I click on t("search")

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -54,7 +54,7 @@ module PathHelpers
         path = user_path(user)
     end
 
-    expect(path).not_to be_empty, "A step was called with path= /'#{pagename}/', but that path is not defined in #{__method__}"
+    expect(path).not_to be_empty, "A step was called with path= '#{pagename}', but that path is not defined in #{__method__} \n    (which is in #{__FILE__}"
 
     path
   end

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -52,9 +52,10 @@ module PathHelpers
         path = new_shf_document_path
       when 'user details'
         path = user_path(user)
-      else
-        fail("no path defined for \"#{pagename}\"")
     end
+
+    expect(path).not_to be_empty, "A step was called with path= /'#{pagename}/', but that path is not defined in #{__method__}"
+
     path
   end
 end


### PR DESCRIPTION
PT Story: 



Changes proposed in this pull request:
1.   add in an `expect...` test so that the current cucumber step will really fail
2.  Fix `search_and_sort_users.feature` so that it uses the standard path name for 'all users' so that it will pass.  (Otherwise, it would now fail since it was using a path name that doesn't exist.)

Ready for review:
@AgileVentures/shf-project-team 
