### PR TITLE
Followup changes to PR392 (Implement payment processing for membershipfee)

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -75,9 +75,9 @@ class PaymentsController < ApplicationController
     payment = Payment.find(payment_id)
     payment.update(status: Payment.order_to_payment_status(resource['status']))
 
-    # When fee is paid, user is made a member, and a membership_number is issued
+    # When fee is paid, user is granted membership
     user = payment.user
-    user.update(member: true, membership_number: user.issue_membership_number)
+    user.grant_membership
 
     log_hips_activity('Webhook', 'info', payment_id, hips_id)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,15 +116,21 @@ class User < ApplicationRecord
   end
 
 
-  def issue_membership_number
-    self.membership_number = self.membership_number.blank? ? get_next_membership_number : self.membership_number
+  def grant_membership
+    update(member: true, membership_number: issue_membership_number)
   end
+
 
   ransacker :padded_membership_number do
     Arel.sql("lpad(membership_number, 20, '0')")
   end
 
   private
+
+  def issue_membership_number
+    self.membership_number = self.membership_number.blank? ? get_next_membership_number : self.membership_number
+  end
+
 
   def get_next_membership_number
     self.class.connection.execute("SELECT nextval('membership_number_seq')").getvalue(0,0).to_s

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -22,6 +22,10 @@ class ApplicationPolicy
     update?
   end
 
+  def create?
+    admin_or_owner?
+  end
+
 
   def destroy?
     user.admin?

--- a/app/policies/payment_policy.rb
+++ b/app/policies/payment_policy.rb
@@ -1,12 +1,2 @@
-class PaymentPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
-
-  def create?
-    user.admin? || record.user_id == user.id
-  end
+class PaymentPolicy < ApplicationPolicy
 end

--- a/db/seed_helpers.rb
+++ b/db/seed_helpers.rb
@@ -96,7 +96,7 @@ module SeedHelper
       # make a full company object (instance) for the accepted membership application
       ma.company = make_new_company(ma.company_number)
 
-      user.issue_membership_number
+      user.grant_membership
 
       start_date, expire_date = User.next_payment_dates(user.id)
 

--- a/features/step_definitions/payment_steps.rb
+++ b/features/step_definitions/payment_steps.rb
@@ -17,8 +17,7 @@ And(/^I complete the payment$/) do
   payment.update!(status: Payment.order_to_payment_status('successful'),
                   start_date: start_date, expire_date: expire_date)
 
-  @user.member = true
-  @user.issue_membership_number
+  @user.grant_membership
   @user.save
 
   visit payment_success_path(user_id: @user.id, id: payment.id)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -387,21 +387,26 @@ RSpec.describe User, type: :model do
   end
 
 
-  describe '#issue_membership_number' do
+  describe '#grant_membership' do
+
+    it 'sets the member field for the user' do
+      subject.grant_membership
+      expect(subject.member).to be_truthy
+    end
 
     it 'does not overwrite an existing membership_number' do
       existing_number = 'SHF00042'
       subject.membership_number = existing_number
-      subject.issue_membership_number
+      subject.grant_membership
       expect(subject.membership_number).to eq(existing_number)
     end
 
     it 'generates sequential membership_numbers' do
-      subject.issue_membership_number
+      subject.grant_membership
       first_number = subject.membership_number.to_i
 
       subject.membership_number = nil
-      subject.issue_membership_number
+      subject.grant_membership
       second_number = subject.membership_number.to_i
 
       expect(second_number).to eq(first_number+1)

--- a/spec/services/hips_spec.rb
+++ b/spec/services/hips_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe HipsService do
   end
 
   let(:invalid_key) do
-    HIPS_PRIVATE_KEY = '123'
+    HIPS_PRIVATE_KEY = '123' unless defined?(HIPS_PRIVATE_KEY)
   end
 
   let(:fetched_order) do


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/152126654

Changes proposed in this pull request:

1.  Introduce `grant_membership` method on user that sets the member field and issues a membershipnumber

2. Make `PaymentPolicy` inherit from `ApplicationPolicy` and move the `create?` method

3. Get rid of the "already initialized constant" error by adding `unless defined?(HIPS_PRIVATE_KEY)`

Ready for review:
@patmbolger @weedySeaDragon @thesuss 