### PR TITLE
Catch and log any errors with Mailgun REST

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,4 +115,8 @@ group :test do
   gem 'email_spec'
   gem 'selenium-webdriver'
   gem 'chromedriver-helper'
+
+  gem 'webmock'  # to mock web (HTTP) interactions.  Required by the vcr gem
+  gem 'vcr'      # to record and 'playback' (mock) http requests
+
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,8 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.4)
       tins (~> 1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.2)
     css_parser (1.5.0)
       addressable
@@ -210,6 +212,7 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
+    hashdiff (0.3.7)
     high_voltage (3.0.0)
     highline (1.7.8)
     html2haml (2.2.0)
@@ -384,6 +387,7 @@ GEM
     ruby_parser (3.10.1)
       sexp_processor (~> 4.9)
     rubyzip (1.2.1)
+    safe_yaml (1.0.4)
     sanitize (4.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
@@ -450,6 +454,7 @@ GEM
     unf_ext (0.0.7.4)
     unicode-display_width (1.3.0)
     uniform_notifier (1.10.0)
+    vcr (3.0.3)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -457,6 +462,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.1.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -536,7 +545,9 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
+  vcr
   web-console
+  webmock
   will_paginate
 
 RUBY VERSION

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,6 @@
+require 'activity_logger'
+
+
 class ApplicationMailer < ActionMailer::Base
 
   # Formatting email is tricky because you cannot use the same CSS as you can in web pages,
@@ -22,25 +25,25 @@ class ApplicationMailer < ActionMailer::Base
   helper :application # gives access to all helpers defined within `application_helper`.
 
 
-  # if there is a problem communicating with the MailGun REST server, log the problem
+  LOG_FILE = File.join(Rails.configuration.paths['log'].absolute_current, 'mailgun.log')
+  LOG_FACILITY = 'Mailgun REST'
+
+
+  # If there is a problem communicating with the MailGun REST server, log the problem
+  # TODO notify the SHF admin(s) using the ExceptionNotfication gem (must be able to send a notification that does not use MailGun)
+  # Do not raise the error.  Do not want to show anything to the user
   def self.deliver_mail(mail)
 
-    begin
-      super
+    super
 
-    rescue => e
+  rescue  Mailgun::CommunicationError => mailgun_error
 
-      # This would be a great place to use the ExceptionNotification gem so we
-      # can also do other notifications in case we cannot communicate at all with MailGun.
+    ActivityLogger.open(LOG_FILE, LOG_FACILITY, 'Mailgun::CommunicationError', false) do |log|
 
-      # LOG the error
-      error_prefix = '>>> MAILGUN ERROR!  '
-      logger.debug( error_prefix + "Could not send email via mailgun at #{Time.now}" )
-      logger.debug{ error_prefix + " Error received from Mailgun: #{e}" }
-
-      raise e
+      log.record('error', "Could not send email via mailgun at #{Time.now}  Error received from Mailgun: #{mailgun_error}")
 
     end
+
   end
 
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -35,8 +35,8 @@ class ApplicationMailer < ActionMailer::Base
 
       # LOG the error
       error_prefix = '>>> MAILGUN ERROR!  '
-      logger.debug ( error_prefix + "Could not send email via mailgun at #{Time.now}" )
-      logger.debug { error_prefix + " Error received from Mailgun: #{e}" }
+      logger.debug( error_prefix + "Could not send email via mailgun at #{Time.now}" )
+      logger.debug{ error_prefix + " Error received from Mailgun: #{e}" }
 
       raise e
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -22,6 +22,28 @@ class ApplicationMailer < ActionMailer::Base
   helper :application # gives access to all helpers defined within `application_helper`.
 
 
+  # if there is a problem communicating with the MailGun REST server, log the problem
+  def self.deliver_mail(mail)
+
+    begin
+      super
+
+    rescue => e
+
+      # This would be a great place to use the ExceptionNotification gem so we
+      # can also do other notifications in case we cannot communicate at all with MailGun.
+
+      # LOG the error
+      error_prefix = '>>> MAILGUN ERROR!  '
+      logger.debug ( error_prefix + "Could not send email via mailgun at #{Time.now}" )
+      logger.debug { error_prefix + " Error received from Mailgun: #{e}" }
+
+      raise e
+
+    end
+  end
+
+
   def test_email(user)
     @action_name = __method__.to_s
     @greeting_name = set_greeting_name(user)

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 require 'email_spec'
 require 'email_spec/rspec'
 
-#  shared examples for RSpec below
+require File.join(__dir__, 'shared_email_tests')
+
+
 
 shared_examples 'delivery is OK' do
 
@@ -62,7 +64,7 @@ RSpec.describe ApplicationMailer, type: :mailer do
 
   describe '#domain' do
 
-    it 'can be nil (which should then rightly mean an error response from Mailgun)' do
+    it 'can be nil (which would then rightly mean an error response from Mailgun)' do
 
       stub_const('ENV', ENV.to_hash)
       ENV.delete('MAILGUN_DOMAIN')
@@ -91,7 +93,7 @@ RSpec.describe ApplicationMailer, type: :mailer do
     end
 
     it "should have the correct subject" do
-      expect(@email).to have_subject( I18n.t('application_mailer.greeting', greeting_name: @test_user.full_name))
+      expect(@email).to have_subject(I18n.t('application_mailer.greeting', greeting_name: @test_user.full_name))
     end
 
     it "default from address is ENV['SHF_NOREPLY_EMAIL']" do
@@ -169,6 +171,70 @@ RSpec.describe ApplicationMailer, type: :mailer do
 
     end
 
+
+  end
+
+
+  describe 'logs Mailgun errors', vcr: { cassette_name: 'mailgun', record: :none } do
+
+    # do not actually hit the net; mock the responses from the vcr file instead
+    before(:all) do
+
+      @orig_delivery_method = ApplicationMailer.delivery_method
+      ApplicationMailer.delivery_method = :mailgun
+
+      WebMock.disable_net_connect!(allow_localhost: true)
+    end
+
+    after(:all) do
+      ApplicationMailer.delivery_method = @orig_delivery_method
+      WebMock.allow_net_connect!(allow_localhost: true)
+    end
+
+
+    # return the number of matches in the file.
+    # Don't read the entire file into memory;
+    # read it only (num_lines_per_batch) lines at a time
+    def num_matches_in_file(fname, match_regexp)
+
+      num_lines_per_batch = 5000
+
+      num_matched = 0
+      File.open(fname, "r") do |f|
+
+        # use an enumerator to read just (num_lines_per_batch) lines at a time
+        f.lazy.each_slice(num_lines_per_batch) do |lines|
+
+          num_matched += lines.select { |line| line.match(match_regexp) }.count
+
+        end
+
+      end
+      num_matched
+    end
+
+
+    it 'will write to the log file if there was a problem sending info to Mailgun' do
+
+      test_user = create(:user)
+      mail_to_send = ApplicationMailer.test_email(test_user)
+
+      # this is a mocked response/error from the vcr cassette file
+      expect { mail_to_send.deliver }.to raise_error(Mailgun::CommunicationError)
+
+      log_fname = File.absolute_path(Rails.configuration.paths["log"].first)
+
+      mailgun_error_regexp = />>> MAILGUN ERROR\!\s+Could not send email via mailgun at/
+
+      before_mailgun_errors = num_matches_in_file(log_fname, mailgun_error_regexp)
+      expect { mail_to_send.deliver }.to raise_error(Mailgun::CommunicationError)
+
+      after_mailgun_errors = num_matches_in_file(log_fname, mailgun_error_regexp)
+      expect(after_mailgun_errors - before_mailgun_errors).to eq 1
+
+      expect(num_matches_in_file(log_fname, /An HTTP request has been made that VCR does not know how to handle/)).to eq 0
+
+    end
 
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,9 +4,20 @@ require 'simplecov'
 require 'pundit/rspec'
 require 'paperclip/matchers'
 
+require 'vcr'
+
+
 # Coveralls.wear_merged!('rails')
 
 # CodeClimate::TestReporter.start
+
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/vcr_cassettes'
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+end
+
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/vcr_cassettes/mailgun.yml
+++ b/spec/vcr_cassettes/mailgun.yml
@@ -1,0 +1,102 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/sverigeshundforetagare.se/messages
+    body:
+      encoding: UTF-8
+      string: from[hello@example.com]=noreply%40sverigeshundforetagare.se&subject[]=Hej+Firstname+Lastname&text[]=Hej+Firstname+Lastname%0A%0A%0AHej+Firstname+Lastname%0A%0A%0A%0A----------%0ASVERIGES+HUNDF%C3%96RETAGARE%0AKOMPETENS+%E2%80%93+GLA%CC%88DJE+%E2%80%93+OMTANKE%0Ahttp%3A%2F%2Fwww.sverigeshundforetagare.se%0Ahttp%3A%2F%2Fwww.facebook.com%2Fsverigeshundforetagare%0Ahttp%3A%2F%2Finstagram.com%2Fsverigeshundforetagare%0A%0ADet+h%C3%A4r+mailet+skickades+till+email_6%40random.com%0ADu+f%C3%A5r+detta+e-postmeddelande+eftersom+du+%C3%A4r+intresserad+av+medlemsskap+i+SVERIGES+HUNDF%C3%96RETAGARE+eller+du+%C3%A4r+medlem.%0A%0A&to[]=email_6%40random.com
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin15.6.0 x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '13032'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS03NDZkZjExNjU0MzYxYjM5MGIxYjUwMThiMDU4NTlhYw==
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 Nov 2016 19:42:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '52'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+           "message": "Domain not found: not-our-doma.in"
+        }
+    http_version:
+  recorded_at: Thu, 12 Oct 2017 21:53:28 GMT
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/sverigeshundforetagare.se/messages
+    body:
+      encoding: UTF-8
+      string: from[]=noreply%40sverigeshundforetagare.se&subject[]=Hej+Firstname+Lastname&to[]=email_1%40random.com
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin15.6.0 x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '13032'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS03NDZkZjExNjU0MzYxYjM5MGIxYjUwMThiMDU4NTlhYw==
+  response:
+    status:
+      code: 500
+      message: REQUEST FAILED
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 12 Oct 2017 22:31:06 GMT
+      Server:
+      - nginx
+      Content-Length:
+      - '115'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "<20171012223106.106709.094B6904BF5D87E7@sverigeshundforetagare.se>",
+          "message": "The request failed."
+        }
+    http_version:
+  recorded_at: Thu, 12 Oct 2017 22:31:06 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
### PT Story: Send applicant email acknowledging that their application was received
https://www.pivotaltracker.com/story/show/151614904

As I started working on that story, I realized we needed to be able to deal a bad response from MailGun when we tried to deliver mail.

## Changes proposed in this pull request:
1.  add a method to the ApplicationMailer that will rescue any problems with MailGun communication and log them.  Use a prefix so the logged info will be easy to find with a search/grep/etc.

### Ready for review:
@AgileVentures/shf-project-team 
