### PR TITLE
Do not allow delete of a company "mail" address

### DIFF
--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -1,6 +1,8 @@
 %header.entry-header
   %h1.entry-title= t('.title', company_name: @company.name)
   = t('.cannot_delete_address') if @address.mail
+  %span.glyphicon.glyphicon-info-sign{ title: "#{t('.delete_address_tooltip')}",
+                                       data: {toggle: 'tooltip'} }
   .post-title-divider
     %span
 

--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -1,5 +1,6 @@
 %header.entry-header
   %h1.entry-title= t('.title', company_name: @company.name)
+  = t('.cannot_delete_address') if @address.mail
   .post-title-divider
     %span
 
@@ -9,8 +10,9 @@
                      url: company_address_path(@company.id, @address.id) }
   .center
     = link_to "#{t('companies.view_company')}", @company
-    \|
-    = link_to "#{t('.delete')}", company_address_delete_path(@company, @address),
-              method: :delete,
-              data: { confirm: "#{t('.delete_confirm')}" },
-              class: 'btn btn-xs btn-danger'
+    - unless @address.mail
+      \|
+      = link_to "#{t('.delete')}", company_address_delete_path(@company, @address),
+                method: :delete,
+                data: { confirm: "#{t('.delete_confirm')}" },
+                class: 'btn btn-xs btn-danger'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -501,6 +501,7 @@ en:
       title: 'Editing Address for: %{company_name}'
       delete: 'Delete this address'
       delete_confirm: Are you sure you want to delete this address?
+      cannot_delete_address: (Company mail address - cannot be deleted)
     update:
       error: There was a problem updating the address.
       success: The address was updated.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -502,6 +502,8 @@ en:
       delete: 'Delete this address'
       delete_confirm: Are you sure you want to delete this address?
       cannot_delete_address: (Company mail address - cannot be deleted)
+      delete_address_tooltip: If you want to delete this address, specify
+                              another address as the company mail address.
     update:
       error: There was a problem updating the address.
       success: The address was updated.

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -503,6 +503,8 @@ sv:
       delete: 'Ta bort den här adressen'
       delete_confirm: Är du säker på att du vill radera den här adressen?
       cannot_delete_address: (Företagets mailadress - kan inte raderas)
+      delete_address_tooltip: Om du vill radera den här adressen anger du en
+                              annan adress som företagets mailadress.
     update:
       error: Det gick inte att uppdatera adressen.
       success: Adressen uppdaterades.

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -502,6 +502,7 @@ sv:
       title: 'Redigera adress för: %{company_name}'
       delete: 'Ta bort den här adressen'
       delete_confirm: Är du säker på att du vill radera den här adressen?
+      cannot_delete_address: (Företagets mailadress - kan inte raderas)
     update:
       error: Det gick inte att uppdatera adressen.
       success: Adressen uppdaterades.

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,6 +1,5 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
@@ -563,98 +562,98 @@ ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
--- Name: addresses id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY addresses ALTER COLUMN id SET DEFAULT nextval('addresses_id_seq'::regclass);
 
 
 --
--- Name: business_categories id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY business_categories ALTER COLUMN id SET DEFAULT nextval('business_categories_id_seq'::regclass);
 
 
 --
--- Name: business_categories_membership_applications id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY business_categories_membership_applications ALTER COLUMN id SET DEFAULT nextval('business_categories_membership_applications_id_seq'::regclass);
 
 
 --
--- Name: ckeditor_assets id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY ckeditor_assets ALTER COLUMN id SET DEFAULT nextval('ckeditor_assets_id_seq'::regclass);
 
 
 --
--- Name: companies id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY companies ALTER COLUMN id SET DEFAULT nextval('companies_id_seq'::regclass);
 
 
 --
--- Name: kommuns id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY kommuns ALTER COLUMN id SET DEFAULT nextval('kommuns_id_seq'::regclass);
 
 
 --
--- Name: member_app_waiting_reasons id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY member_app_waiting_reasons ALTER COLUMN id SET DEFAULT nextval('member_app_waiting_reasons_id_seq'::regclass);
 
 
 --
--- Name: member_pages id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY member_pages ALTER COLUMN id SET DEFAULT nextval('member_pages_id_seq'::regclass);
 
 
 --
--- Name: membership_applications id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY membership_applications ALTER COLUMN id SET DEFAULT nextval('membership_applications_id_seq'::regclass);
 
 
 --
--- Name: regions id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY regions ALTER COLUMN id SET DEFAULT nextval('regions_id_seq'::regclass);
 
 
 --
--- Name: shf_documents id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY shf_documents ALTER COLUMN id SET DEFAULT nextval('shf_documents_id_seq'::regclass);
 
 
 --
--- Name: uploaded_files id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY uploaded_files ALTER COLUMN id SET DEFAULT nextval('uploaded_files_id_seq'::regclass);
 
 
 --
--- Name: users id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
 
 
 --
--- Name: addresses addresses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: addresses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY addresses
@@ -662,7 +661,7 @@ ALTER TABLE ONLY addresses
 
 
 --
--- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY ar_internal_metadata
@@ -670,7 +669,7 @@ ALTER TABLE ONLY ar_internal_metadata
 
 
 --
--- Name: business_categories_membership_applications business_categories_membership_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: business_categories_membership_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY business_categories_membership_applications
@@ -678,7 +677,7 @@ ALTER TABLE ONLY business_categories_membership_applications
 
 
 --
--- Name: business_categories business_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: business_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY business_categories
@@ -686,7 +685,7 @@ ALTER TABLE ONLY business_categories
 
 
 --
--- Name: ckeditor_assets ckeditor_assets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ckeditor_assets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY ckeditor_assets
@@ -694,7 +693,7 @@ ALTER TABLE ONLY ckeditor_assets
 
 
 --
--- Name: companies companies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: companies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY companies
@@ -702,7 +701,7 @@ ALTER TABLE ONLY companies
 
 
 --
--- Name: kommuns kommuns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: kommuns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY kommuns
@@ -710,7 +709,7 @@ ALTER TABLE ONLY kommuns
 
 
 --
--- Name: member_app_waiting_reasons member_app_waiting_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: member_app_waiting_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY member_app_waiting_reasons
@@ -718,7 +717,7 @@ ALTER TABLE ONLY member_app_waiting_reasons
 
 
 --
--- Name: member_pages member_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: member_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY member_pages
@@ -726,7 +725,7 @@ ALTER TABLE ONLY member_pages
 
 
 --
--- Name: membership_applications membership_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: membership_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY membership_applications
@@ -734,7 +733,7 @@ ALTER TABLE ONLY membership_applications
 
 
 --
--- Name: regions regions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: regions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY regions
@@ -742,7 +741,7 @@ ALTER TABLE ONLY regions
 
 
 --
--- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY schema_migrations
@@ -750,7 +749,7 @@ ALTER TABLE ONLY schema_migrations
 
 
 --
--- Name: shf_documents shf_documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: shf_documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY shf_documents
@@ -758,7 +757,7 @@ ALTER TABLE ONLY shf_documents
 
 
 --
--- Name: uploaded_files uploaded_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: uploaded_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY uploaded_files
@@ -766,7 +765,7 @@ ALTER TABLE ONLY uploaded_files
 
 
 --
--- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users
@@ -893,7 +892,7 @@ CREATE UNIQUE INDEX index_users_on_reset_password_token ON users USING btree (re
 
 
 --
--- Name: ckeditor_assets fk_rails_1b8d2a3863; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_1b8d2a3863; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY ckeditor_assets
@@ -901,7 +900,7 @@ ALTER TABLE ONLY ckeditor_assets
 
 
 --
--- Name: uploaded_files fk_rails_2224289299; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_2224289299; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY uploaded_files
@@ -909,7 +908,7 @@ ALTER TABLE ONLY uploaded_files
 
 
 --
--- Name: membership_applications fk_rails_3ee395b045; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_3ee395b045; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY membership_applications
@@ -917,7 +916,7 @@ ALTER TABLE ONLY membership_applications
 
 
 --
--- Name: addresses fk_rails_76a66052a5; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_76a66052a5; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY addresses
@@ -925,7 +924,7 @@ ALTER TABLE ONLY addresses
 
 
 --
--- Name: shf_documents fk_rails_bb6df17516; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_bb6df17516; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY shf_documents
@@ -933,7 +932,7 @@ ALTER TABLE ONLY shf_documents
 
 
 --
--- Name: membership_applications fk_rails_be394644c4; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_be394644c4; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY membership_applications
@@ -941,7 +940,7 @@ ALTER TABLE ONLY membership_applications
 
 
 --
--- Name: addresses fk_rails_f7aa0f06a9; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_f7aa0f06a9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY addresses

--- a/features/member_edits_company_page.feature
+++ b/features/member_edits_company_page.feature
@@ -81,7 +81,13 @@ Feature: As a member
     And I click on t("submit")
     And I should see "3" addresses
 
+    Then I click the third address for company "Happy Mutts"
+    And I should see t("addresses.edit.cannot_delete_address")
+    And I should not see t("'addresses.edit.delete'")
+    And I click on the t("companies.view_company") link
+
     And I click the second address for company "Happy Mutts"
+    And I should not see t("addresses.edit.cannot_delete_address")
     And I click on the t("addresses.edit.delete") link
     And I confirm popup
     Then I should see t("addresses.destroy.success")


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/151803266


Changes proposed in this pull request:

In address `edit` view (for `mail` address):

1. Tell user that this is the company's `mail` address (and can't be deleted)
  - (tooltip explains how to delete _this_ address)
2. Do not show `Delete this address` button

Screenshot: `edit` view for company address:

<img width="768" alt="screen shot 2017-10-10 at 6 41 46 am" src="https://user-images.githubusercontent.com/9968213/31382572-23e63832-ad86-11e7-89a7-6a6258a93faa.png">


Ready for review:
@weedySeaDragon @RobertCram @thesuss 