### PR TITLE
Remove membership assumption from factories and tests

### DIFF
--- a/features/devise-views-i18n.feature
+++ b/features/devise-views-i18n.feature
@@ -10,8 +10,8 @@ Feature: As a non-swedish speaking potential member
 
   Background:
     Given the following users exists
-      | email                | password | admin | is_member |
-      | emma@random.com      | password | false | false     |
+      | email                |
+      | emma@random.com      |
 
 
   Scenario: Devise new session view is translated

--- a/features/disallow-company-malicious-website.feature
+++ b/features/disallow-company-malicious-website.feature
@@ -7,9 +7,9 @@ Feature: Don't allow malicious code in Company website value
 
   Background:
     Given the following users exists
-      | email               | admin |
-      | emma@happymutts.com |       |
-      | admin@shf.se        | true  |
+      | email               | admin | member |
+      | emma@happymutts.com |       | true   |
+      | admin@shf.se        | true  |        |
 
     And the following regions exist:
       | name         |

--- a/features/edit_company.feature
+++ b/features/edit_company.feature
@@ -4,7 +4,7 @@ Feature: As a member
 
   Background:
     Given the following users exists
-      | email                      | admin | is_member |
+      | email                      | admin | member    |
       | applicant_1@happymutts.com |       | true      |
       | applicant_3@happymutts.com |       | false     |
       | admin@shf.se               | true  | true      |
@@ -24,6 +24,12 @@ Feature: As a member
     Given I am logged in as "applicant_1@happymutts.com"
     And I am on the edit company page for "5560360793"
     Then I should see t("companies.edit.title", company_name: "No More Snarky Barky")
+
+  Scenario: Prospective member can not edit their company
+    Given I am logged in as "applicant_3@happymutts.com"
+    And I am on the edit company page for "2120000142"
+    Then I should not see t("companies.edit.title", company_name: "Bowsers")
+    And I should see t("errors.not_permitted")
 
   Scenario: Visitor tries to edit a company
     Given I am Logged out

--- a/features/edit_link_on_company_page.feature
+++ b/features/edit_link_on_company_page.feature
@@ -5,12 +5,23 @@ Feature: As the owner of a company (or an admin)
   Background:
 
     Given the following users exists
-      | email                 | admin | is_member | company_number |
-      | emma@happymutts.com   |       | true      | 5562252998     |
-      | lars@happymutts.com   |       | true      | 5562252998     |
-      | anna@happymutts.com   |       | true      | 5562252998     |
-      | bowser@snarkybarky.se |       | true      | 2120000142     |
-      | admin@shf.se          | true  | false     |                |
+      | email                 | admin | member    |
+      | emma@happymutts.com   |       | true      |
+      | lars@happymutts.com   |       | true      |
+      | anna@happymutts.com   |       | true      |
+      | bowser@snarkybarky.se |       | true      |
+      | admin@shf.se          | true  | false     |
+
+    Given the following companies exist:
+      | name         | email                 | company_number |
+      | happy mutts  | emma@happymutts.com   | 5562252998     |
+      | snarky barky | bowser@snarkybarky.se | 2120000142     |
+
+    And the following applications exist:
+      | user_email            | company_number | state    |
+      | emma@happymutts.com   | 5562252998     | accepted |
+      | bowser@snarkybarky.se | 2120000142     | accepted |
+
 
   Scenario: Visitor does not see edit link for a company
     Given I am Logged out

--- a/features/edit_member_page.feature
+++ b/features/edit_member_page.feature
@@ -6,8 +6,8 @@ Feature: Edit a member page
   Background:
 
     Given the following users exists
-      | email                    | admin | is_member |
-      | admin@shf.se             | true  | true      |
+      | email                    | admin |
+      | admin@shf.se             | true  |
 
   Scenario: Admin can edit contents of member page
     Given I am logged in as "admin@shf.se"

--- a/features/edit_membership_application.feature
+++ b/features/edit_membership_application.feature
@@ -7,7 +7,7 @@ Feature: As an applicant
 
   Background:
     Given the following users exists
-      | email             | is_member | admin |
+      | email             | member    | admin |
       | emma@random.com   | false     |       |
       | hans@random.com   | false     |       |
       | nils@random.com   | true      |       |

--- a/features/landing_page_for_admin.feature
+++ b/features/landing_page_for_admin.feature
@@ -6,10 +6,10 @@ Feature: As an Admin
 
   Background:
     Given the following users exists
-      | email              | is_member | admin |
-      | emma@happymutts.se | true      |       |
-      | hans@bowsers.com   | false     |       |
-      | admin@shf.se       | true      | true  |
+      | email              | admin | member |
+      | emma@happymutts.se |       | true   |
+      | hans@bowsers.com   |       | false  |
+      | admin@shf.se       | true  | false  |
 
 
 

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -4,11 +4,11 @@ Feature: As a registered user
 
   Background:
     Given the following users exists
-      | email                | password | admin | is_member |
-      | emma@random.com      | password | false | true      |
-      | lars-user@random.com | password | false | false     |
-      | anne@random.com      | password | false | false     |
-      | arne@random.com      | password | true  | true      |
+      | email                | password | admin | member |
+      | emma@random.com      | password | false | true   |
+      | lars-user@random.com | password | false | false  |
+      | anne@random.com      | password | false | false  |
+      | arne@random.com      | password | true  | true   |
 
     And the following applications exist:
       | user_email           | company_number | state    |

--- a/features/manage_users.feature
+++ b/features/manage_users.feature
@@ -44,7 +44,7 @@ Feature: As an admin
     Then I should see "emma@happymutts.com"
     And I should see "3 dagar sedan" for class "created-at" in the row for user "emma@happymutts.com"
     And I should see "1" for class "sign-in-count" in the row for user "emma@happymutts.com"
-    And I should see t("yes") for class "is-member" in the row for user "emma@happymutts.com"
+    And I should see t("no") for class "is-member" in the row for user "emma@happymutts.com"
     And I should see t("no") for class "is-member" in the row for user "david@dogs.com"
     And I should not see "3 månader sedan" in the row for user "ernt@mutts.com"
     And I should see "1" for class "applications-open" in the row for user "ernt@mutts.com"

--- a/features/member_edits_company_page.feature
+++ b/features/member_edits_company_page.feature
@@ -6,9 +6,9 @@ Feature: As a member
 
   Background:
     Given the following users exists
-      | email               | admin | is_member |
-      | emma@happymutts.com |       | true      |
-      | admin@shf.se        | true  | true      |
+      | email               | admin | member |
+      | emma@happymutts.com |       | true   |
+      | admin@shf.se        | true  | false  |
 
     Given the following regions exist:
       | name         |
@@ -22,6 +22,7 @@ Feature: As a member
     And the following companies exist:
       | name                 | company_number | email                  |
       | No More Snarky Barky | 2120000142     | snarky@snarkybarky.com |
+      | Woof Woof            | 5560360793     | emma@happymutts.com    |
 
     And the following business categories exist
       | name         |
@@ -32,6 +33,7 @@ Feature: As a member
 
     And the following applications exist:
       | user_email          | company_number | categories | state    |
+      | emma@happymutts.com | 5560360793     |            | accepted |
       | emma@happymutts.com | 5562252998     | Awesome    | accepted |
 
     And the following payments exist

--- a/features/payments_and_branding_status/admin_edit_branding_status.feature
+++ b/features/payments_and_branding_status/admin_edit_branding_status.feature
@@ -4,9 +4,9 @@ Feature: As an admin
 
   Background:
     Given the following users exist
-      | email          | admin | is_member | membership_number |
-      | admin@shf.se   | true  | true      | 1                 |
-      | emma@mutts.com |       | true      | 1001              |
+      | email          | admin | member | membership_number |
+      | admin@shf.se   | true  | false  |                   |
+      | emma@mutts.com |       | true   | 1001              |
 
     Given the following companies exist:
       | name       | company_number | email                 | region    |

--- a/features/payments_and_branding_status/member_pays_branding_fee.feature
+++ b/features/payments_and_branding_status/member_pays_branding_fee.feature
@@ -4,9 +4,9 @@ Feature: As a member
 
   Background:
     Given the following users exist
-      | email          | admin | is_member | membership_number |
-      | emma@mutts.com |       | true      | 1001              |
-      | admin@shf.se   | true  | true      | 1                 |
+      | email          | admin | member | membership_number |
+      | emma@mutts.com |       | true   | 1001              |
+      | admin@shf.se   | true  | false  |                   |
 
     Given the following companies exist:
       | name       | company_number | email                 | region    |

--- a/features/payments_and_member_status/admin_edit_membership_status.feature
+++ b/features/payments_and_member_status/admin_edit_membership_status.feature
@@ -4,9 +4,9 @@ Feature: As an admin
 
   Background:
     Given the following users exist
-      | email          | admin | is_member | membership_number |
-      | emma@mutts.com |       | true      | 1001              |
-      | admin@shf.se   | true  | true      | 1                 |
+      | email          | admin | member | membership_number |
+      | emma@mutts.com |       | true   | 1001              |
+      | admin@shf.se   | true  | false  |                   |
 
     Given the following payments exist
       | user_email     | start_date | expire_date | payment_type | status | hips_id |

--- a/features/payments_and_member_status/member_pays_membership_fee.feature
+++ b/features/payments_and_member_status/member_pays_membership_fee.feature
@@ -4,9 +4,13 @@ Feature: As a member
 
   Background:
     Given the following users exist
-      | email          | admin | is_member | membership_number |
+      | email          | admin | member    | membership_number |
       | emma@mutts.com |       | true      | 1001              |
-      | admin@shf.se   | true  | true      | 1                 |
+      | admin@shf.se   | true  | false     |                   |
+
+    Given the following applications exist:
+      | user_email     | company_number | state    |
+      | emma@mutts.com | 2120000142     | accepted |
 
     Given the following payments exist
       | user_email     | start_date | expire_date | payment_type | status | hips_id |

--- a/features/payments_and_member_status/user_pays_membership_fee.feature
+++ b/features/payments_and_member_status/user_pays_membership_fee.feature
@@ -4,9 +4,9 @@ Feature: As a user
 
   Background:
     Given the following users exist
-      | email          | admin | is_member |
-      | emma@mutts.com |       | false     |
-      | admin@shf.se   | true  | true      |
+      | email          | admin | member |
+      | emma@mutts.com |       | false  |
+      | admin@shf.se   | true  | false  |
 
     Given the following business categories exist
       | name         | description           |

--- a/features/search_and_sort_users.feature
+++ b/features/search_and_sort_users.feature
@@ -7,11 +7,11 @@ Feature:
 
   Background:
     Given the following users exist
-      | first_name | last_name | email                               | admin | membership_number |
-      | John       | Adams     | ja@hotmail.com                      | false | 1                 |
-      | Sarah      | Connor    | sconnor@example.com                 | false | 2                 |
-      | Luke       | Skywalker | luke@force.net                      | false | 14                |
-      | admin      | admin     | admin@sverigeshundforetagare.se     | true  | 3                 |
+      | first_name | last_name | email                               | admin | membership_number | member |
+      | John       | Adams     | ja@hotmail.com                      | false | 1                 | false  |
+      | Sarah      | Connor    | sconnor@example.com                 | false | 2                 | true   |
+      | Luke       | Skywalker | luke@force.net                      | false | 14                | false  |
+      | admin      | admin     | admin@sverigeshundforetagare.se     | true  | 3                 | false  |
     And the following applications exist:
       | user_email          | state                 | company_number |
       | ja@hotmail.com      | waiting_for_applicant | 0000000000     |

--- a/features/shf-documents/view-all-shf-documents.feature
+++ b/features/shf-documents/view-all-shf-documents.feature
@@ -11,10 +11,10 @@ Feature: SHF members (and admins) can views board meeting minutes (SHF documents
   Background:
 
     Given the following users exists
-      | email              | admin |
-      | emma@happymutts.se |       |
-      | bob@snarkybarky.se |       |
-      | admin@shf.se       | true  |
+      | email              | admin | member |
+      | emma@happymutts.se |       | true   |
+      | bob@snarkybarky.se |       | false  |
+      | admin@shf.se       | true  | false  |
 
     And the following companies exist:
       | name        | company_number | email               |

--- a/features/show-company.feature
+++ b/features/show-company.feature
@@ -32,11 +32,11 @@ Feature: As a visitor,
       | Company6             | 6914762726     | cmpy6@mail.com         | Stockholm    | Alingsås | none           |
 
     And the following users exists
-      | email               | admin |
-      | emma@happymutts.com |       |
-      | a@happymutts.com    |       |
-      | member@cmpy6.com    |       |
-      | admin@shf.se        | true  |
+      | email               | admin | member |
+      | emma@happymutts.com |       | true   |
+      | a@happymutts.com    |       | true   |
+      | member@cmpy6.com    |       | true   |
+      | admin@shf.se        | true  | false  |
 
     And the following business categories exist
       | name         |

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,26 +1,12 @@
 Given(/^the following users exist(?:s|)$/) do |table|
   table.hashes.each do |user|
 
-    is_member = user.delete('is_member')
-    is_legacy = user.delete('is_legacy')
-
     user['membership_number'] = nil if user['membership_number'].blank?
 
-    if user['admin'] == 'true'
-      FactoryGirl.create(:user, user)
-    else
-      if is_legacy == 'true'
-        FactoryGirl.create(:user_without_first_and_lastname, user)
-      elsif is_member == 'true'
-        FactoryGirl.create(:member_with_membership_app, user)
-      else
-        if ! user['company_number'].nil?
-          FactoryGirl.create(:user_with_membership_app, user, company_number: user['company_number'])
-        else
-          FactoryGirl.create(:user, user)
-        end
-      end
-    end
+    is_legacy = user.delete('is_legacy')
+
+    is_legacy == 'true' ? FactoryGirl.create(:user_without_first_and_lastname, user) : FactoryGirl.create(:user, user)
+
   end
 end
 

--- a/features/user-applies-approved-edits-co.feature
+++ b/features/user-applies-approved-edits-co.feature
@@ -3,9 +3,9 @@ Feature: Whole process of a new user creating a login, applying, being approved,
 
   Background:
     Given the following users exists
-      | email                | admin | is_member |
-      | new_user@example.com |       | false     |
-      | admin@shf.se         | true  | true      |
+      | email                | admin |
+      | new_user@example.com |       |
+      | admin@shf.se         | true  |
 
     Given the following regions exist:
       | name         |

--- a/features/user_profile/user-edits-profile.feature
+++ b/features/user_profile/user-edits-profile.feature
@@ -4,10 +4,14 @@ Feature: As a registered user
 
   Background:
     Given the following users exists
-      | email             | password | admin | is_member | first_name | last_name |
+      | email             | password | admin | member    | first_name | last_name |
       | admin@random.com  | password | true  | false     | emma       | admin     |
       | member@random.com | password | false | true      | mary       | member    |
       | user@random.com   | password | false | false     | ulysses    | user      |
+
+    And the following applications exist:
+      | user_email        | company_number | state    |
+      | member@random.com | 5560360793     | accepted |
 
   Scenario: Admin edits profile
     Given I am on the "landing" page

--- a/features/view_hidden_pages.feature
+++ b/features/view_hidden_pages.feature
@@ -3,10 +3,10 @@ Feature: Only members and admins can see members only (hidden) pages
   Background:
 
     Given the following users exists
-      | email                    | admin | is_member |
+      | email                    | admin | member    |
       | emma@happymutts.com      |       | true      |
       | not_a_member@bowsers.com |       | false     |
-      | admin@shf.se             | true  | true      |
+      | admin@shf.se             | true  | false     |
 
     And the following business categories exist
       | name  |

--- a/features/view_membership_applications.feature
+++ b/features/view_membership_applications.feature
@@ -4,12 +4,12 @@ Feature: As an admin,
 
   Background:
     Given the following users exists
-      | email             | is_member | admin |
-      | emma@random.com   | false     | true  |
-      | hans@random.com   | false     | true  |
-      | nils@random.com   | true      | true  |
-      | bob@barkybobs.com | true      | true  |
-      | admin@shf.se      | true      | true  |
+      | email             | admin | member    |
+      | emma@random.com   |       | false     |
+      | hans@random.com   |       | false     |
+      | nils@random.com   |       | true      |
+      | bob@barkybobs.com |       | true      |
+      | admin@shf.se      | true  | false     |
 
     And the following simple applications exist:
       | user_email        | company_number | state                 |

--- a/spec/factories/membership_applications.rb
+++ b/spec/factories/membership_applications.rb
@@ -36,8 +36,6 @@ FactoryGirl.define do
       if (evaluator.state) && evaluator.state.to_sym == :accepted
         membership_app.state = :accepted
 
-        membership_app.user.member = true
-
         company = Company.find_by(company_number: evaluator.company_number)
         unless company
           company = FactoryGirl.create(:company, company_number: evaluator.company_number)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -45,6 +45,8 @@ FactoryGirl.define do
 
     factory :member_with_membership_app do
 
+      member true
+
       transient do
         company_number 5562728336
       end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/153369396

In the current codebase the scenario "Prospective member can not edit their company" below would fail, although there is no real problem in the application. The proposed changes in the PR are meant to make the assumptions in the tests more explicit (and make the test below pass as expected)

```
Feature: As a member
  in order to easily update my information
  I need to be able to edit my company

  Background:
    Given the following users exists
      | email                      | admin | member    |
      | applicant_1@happymutts.com |       | true      |
      | applicant_3@happymutts.com |       | false     |
      | admin@shf.se               | true  | true      |

    And the following companies exist:
      | name                 | company_number | email                  |
      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.com |
      | Bowsers              | 2120000142     | bowwow@bowsersy.com    |

    And the following applications exist:
      | user_email                 | company_number | state    |
      | applicant_1@happymutts.com | 5560360793     | accepted |
      | applicant_3@happymutts.com | 2120000142     | accepted |

  Scenario: Prospective member can not edit their company
    Given I am logged in as "applicant_3@happymutts.com"
    And I am on the edit company page for "2120000142"
    Then I should not see t("companies.edit.title", company_name: "Bowsers")
    And I should see t("errors.not_permitted")
```


**Changes proposed in this pull request:**

1. Do not let the membership_application factory implicitly make a user a member when an accepted application is created.

2. Replace `is_member` in tests (which implicitly created an accepted application) with the simple attribute `member`, and make the creation of the appliction explicit where needed

3. Don't assume an administrator is a member where not explicitly needed.


Ready for review:
@patmbolger @weedySeaDragon 