### PR TITLE
Adds missing entry-content class to texts

### DIFF
--- a/app/views/membership_applications/edit.html.haml
+++ b/app/views/membership_applications/edit.html.haml
@@ -4,7 +4,7 @@
     %h1.entry-title= t('.title')
   .post-title-divider
     %span
-  .instructions= t('membership_applications.new.instructions')
+  .entry-content.instructions= t('membership_applications.new.instructions')
 
   .entry-content.wpcf7
 

--- a/app/views/membership_applications/new.html.haml
+++ b/app/views/membership_applications/new.html.haml
@@ -4,7 +4,7 @@
     %h1.entry-title= t('.title')
   .post-title-divider
     %span
-  .instructions= t('membership_applications.new.instructions')
+  .entry-content.instructions= t('membership_applications.new.instructions')
 
   .entry-content.wpcf7
     = form_for @membership_application, html: {multipart: true}, url: membership_applications_path do |f|


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/151100580


Changes proposed in this pull request:
1. all text must be within class "entry-content" otherwise the margins are off. 
(100% wide images are the exception)

Screenshots (Optional):
![skarmavbild 2017-09-29 kl 18 04 18](https://user-images.githubusercontent.com/7266909/31024848-a3a411c8-a540-11e7-9b9c-23a24d71eef9.png)


Ready for review:
@weedySeaDragon @patmbolger @RobertCram 
