### PR TITLE
HOTFIX: share app/views/pages across all releases (capistrano deploy)

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -31,6 +31,7 @@ set :linked_dirs, %w{
   public/.well-known
   public/storage
   public/ckeditor_assets
+  app/views/pages
 }
 
 # public/.well-known  created by diffouo (raoul) when this was set up. used for ??? (not used?)
@@ -38,6 +39,7 @@ set :linked_dirs, %w{
 # public/uploads      created by diffouo (raoul) when this was set up. used for ??? (not used?)
 # public/storage  Files uploaded for  membership applications
 # public/ckeditor_assets Files uploaded by members, admins when using the ckeditor (ex: company page custom infor, SHF member documents)
+# app/views/pages  Member Documents are stored here.  (Eventually they should moved to a different directory)
 
 
 set :keep_releases, 5


### PR DESCRIPTION
### PT Story:  HOTFIX: deploy: do NOT clobber member files
https://www.pivotaltracker.com/story/show/151407485

Changes proposed in this pull request:
1. add `app/views/pages` to the directories that are shared across all releases.  
  (This means that all releases will use a symbolic link to point to the same directory.)

Ready for review:
@patmbolger @thesuss 
