### PR TITLE
update to Devise::Test::ControllerHelper (get rid of deprecation warning)

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,8 +10,8 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
 
-  config.include Devise::TestHelpers, :type => :controller
-  config.include Devise::TestHelpers, :type => :view
+  config.include Devise::Test::ControllerHelpers, :type => :controller
+  config.include Devise::Test::ControllerHelpers, :type => :view
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
### PT Story:  Fix Devise::TestHelpers (deprecated) -> Devise::Test::ControllerHelpers
https://www.pivotaltracker.com/story/show/151356358


### Changes proposed in this pull request:
1.  updated the Devise classes per the Devise gem README to get rid of annoying deprecation warnings


Ready for review:
@AgileVentures/shf-project-team 
