### PR TITLE
[WIP] Admin gets an email when existing application is ready for review

### DIFF
--- a/app/controllers/membership_applications_controller.rb
+++ b/app/controllers/membership_applications_controller.rb
@@ -114,6 +114,7 @@ class MembershipApplicationsController < ApplicationController
   def check_and_mark_if_ready_for_review(app_params)
     if app_params.fetch('marked_ready_for_review', false) && app_params['marked_ready_for_review'] != "0"
       @membership_application.is_ready_for_review!
+      AdminMailer.create_application_ready_for_review(@membership_application)
     end
   end
 

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -8,6 +8,14 @@ class AdminMailer < AbstractMembershipInfoMailer
   end
 
 
+  def application_ready_for_review(member_app)
+
+    send_mail_for __method__, member_app, t('application_mailer.admin.new_application_received.subject')
+
+  end
+
+
+
 
   private
 

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -29,4 +29,20 @@ RSpec.describe AdminMailer, type: :mailer do
 
   end
 
+  describe '#application_ready_for_review' do
+
+    let(:new_app) { create(:membership_application, user: test_user)  }
+
+    let(:email_sent) { AdminMailer.member_application_received(new_app) }
+
+    it_behaves_like 'a successfully created email',
+                    I18n.t('application_mailer.admin.new_application_received.subject'),
+                    ENV['SHF_MEMBERSHIP_EMAIL'],
+                    '' do
+      let(:email_created) { email_sent }
+    end
+
+
+  end
+
 end


### PR DESCRIPTION
_Ashwin and I are stepping thru this process.  This is just an example.  IGNORE!!_

PT Story:  Send admin email when a membership app is ready for review
https://www.pivotaltracker.com/story/show/151615434

Most tests are failing but I need help figuring out ....

Changes proposed in this pull request:
1.  added method to send email to admins to let them know an application is ready to be reviewed
2. create a new email with the text needed
3. changed the MEmbershipApplicationController to send the mail when the state has changed...

Screenshots (Optional):


Ready for review:
@AgileVentures/shf-project-team 
