### PR TITLE
Selenium WebDriver: suppress deprecated warning, enhance cuke step, add hooks

### DIFF
--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -17,9 +17,15 @@ When(/^I click on(?: the)?( \w*)? #{CAPTURE_STRING}[ ]?(link|button)?$/) do |ord
 end
 
 When /^I confirm popup$/ do
-  # requires poltergeist:
-  using_wait_time 3 do
-    page.driver.accept_modal(:confirm)
+
+  if Capybara.current_driver == :poltergeist
+    using_wait_time 3 do
+      page.driver.accept_modal(:confirm)
+    end
+  elsif Capybara.current_driver == :selenium_browser
+    page.driver.browser.switch_to.alert.accept
+  else
+    raise 'step not configured for current browser driver'
   end
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -39,19 +39,16 @@ def i18n_content(content, locale=I18n.locale)
   I18n.t(content, locale)
 end
 
-# For tests requiring javascript, headless
-Capybara.javascript_driver = :poltergeist
-
 Capybara.register_driver :selenium do |app|
+  options = Selenium::WebDriver::Chrome::Options.new(args: ['headless'])
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    args: ['headless']
+    options: options
   )
 end
 
-# Displayed chrome browser
-# Use @selenium_browser
+# Displayed chrome browser - @selenium_browser
 Capybara.register_driver :selenium_browser do |app|
   Capybara::Selenium::Driver.new(
     app,

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -2,10 +2,19 @@ Before('@javascript, @poltergeist') do
   Capybara.current_driver = :poltergeist
 end
 
-After('@javascript, @poltergeist') do
+Before('@selenium') do
+  # Use this hook for running headless tests using Chrome
+  Capybara.current_driver = :selenium
+end
+
+Before('@selenium_browser') do
+  # Use this hook for running tests with visible browser
+ Capybara.current_driver = :selenium_browser
+end
+
+After('@javascript, @poltergeist, @selenium, @selenium_browser') do
   ajax_active = !page.evaluate_script('window.jQuery ? jQuery.active : 0').zero?
   Capybara.reset_sessions!
   Capybara.current_driver = :rack_test
   raise "expected all ajax requests to be completed after scenario, but some ajax requests were still running." if ajax_active
 end
-


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/148950573

Changes proposed in this pull request:
1. Change config to add Chrome startup args to prevent deprecated warning
2. Enhanced "I confirm popup" to accommodate :selenium_browser (visible Chrome)
3. Added hooks for :selenium, :selenium_browser

Ready for review:
@weedySeaDragon @RobertCram 