### PR TITLE
Add membership number to user show page

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -12,6 +12,8 @@
 .entry-content
   = field_or_none("#{t('.email')}", mail_to(@user.email), label_class: 'standard-label')
 
+  = field_or_none("#{t('.membership_number')}", @user.membership_number, label_class: 'standard-label')
+
   - unless @user.membership_applications.exists?
     = field_or_none("#{t('applications')}", t('none'), label_class: 'standard-label')
   - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -570,6 +570,7 @@ en:
       no_search_results: No records matched your search criteria.
 
     show:
+      membership_numer: *membership_number
       email: *email
       current_sign_in_at: *user_current_signed_in_time
       current_sign_in_ip: *user_current_ip

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -570,7 +570,7 @@ en:
       no_search_results: No records matched your search criteria.
 
     show:
-      membership_numer: *membership_number
+      membership_number: *membership_number
       email: *email
       current_sign_in_at: *user_current_signed_in_time
       current_sign_in_ip: *user_current_ip

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -571,6 +571,7 @@ sv:
       no_search_results: Din sökning gav inget resultat, prova att ta bort något av dina val.
 
     show:
+      membership_number: *membership_number
       email: *email
       current_sign_in_at: *user_current_signed_in_time
       current_sign_in_ip: *user_current_ip

--- a/features/show-user-details.feature
+++ b/features/show-user-details.feature
@@ -7,16 +7,16 @@ Feature: As an admin
   Background:
 
     Given the following users exists
-      | email                   | admin |
-      | emma@personal.com       |       |
-      | lars@personal.com       |       |
-      | hannah@personal.com     |       |
-      | nils@personal.se        |       |
-      | anna@personal.se        |       |
-      | sam@personal.se         |       |
-      | admin@shf.se            | true  |
-      | yesterday_admin@shf.se  | true  |
-      | lazy_admin@shf.se       | true  |
+      | email                   | admin | membership_number |
+      | emma@personal.com       |       | 100               |
+      | lars@personal.com       |       | 101               |
+      | hannah@personal.com     |       | 102               |
+      | nils@personal.se        |       |                   |
+      | anna@personal.se        |       |                   |
+      | sam@personal.se         |       |                   |
+      | admin@shf.se            | true  |                   |
+      | yesterday_admin@shf.se  | true  |                   |
+      | lazy_admin@shf.se       | true  |                   |
 
     And the following regions exist:
       | name         |
@@ -108,6 +108,12 @@ Feature: As an admin
     When I am on the "user details" page for "emma@personal.com"
     Then I should see t("users.show.password_never_reset")
 
+  @member
+  Scenario: Show the membership number for a member
+    When I am on the "user details" page for "emma@personal.com"
+    Then I should see t("users.show.membership_number")
+    And I should see "100"
+
 
   @user
   Scenario: Show an user who has never logged in
@@ -140,3 +146,9 @@ Feature: As an admin
     And I should see "emma@bowsers.com"
     And I should see "5560360793"
     And I should see "2120000142"
+
+  @user
+  Scenario: Do not show the membership number when there is none
+    When I am on the "user details" page for "nils@personal.se"
+    Then I should not see t("users.show.membership_number")
+

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -4,6 +4,8 @@ Given(/^the following users exist(?:s|)$/) do |table|
     is_member = user.delete('is_member')
     is_legacy = user.delete('is_legacy')
 
+    user['membership_number'] = nil if user['membership_number'].blank?
+
     if user['admin'] == 'true'
       FactoryGirl.create(:user, user)
     else


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/151634640

**Changes proposed in this pull request:**

1.  If it exists, show membership number on the user show page

2. Add feature tests for user show page with and without membership number

Ready for review:
@Thesus @patmbolger @weedySeaDragon 