### PR TITLE
Fix Country field in CSV export so it is always "Sverige" 

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -64,7 +64,7 @@ class AdminController < ApplicationController
     header_member_strs = ['activerecord.attributes.membership_application.contact_email',
                           'activerecord.attributes.membership_application.first_name',
                           'activerecord.attributes.membership_application.last_name',
-                          'activerecord.attributes.membership_application.membership_number',
+                          'activerecord.attributes.user.membership_number',
                           'activerecord.attributes.membership_application.state',
                           'activerecord.models.business_category.other',
                           'activerecord.models.company.one',

--- a/app/services/address_exporter.rb
+++ b/app/services/address_exporter.rb
@@ -11,8 +11,7 @@
 class AddressExporter
 
   SVERIGE_COUNTRY    = 'Sverige'
-  SVERIGE_POSTAL_STR = 'SE-Sweden'
-
+  SVERIGE_VARIATIONS = ['SE', 'Sverige', 'SE-Sweden', 'Sveriges', 'SE-Sverige']
 
 
   def self.se_mailing_csv_str(address)
@@ -35,11 +34,14 @@ class AddressExporter
 
 
 
-  # if country == 'Sverige' return what the Swedish Postal service wants to see for a mailing address
+  # if country == 'Sverige' || 'SE' || 'Sveriges' standardize to "Sverige"
   def self.country_postal(address)
 
     if address
-      address.country == SVERIGE_COUNTRY ? SVERIGE_POSTAL_STR : address.country
+      if SVERIGE_VARIATIONS.include?(address.country)
+        address.country = SVERIGE_COUNTRY
+      end
+      address.country
     else
       ''
     end

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AdminController, type: :controller do
   out_str << "'#{I18n.t('activerecord.attributes.membership_application.contact_email').strip}',"
   out_str << "'#{I18n.t('activerecord.attributes.membership_application.first_name').strip}',"
   out_str << "'#{I18n.t('activerecord.attributes.membership_application.last_name').strip}',"
-  out_str << "'#{I18n.t('activerecord.attributes.membership_application.membership_number').strip}',"
+  out_str << "'#{I18n.t('activerecord.attributes.user.membership_number').strip}',"
   out_str << "'#{I18n.t('activerecord.attributes.membership_application.state').strip}',"
   out_str << "'#{I18n.t('activerecord.models.business_category.other').strip}',"
   out_str << "'#{I18n.t('activerecord.models.company.one').strip}',"

--- a/spec/services/address_exporter_spec.rb
+++ b/spec/services/address_exporter_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe AddressExporter do
     it 'is a comma separated string' do
 
       expected_str = '"' + valid_address1.street_address + '",'
-      expected_str << "#{post_code_str valid_address1.post_code},#{valid_address1.city},#{valid_address1.kommun.name },#{valid_address1.region.name},SE-Sweden"
+      expected_str << "#{post_code_str valid_address1.post_code},#{valid_address1.city},#{valid_address1.kommun.name },#{valid_address1.region.name},Sverige"
 
       expect(AddressExporter.se_mailing_csv_str(valid_address1)).to eq expected_str
     end
@@ -83,7 +83,7 @@ RSpec.describe AddressExporter do
       valid_address1.kommun = nil
 
       expected_str = '"' + valid_address1.street_address + '",'
-      expected_str << "#{post_code_str valid_address1.post_code},#{valid_address1.city},,#{valid_address1.region.name},SE-Sweden"
+      expected_str << "#{post_code_str valid_address1.post_code},#{valid_address1.city},,#{valid_address1.region.name},Sverige"
 
       expect(AddressExporter.se_mailing_csv_str(valid_address1)).to eq expected_str
 
@@ -94,30 +94,53 @@ RSpec.describe AddressExporter do
       valid_address1.region = nil
 
       expected_str = '"' + valid_address1.street_address + '",'
-      expected_str << "#{post_code_str valid_address1.post_code},#{valid_address1.city},#{valid_address1.kommun.name },,SE-Sweden"
+      expected_str << "#{post_code_str valid_address1.post_code},#{valid_address1.city},#{valid_address1.kommun.name },,Sverige"
 
       expect(AddressExporter.se_mailing_csv_str(valid_address1)).to eq expected_str
 
     end
 
-
-    it "will print SE-Sweden for the country if the country attribute == 'Sverige'" do
-
-      export_str = AddressExporter.se_mailing_csv_str(valid_address1)
-
-      expect(export_str).to match(/SE-Sweden/)
-      expect(export_str).not_to match(/Sverige/)
-    end
-
-
-    it "will use whatever is stored for the country if it is something other than 'Sveriges'" do
+    it "will use whatever is stored for the country if it is something other than 'Sverige' or a variation" do
 
       valid_address1.country = "Sweeeeeden"
 
       export_str = AddressExporter.se_mailing_csv_str(valid_address1)
 
       expect(export_str).to match(/Sweeeeeden/)
-      expect(export_str).not_to match(/SE-Sweden/)
+      expect(export_str).not_to match(/Sverige/)
+    end
+
+
+    describe 'country is standardized to Sverige if is any variation of SE/Sverige, etc.' do
+
+
+
+      it 'SE' do
+        valid_address1.country = "SE"
+
+        export_str = AddressExporter.se_mailing_csv_str(valid_address1)
+
+        expect(export_str).to match(/Sverige/)
+        expect(export_str).not_to match(/SE/)
+      end
+
+      it 'Sverige' do
+        valid_address1.country = "Sverige"
+
+        export_str = AddressExporter.se_mailing_csv_str(valid_address1)
+
+        expect(export_str).to match(/Sverige/)
+      end
+
+      it 'Sveriges' do
+        valid_address1.country = "Sveriges"
+
+        export_str = AddressExporter.se_mailing_csv_str(valid_address1)
+
+        expect(export_str).to match(/Sverige/)
+        expect(export_str).not_to match(/Sveriges/)
+      end
+
     end
 
 


### PR DESCRIPTION
PT Story: Fix Country field in CSV export
https://www.pivotaltracker.com/story/show/151516619

Changes proposed in this pull request:
1.  update the locale lookup  for the attribute name to use "user.membership_number" vs. "membership_application.membership_number"
2. If the country name is anything that might be Sweden, then standardize what is output in the CSV export to "Sverige".  (The data for `country` should only be "Sverige" since we don't provide a way for a user to change that.  But legacy data might have something else.)
(And in the future, people might be in a different or close-by country.)

Ready for review:
@thesuss @AgileVentures/shf-project-team 
