### PR TITLE
Refactor Company#main_address to return mail address for company

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -34,6 +34,8 @@ class Address < ApplicationRecord
 
   scope :visible, -> { where.not(visibility: 'none') }
 
+  scope :mail_address, -> { where(mail: true) }
+
   geocoded_by :entire_address
 
   GEO_FIELDS = %w(street_address post_code city kommun_id

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -82,7 +82,10 @@ class Company < ApplicationRecord
 
 
   def main_address
-    return addresses.includes(:region).first unless addresses.empty?
+
+    return addresses.mail_address.includes(:region)[0] if addresses.mail_address.exists?
+
+    return addresses.includes(:region).first if addresses.exists?
 
     new_address = Address.new(addressable: self)
     addresses << new_address

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Address, type: :model do
 
-  let(:co_has_regions) { create(:company, name: 'Has Region', company_number: '4268582063', city: 'HasRegionBorg') }
+  let(:co_has_region) { create(:company, name: 'Has Region', company_number: '4268582063', city: 'HasRegionBorg') }
   let(:co_missing_region) { create(:company, name: 'Missing Region', company_number: '6112107039', city: 'NoRegionBorg') }
 
-  let(:addr_has_region) { co_has_regions.main_address }
+  let(:addr_has_region) { co_has_region.main_address }
 
   let(:no_region) do
     addr_no_region = co_missing_region.main_address
@@ -14,11 +14,11 @@ RSpec.describe Address, type: :model do
   end
 
   let(:not_visible_addr) do
-    create(:address, visibility: 'none', addressable: co_has_regions)
+    create(:address, visibility: 'none', addressable: co_has_region)
   end
 
   let(:visible_addr) do
-    create(:address, visibility: 'city', addressable: co_has_regions)
+    create(:address, visibility: 'city', addressable: co_has_region)
   end
 
   describe 'Factory' do
@@ -71,7 +71,7 @@ RSpec.describe Address, type: :model do
 
     describe 'visible' do
       it 'only returns addresses that are visible' do
-        expect(co_has_regions.addresses.visible).
+        expect(co_has_region.addresses.visible).
           to contain_exactly(addr_has_region, visible_addr)
       end
     end
@@ -104,6 +104,17 @@ RSpec.describe Address, type: :model do
         expect(lacking_region_scope & has_regions).to match_array([])
       end
 
+    end
+
+    describe 'mail_address' do
+      it 'returns mail address if present' do
+        mail_addr = create(:address, mail: true, addressable: co_has_region)
+        expect(co_has_region.addresses.mail_address[0]).to eq mail_addr
+      end
+      it 'returns nil if mail address not present' do
+        second_address = create(:address, addressable: co_has_region)
+        expect(co_has_region.addresses.mail_address[0]).to be_nil
+      end
     end
 
   end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Address, type: :model do
         expect(co_has_region.addresses.mail_address[0]).to eq mail_addr
       end
       it 'returns nil if mail address not present' do
-        second_address = create(:address, addressable: co_has_region)
+        create(:address, addressable: co_has_region)
         expect(co_has_region.addresses.mail_address[0]).to be_nil
       end
     end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -178,7 +178,13 @@ RSpec.describe Company, type: :model do
 
     end
 
-    it 'returns the first address for the company' do
+    it 'returns mail address for company' do
+      company = create(:company, num_addresses: 3)
+      company.addresses[1].update(mail: true)
+      expect(company.main_address).to eq(company.addresses.second)
+    end
+
+    it 'returns the first address for the company if no mail address' do
       company = create(:company, num_addresses: 3)
       expect(company.addresses.count).to eq 3
       expect(company.main_address).to eq(company.addresses.first)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/151580859


Changes proposed in this pull request:
1. Adjust `main_address` to return the company's `mail` address


Ready for review:
@AgileVentures/shf-project-team 