### PR TITLE
Move membership number to User model

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -35,7 +35,7 @@ class AdminController < ApplicationController
     out_str = export_header_str
 
     membership_apps.each do |m_app|
-      out_str << "#{m_app.contact_email},#{m_app.user.first_name},#{m_app.user.last_name},#{m_app.membership_number},"
+      out_str << "#{m_app.contact_email},#{m_app.user.first_name},#{m_app.user.last_name},#{m_app.user.membership_number},"
       out_str << t("membership_applications.state.#{m_app.state}")
       out_str << ','
 

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -137,7 +137,7 @@ class MembershipApplication < ApplicationRecord
     begin
 
       user.issue_membership_number
-      user.update(membership_number: membership_number)
+      user.save
 
       company = Company.find_or_create_by!(company_number: company_number) do |co|
         co.email = contact_email

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -34,7 +34,6 @@ class MembershipApplication < ApplicationRecord
   validates_length_of :company_number, is: 10
   validates_format_of :contact_email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: [:create, :update]
   validates_uniqueness_of :user_id, scope: :company_number
-  validates_uniqueness_of :membership_number, allow_blank: true
   validate :swedish_organisationsnummer
 
   accepts_nested_attributes_for :uploaded_files, allow_destroy: true
@@ -136,13 +135,14 @@ class MembershipApplication < ApplicationRecord
   def accept_membership
     begin
 
-      membership_number = self.membership_number.blank? ? self.class.get_next_membership_number : self.membership_number
+      membership_number = user.membership_number.blank? ? self.class.get_next_membership_number : user.membership_number
+      user.update(membership_number: membership_number)
 
       company = Company.find_or_create_by!(company_number: company_number) do |co|
         co.email = contact_email
       end
 
-      update(company: company, membership_number: membership_number)
+      update(company: company)
 
     rescue => e
       puts "ERROR: could not accept_membership.  error: #{e.inspect}"
@@ -152,7 +152,7 @@ class MembershipApplication < ApplicationRecord
 
 
   def reject_membership
-    update(membership_number: nil)
+    user.update(membership_number: nil)
     delete_uploaded_files
   end
 

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -136,7 +136,7 @@ class MembershipApplication < ApplicationRecord
   def accept_membership
     begin
 
-      membership_number = user.membership_number.blank? ? self.class.get_next_membership_number : user.membership_number
+      user.issue_membership_number
       user.update(membership_number: membership_number)
 
       company = Company.find_or_create_by!(company_number: company_number) do |co|
@@ -172,11 +172,6 @@ class MembershipApplication < ApplicationRecord
 
   def se_mailing_csv_str
      company.nil? ?  AddressExporter.se_mailing_csv_str(nil) : company.se_mailing_csv_str
-  end
-
-
-  def self.get_next_membership_number
-    connection.execute("SELECT nextval('membership_number_seq')").getvalue(0,0).to_s
   end
 
 

--- a/app/models/membership_application.rb
+++ b/app/models/membership_application.rb
@@ -42,6 +42,7 @@ class MembershipApplication < ApplicationRecord
   scope :open, -> { where.not(state: [:accepted, :rejected]) }
 
   delegate :full_name, to: :user, prefix: true
+  delegate :membership_number, :membership_number=, to: :user, prefix: false
 
   include AASM
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,4 +72,17 @@ class User < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
+
+  def issue_membership_number
+    self.membership_number = self.membership_number.blank? ? self.class.get_next_membership_number : self.membership_number
+  end
+
+
+  private
+
+  def self.get_next_membership_number
+    connection.execute("SELECT nextval('membership_number_seq')").getvalue(0,0).to_s
+  end
+
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,14 +74,13 @@ class User < ApplicationRecord
 
 
   def issue_membership_number
-    self.membership_number = self.membership_number.blank? ? self.class.get_next_membership_number : self.membership_number
+    self.membership_number = self.membership_number.blank? ? get_next_membership_number : self.membership_number
   end
-
 
   private
 
-  def self.get_next_membership_number
-    connection.execute("SELECT nextval('membership_number_seq')").getvalue(0,0).to_s
+  def get_next_membership_number
+    self.class.connection.execute("SELECT nextval('membership_number_seq')").getvalue(0,0).to_s
   end
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
 
   validates_presence_of :first_name, :last_name, unless: Proc.new {!new_record? && !(first_name_changed? || last_name_changed?)}
-
+  validates_uniqueness_of :membership_number, allow_blank: true
 
   scope :are_members, lambda {
     User.all.select { | user | user.is_member? }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,7 +124,7 @@ en:
         email: &email Profile Email
         password: *password
         password_confirmation: Password confirmation
-        membership_number: Membership number
+        membership_number: &membership_number Membership number
         created: &created Created
         current_sign_in_at: &user_current_signed_in_time Currently signed in at
         current_sign_in_ip: &user_current_ip Currently signed in from IP address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,7 @@ en:
         email: &email Profile Email
         password: *password
         password_confirmation: Password confirmation
+        membership_number: Membership number
         created: &created Created
         current_sign_in_at: &user_current_signed_in_time Currently signed in at
         current_sign_in_ip: &user_current_ip Currently signed in from IP address
@@ -133,7 +134,6 @@ en:
         created: *created
         reset_password_sent_at: &user_reset_password_sent_at Password reset info sent
 
-
       membership_application:
         company_number: &company_number Company number
         first_name: *first_name
@@ -141,7 +141,6 @@ en:
         contact_email: &contact_email Contact Email
         state: &state Status
         phone_number: Phone number
-        membership_number: Membership number
 
       address:
         street: &street Street

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -124,6 +124,7 @@ sv:
         email: &email Profil E-post
         password: *password
         password_confirmation: Lösenordsbekräftelse
+        membership_number: &membership_number Medlemsnummer
         created: &created Skapad
         current_sign_in_at: &user_current_signed_in_time Inloggad
         current_sign_in_ip: &user_current_ip Inloggad med IP
@@ -141,7 +142,6 @@ sv:
         contact_email: &contact_email Kontakt e-post
         state: &state Status
         phone_number: Telefonnummer
-        membership_number: &membership_number Medlemsnummer
 
       address:
         street: &street Gata

--- a/db/migrate/20171005113112_move_membershipnumber_to_user.rb
+++ b/db/migrate/20171005113112_move_membershipnumber_to_user.rb
@@ -3,14 +3,14 @@ class MoveMembershipnumberToUser < ActiveRecord::Migration[5.1]
     reversible do |direction|
 
       direction.up do
-        add_column :users, :membership_number, :string, index: :unique
+        add_column :users, :membership_number, :string
         add_index :users, :membership_number, unique: true
         execute "UPDATE users u SET membership_number = ma.membership_number FROM membership_applications ma WHERE u.id = ma.user_id;"
         remove_column :membership_applications, :membership_number
       end
 
       direction.down do
-        add_column :membership_applications, :membership_number, :string, index: :unique
+        add_column :membership_applications, :membership_number, :string
         execute "UPDATE membership_applications ma SET membership_number = u.membership_number FROM users u WHERE ma.user_id = u.id;"
         remove_column :users, :membership_number
       end

--- a/db/migrate/20171005113112_move_membershipnumber_to_user.rb
+++ b/db/migrate/20171005113112_move_membershipnumber_to_user.rb
@@ -1,0 +1,19 @@
+class MoveMembershipnumberToUser < ActiveRecord::Migration[5.1]
+  def change
+    reversible do |direction|
+
+      direction.up do
+        add_column :users, :membership_number, :string
+        execute "UPDATE users u SET membership_number = ma.membership_number FROM membership_applications ma WHERE u.id = ma.user_id;"
+        remove_column :membership_applications, :membership_number
+      end
+
+      direction.down do
+        add_column :membership_applications, :membership_number, :string
+        execute "UPDATE membership_applications ma SET membership_number = u.membership_number FROM users u WHERE ma.user_id = u.id;"
+        remove_column :users, :membership_number
+      end
+
+    end
+  end
+end

--- a/db/migrate/20171005113112_move_membershipnumber_to_user.rb
+++ b/db/migrate/20171005113112_move_membershipnumber_to_user.rb
@@ -3,13 +3,14 @@ class MoveMembershipnumberToUser < ActiveRecord::Migration[5.1]
     reversible do |direction|
 
       direction.up do
-        add_column :users, :membership_number, :string
+        add_column :users, :membership_number, :string, index: :unique
+        add_index :users, :membership_number, unique: true
         execute "UPDATE users u SET membership_number = ma.membership_number FROM membership_applications ma WHERE u.id = ma.user_id;"
         remove_column :membership_applications, :membership_number
       end
 
       direction.down do
-        add_column :membership_applications, :membership_number, :string
+        add_column :membership_applications, :membership_number, :string, index: :unique
         execute "UPDATE membership_applications ma SET membership_number = u.membership_number FROM users u WHERE ma.user_id = u.id;"
         remove_column :users, :membership_number
       end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170922144510) do
+ActiveRecord::Schema.define(version: 20171005113112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,13 +106,11 @@ ActiveRecord::Schema.define(version: 20170922144510) do
     t.bigint "user_id"
     t.string "contact_email"
     t.bigint "company_id"
-    t.string "membership_number"
     t.string "state", default: "new"
     t.integer "member_app_waiting_reasons_id"
     t.string "custom_reason_text"
     t.index ["company_id"], name: "index_membership_applications_on_company_id"
     t.index ["member_app_waiting_reasons_id"], name: "index_membership_applications_on_member_app_waiting_reasons_id"
-    t.index ["membership_number"], name: "index_membership_applications_on_membership_number", unique: true
     t.index ["user_id"], name: "index_membership_applications_on_user_id"
   end
 
@@ -163,6 +161,7 @@ ActiveRecord::Schema.define(version: 20170922144510) do
     t.boolean "admin", default: false
     t.string "first_name"
     t.string "last_name"
+    t.string "membership_number"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -163,6 +163,7 @@ ActiveRecord::Schema.define(version: 20171005113112) do
     t.string "last_name"
     t.string "membership_number"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["membership_number"], name: "index_users_on_membership_number", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/db/seed_helpers.rb
+++ b/db/seed_helpers.rb
@@ -96,7 +96,7 @@ module SeedHelper
       # make a full company object (instance) for the accepted membership application
       ma.company = make_new_company(ma.company_number)
 
-      user.membership_number = MembershipApplication.get_next_membership_number
+      user.issue_membership_number
     end
 
 

--- a/db/seed_helpers.rb
+++ b/db/seed_helpers.rb
@@ -96,7 +96,7 @@ module SeedHelper
       # make a full company object (instance) for the accepted membership application
       ma.company = make_new_company(ma.company_number)
 
-      ma.membership_number = MembershipApplication.get_next_membership_number
+      user.membership_number = MembershipApplication.get_next_membership_number
     end
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -879,6 +879,13 @@ CREATE UNIQUE INDEX index_users_on_email ON users USING btree (email);
 
 
 --
+-- Name: index_users_on_membership_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_users_on_membership_number ON users USING btree (membership_number);
+
+
+--
 -- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
 --
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -44,7 +44,7 @@ CREATE TABLE addresses (
     latitude double precision,
     longitude double precision,
     visibility character varying DEFAULT 'street_address'::character varying,
-    mail boolean
+    mail boolean DEFAULT false
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,5 +1,6 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
@@ -43,7 +44,7 @@ CREATE TABLE addresses (
     latitude double precision,
     longitude double precision,
     visibility character varying DEFAULT 'street_address'::character varying,
-    mail boolean DEFAULT false
+    mail boolean
 );
 
 
@@ -367,7 +368,6 @@ CREATE TABLE membership_applications (
     user_id bigint,
     contact_email character varying,
     company_id bigint,
-    membership_number character varying,
     state character varying DEFAULT 'new'::character varying,
     member_app_waiting_reasons_id integer,
     custom_reason_text character varying
@@ -538,7 +538,8 @@ CREATE TABLE users (
     updated_at timestamp without time zone NOT NULL,
     admin boolean DEFAULT false,
     first_name character varying,
-    last_name character varying
+    last_name character varying,
+    membership_number character varying
 );
 
 
@@ -562,98 +563,98 @@ ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: addresses id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY addresses ALTER COLUMN id SET DEFAULT nextval('addresses_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: business_categories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY business_categories ALTER COLUMN id SET DEFAULT nextval('business_categories_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: business_categories_membership_applications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY business_categories_membership_applications ALTER COLUMN id SET DEFAULT nextval('business_categories_membership_applications_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: ckeditor_assets id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY ckeditor_assets ALTER COLUMN id SET DEFAULT nextval('ckeditor_assets_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: companies id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY companies ALTER COLUMN id SET DEFAULT nextval('companies_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: kommuns id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY kommuns ALTER COLUMN id SET DEFAULT nextval('kommuns_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: member_app_waiting_reasons id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY member_app_waiting_reasons ALTER COLUMN id SET DEFAULT nextval('member_app_waiting_reasons_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: member_pages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY member_pages ALTER COLUMN id SET DEFAULT nextval('member_pages_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: membership_applications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY membership_applications ALTER COLUMN id SET DEFAULT nextval('membership_applications_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: regions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY regions ALTER COLUMN id SET DEFAULT nextval('regions_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: shf_documents id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY shf_documents ALTER COLUMN id SET DEFAULT nextval('shf_documents_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: uploaded_files id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY uploaded_files ALTER COLUMN id SET DEFAULT nextval('uploaded_files_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
 
 
 --
--- Name: addresses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: addresses addresses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY addresses
@@ -661,7 +662,7 @@ ALTER TABLE ONLY addresses
 
 
 --
--- Name: ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY ar_internal_metadata
@@ -669,7 +670,7 @@ ALTER TABLE ONLY ar_internal_metadata
 
 
 --
--- Name: business_categories_membership_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: business_categories_membership_applications business_categories_membership_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY business_categories_membership_applications
@@ -677,7 +678,7 @@ ALTER TABLE ONLY business_categories_membership_applications
 
 
 --
--- Name: business_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: business_categories business_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY business_categories
@@ -685,7 +686,7 @@ ALTER TABLE ONLY business_categories
 
 
 --
--- Name: ckeditor_assets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ckeditor_assets ckeditor_assets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY ckeditor_assets
@@ -693,7 +694,7 @@ ALTER TABLE ONLY ckeditor_assets
 
 
 --
--- Name: companies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: companies companies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY companies
@@ -701,7 +702,7 @@ ALTER TABLE ONLY companies
 
 
 --
--- Name: kommuns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: kommuns kommuns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY kommuns
@@ -709,7 +710,7 @@ ALTER TABLE ONLY kommuns
 
 
 --
--- Name: member_app_waiting_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: member_app_waiting_reasons member_app_waiting_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY member_app_waiting_reasons
@@ -717,7 +718,7 @@ ALTER TABLE ONLY member_app_waiting_reasons
 
 
 --
--- Name: member_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: member_pages member_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY member_pages
@@ -725,7 +726,7 @@ ALTER TABLE ONLY member_pages
 
 
 --
--- Name: membership_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: membership_applications membership_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY membership_applications
@@ -733,7 +734,7 @@ ALTER TABLE ONLY membership_applications
 
 
 --
--- Name: regions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: regions regions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY regions
@@ -741,7 +742,7 @@ ALTER TABLE ONLY regions
 
 
 --
--- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY schema_migrations
@@ -749,7 +750,7 @@ ALTER TABLE ONLY schema_migrations
 
 
 --
--- Name: shf_documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: shf_documents shf_documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY shf_documents
@@ -757,7 +758,7 @@ ALTER TABLE ONLY shf_documents
 
 
 --
--- Name: uploaded_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: uploaded_files uploaded_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY uploaded_files
@@ -765,7 +766,7 @@ ALTER TABLE ONLY uploaded_files
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users
@@ -836,13 +837,6 @@ CREATE INDEX index_membership_applications_on_member_app_waiting_reasons_id ON m
 
 
 --
--- Name: index_membership_applications_on_membership_number; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_membership_applications_on_membership_number ON membership_applications USING btree (membership_number);
-
-
---
 -- Name: index_membership_applications_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -892,7 +886,7 @@ CREATE UNIQUE INDEX index_users_on_reset_password_token ON users USING btree (re
 
 
 --
--- Name: fk_rails_1b8d2a3863; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: ckeditor_assets fk_rails_1b8d2a3863; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY ckeditor_assets
@@ -900,7 +894,7 @@ ALTER TABLE ONLY ckeditor_assets
 
 
 --
--- Name: fk_rails_2224289299; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: uploaded_files fk_rails_2224289299; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY uploaded_files
@@ -908,7 +902,7 @@ ALTER TABLE ONLY uploaded_files
 
 
 --
--- Name: fk_rails_3ee395b045; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: membership_applications fk_rails_3ee395b045; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY membership_applications
@@ -916,7 +910,7 @@ ALTER TABLE ONLY membership_applications
 
 
 --
--- Name: fk_rails_76a66052a5; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: addresses fk_rails_76a66052a5; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY addresses
@@ -924,7 +918,7 @@ ALTER TABLE ONLY addresses
 
 
 --
--- Name: fk_rails_bb6df17516; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: shf_documents fk_rails_bb6df17516; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY shf_documents
@@ -932,7 +926,7 @@ ALTER TABLE ONLY shf_documents
 
 
 --
--- Name: fk_rails_be394644c4; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: membership_applications fk_rails_be394644c4; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY membership_applications
@@ -940,7 +934,7 @@ ALTER TABLE ONLY membership_applications
 
 
 --
--- Name: fk_rails_f7aa0f06a9; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: addresses fk_rails_f7aa0f06a9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY addresses
@@ -999,6 +993,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170918123414'),
 ('20170919120008'),
 ('20170920153643'),
-('20170922144510');
+('20170922144510'),
+('20171005113112');
 
 

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe AdminController, type: :controller do
                                    state:         app_state.name,
                                    user:          u
 
-            member1_info = "#{m.contact_email},#{u.first_name},#{u.last_name},#{m.membership_number},"+ I18n.t("membership_applications.state.#{app_state.name}")
+            member1_info = "#{m.contact_email},#{u.first_name},#{u.last_name},#{u.membership_number},"+ I18n.t("membership_applications.state.#{app_state.name}")
 
             result_str << member1_info + ','
             result_str << '"",'  # no business categories
@@ -112,7 +112,9 @@ RSpec.describe AdminController, type: :controller do
 
         let(:u1) { FactoryGirl.create(:user,
                                       first_name:     "u1",
-                                      email: "user1@example.com") }
+                                      email: "user1@example.com",
+                                      membership_number: '1234567890')
+        }
 
         let(:c1) { FactoryGirl.create(:company) }
 
@@ -121,10 +123,7 @@ RSpec.describe AdminController, type: :controller do
                                                       state:          :accepted,
                                                       company_number: c1.company_number,
                                                       user:           u1
-
-                        m1.update(membership_number: '1234567890')
-                        m1
-                      }
+        }
 
 
         let(:csv_response) { post :export_ansokan_csv
@@ -136,7 +135,7 @@ RSpec.describe AdminController, type: :controller do
 
           result_str = csv_header
 
-          member1_info = "#{member1.contact_email},#{u1.first_name},#{u1.last_name},#{member1.membership_number},"+ I18n.t("membership_applications.state.#{member1.state}")
+          member1_info = "#{member1.contact_email},#{u1.first_name},#{u1.last_name},#{u1.membership_number},"+ I18n.t("membership_applications.state.#{member1.state}")
 
           result_str << member1_info + ','
           result_str << '"",'  # no business categories
@@ -156,7 +155,9 @@ RSpec.describe AdminController, type: :controller do
 
         let(:u1) { FactoryGirl.create(:user,
                                       first_name:     "u1",
-                                      email: "user1@example.com") }
+                                      email: "user1@example.com",
+                                      membership_number: '1234567890')
+        }
 
         let(:c1) { FactoryGirl.create(:company) }
 
@@ -165,16 +166,13 @@ RSpec.describe AdminController, type: :controller do
                                                 state:          :accepted,
                                                 company_number: c1.company_number,
                                                 user:           u1
-
-                        m1.update(membership_number: '1234567890')
-                        m1
                       }
 
         let(:csv_response) { post :export_ansokan_csv
                              response.body
                            }
 
-        let(:member1_info) {  "#{member1.contact_email},#{u1.first_name},#{u1.last_name},#{member1.membership_number},"+ I18n.t("membership_applications.state.#{member1.state}") }
+        let(:member1_info) {  "#{member1.contact_email},#{u1.first_name},#{u1.last_name},#{u1.membership_number},"+ I18n.t("membership_applications.state.#{member1.state}") }
 
 
         it 'zero/nil business categories' do

--- a/spec/models/membership_application_spec.rb
+++ b/spec/models/membership_application_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe MembershipApplication, type: :model do
     it {is_expected.to have_db_column :company_number}
     it {is_expected.to have_db_column :phone_number}
     it {is_expected.to have_db_column :contact_email}
-    it {is_expected.to have_db_column :membership_number}
     it {is_expected.to have_db_column :state}
     it {is_expected.to have_db_column :custom_reason_text}
   end
@@ -58,8 +57,6 @@ RSpec.describe MembershipApplication, type: :model do
     it {is_expected.not_to allow_value('userexample.com').for(:contact_email)}
 
     it {is_expected.to validate_length_of(:company_number).is_equal_to(10)}
-
-    it {is_expected.to validate_uniqueness_of :membership_number}
   end
 
   describe 'Validate Swedish Orgnr' do
@@ -342,34 +339,34 @@ RSpec.describe MembershipApplication, type: :model do
     end
 
     it 'does not generate a membership_number for a new application' do
-      expect(new_app.membership_number).to be_nil
+      expect(new_app.user.membership_number).to be_nil
     end
 
     it 'generates a membership_number when an application is accepted' do
       new_app.accept
-      expect(new_app.membership_number).not_to be_blank
+      expect(new_app.user.membership_number).not_to be_blank
     end
 
     it 'does not overwrite an existing membership_number when an application is accepted' do
       existing_number = 'SHF00042'
-      new_app.membership_number = existing_number
+      new_app.user.membership_number = existing_number
       new_app.accept
-      expect(new_app.membership_number).to eq(existing_number)
+      expect(new_app.user.membership_number).to eq(existing_number)
     end
 
     it 'removes the membership_number when an application is rejected' do
       new_app.accept
       new_app.reject
-      expect(new_app.membership_number).to be_nil
+      expect(new_app.user.membership_number).to be_nil
     end
 
     it 'generates sequential membership_numbers' do
       new_app.accept
-      first_number = new_app.membership_number.to_i
+      first_number = new_app.user.membership_number.to_i
 
       new_app.reject
       new_app.accept
-      second_number = new_app.membership_number.to_i
+      second_number = new_app.user.membership_number.to_i
 
       expect(second_number).to eq(first_number+1)
     end

--- a/spec/models/membership_application_spec.rb
+++ b/spec/models/membership_application_spec.rb
@@ -332,43 +332,26 @@ RSpec.describe MembershipApplication, type: :model do
 
   describe 'membership number generator' do
 
-    let(:new_app) { create(:membership_application) }
+    let(:user) { create(:user) }
+    let(:new_app) { create(:membership_application, user: user) }
 
     before(:each) do
       new_app.start_review
     end
 
     it 'does not generate a membership_number for a new application' do
-      expect(new_app.user.membership_number).to be_nil
+      expect(user.membership_number).to be_nil
     end
 
     it 'generates a membership_number when an application is accepted' do
       new_app.accept
-      expect(new_app.user.membership_number).not_to be_blank
-    end
-
-    it 'does not overwrite an existing membership_number when an application is accepted' do
-      existing_number = 'SHF00042'
-      new_app.user.membership_number = existing_number
-      new_app.accept
-      expect(new_app.user.membership_number).to eq(existing_number)
+      expect(user.membership_number).not_to be_blank
     end
 
     it 'removes the membership_number when an application is rejected' do
       new_app.accept
       new_app.reject
-      expect(new_app.user.membership_number).to be_nil
-    end
-
-    it 'generates sequential membership_numbers' do
-      new_app.accept
-      first_number = new_app.user.membership_number.to_i
-
-      new_app.reject
-      new_app.accept
-      second_number = new_app.user.membership_number.to_i
-
-      expect(second_number).to eq(first_number+1)
+      expect(user.membership_number).to be_nil
     end
 
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,8 +19,13 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_db_column :id }
     it {is_expected.to have_db_column :first_name}
     it {is_expected.to have_db_column :last_name}
+    it {is_expected.to have_db_column :membership_number}
     it { is_expected.to have_db_column :email }
     it { is_expected.to have_db_column :admin }
+  end
+
+  describe 'Validations' do
+    it {is_expected.to validate_uniqueness_of :membership_number}
   end
 
   describe 'Associations' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe User, type: :model do
   end
 
   describe 'Validations' do
+    it { is_expected.to(validate_presence_of :first_name) }
+    it { is_expected.to(validate_presence_of :last_name) }
     it {is_expected.to validate_uniqueness_of :membership_number}
   end
 
@@ -380,8 +382,27 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'Validations' do
-    it { is_expected.to(validate_presence_of :first_name) }
-    it { is_expected.to(validate_presence_of :last_name) }
+
+  describe '#issue_membership_number' do
+
+    it 'does not overwrite an existing membership_number' do
+      existing_number = 'SHF00042'
+      subject.membership_number = existing_number
+      subject.issue_membership_number
+      expect(subject.membership_number).to eq(existing_number)
+    end
+
+    it 'generates sequential membership_numbers' do
+      subject.issue_membership_number
+      first_number = subject.membership_number.to_i
+
+      subject.membership_number = nil
+      subject.issue_membership_number
+      second_number = subject.membership_number.to_i
+
+      expect(second_number).to eq(first_number+1)
+    end
+
   end
+
 end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/151613380

**Changes proposed in this pull request:**

1. Add a migration to move `membership_number` from the `membership_applications` table to the `users` table.
  
2. Make the minimal changes needed to fix RSpec and Cucumber tests. 

3. Introduce delegates for `membership_number` on the `MembershipApplication` model to defer decisions about if and how to change the UI for issuing membership numbers.

3. Clean up the model code, i.e. Move the `get_next_membership_number` function to the `User` class, and introduce the method `issue_membership_number` on a user.

Screenshots (Optional):


Ready for review:
@weedySeaDragon @patmbolger 