### PR TITLE
User sorting: remove duplicate sorting default 'email'

### DIFF
--- a/app/views/users/_users_list.html.haml
+++ b/app/views/users/_users_list.html.haml
@@ -2,7 +2,7 @@
   %table.table
     %thead.panel-heading
       %tr
-        %th= sort_link(q, :email, t('.email'), { default_order: { email: :desc, email: :asc } }, { remote: true } )
+        %th= sort_link(q, :email, t('.email'), { default_order: { email: :asc } }, { remote: true } )
         %th= t('.created')
         %th= t('.last_login')
         %th= t('.logged_in_count')


### PR DESCRIPTION
### PT Story:   User sorting: default order lists 'email' twice 
https://www.pivotaltracker.com/story/show/151411284

### Changes proposed in this pull request:
1.  removed duplicate `email: ...` 

Ready for review:
@AgileVentures/shf-project-team 
