### PR TITLE
Only geocode addr on create or when location field changed

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -40,7 +40,7 @@ class Address < ApplicationRecord
                   region_id visibility country).freeze
 
   after_validation :geocode_best_possible,
-                   :if => lambda { |obj| !obj.persisted? ||
+                   :if => lambda { |obj| obj.new_record? ||
                                          (obj.changed & GEO_FIELDS).any? }
 
   # geocode all of the addresses that need it

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -36,8 +36,12 @@ class Address < ApplicationRecord
 
   geocoded_by :entire_address
 
+  GEO_FIELDS = %w(street_address post_code city kommun_id
+                  region_id visibility country).freeze
+
   after_validation :geocode_best_possible,
-                   :if => lambda { |obj| obj.changed? }
+                   :if => lambda { |obj| !obj.persisted? ||
+                                         (obj.changed & GEO_FIELDS).any? }
 
   # geocode all of the addresses that need it
   #


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/151622078

Changes proposed in this pull request:

1. Geocode address (before saving) only when first created or if one or more "location" fields have changed.

Ready for review:
@weedySeaDragon @RobertCram