### PR TITLE
In address "edit" view, hide tooltip if address != mail

### DIFF
--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -1,7 +1,7 @@
 %header.entry-header
   %h1.entry-title= t('.title', company_name: @company.name)
   - if @address.mail
-    = t('.cannot_delete_address') if @address.mail
+    = t('.cannot_delete_address')
     %span.glyphicon.glyphicon-info-sign{ title: "#{t('.delete_address_tooltip')}",
                                          data: {toggle: 'tooltip'} }
   .post-title-divider

--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -1,8 +1,9 @@
 %header.entry-header
   %h1.entry-title= t('.title', company_name: @company.name)
-  = t('.cannot_delete_address') if @address.mail
-  %span.glyphicon.glyphicon-info-sign{ title: "#{t('.delete_address_tooltip')}",
-                                       data: {toggle: 'tooltip'} }
+  - if @address.mail
+    = t('.cannot_delete_address') if @address.mail
+    %span.glyphicon.glyphicon-info-sign{ title: "#{t('.delete_address_tooltip')}",
+                                         data: {toggle: 'tooltip'} }
   .post-title-divider
     %span
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/152092590


Changes proposed in this pull request:
1. Hide tooltip (re how to delete an address if it is the mail address) if the edited address is _not_ the mail address.

Screenshots (Optional):


Ready for review:
@AgileVentures/shf-project-team 