### PR TITLE
SHF Documents urls now in Swedish

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,18 +70,19 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :shf_documents
+    resources :shf_documents, path: 'dokument'
 
-    get 'shf_documents/contents/:page',
+    get 'dokument/innehall/:page',
       to: 'shf_documents#contents_show', as: 'contents_show'
 
-    get 'shf_documents/contents/:page/redigera',
+    get 'dokument/innehall/:page/redigera',
       to: 'shf_documents#contents_edit', as: 'contents_edit'
 
-    patch 'shf_documents/contents/:page',
+    patch 'dokument/innehall/:page',
       to: 'shf_documents#contents_update', as: 'contents_update'
 
-    get 'member-pages', to: 'shf_documents#minutes_and_static_pages'
+    get 'medlemssidor', to: 'shf_documents#minutes_and_static_pages',
+                        as: 'member_pages'
 
   end
 

--- a/spec/views/application/_navigation.html.haml_spec.rb
+++ b/spec/views/application/_navigation.html.haml_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe 'companies/index' do
 
       it 'renders menu link == member pages index' do
         text = t('menus.nav.members.member_pages')
-        expect(rendered).to match %r{<a href=\"\/member-pages\">#{text}}
+        expect(rendered).to match %r{<a href=\"\/medlemssidor\">#{text}}
       end
 
       it 'renders link to view SHF Board meeting minutes' do
         text = t('menus.nav.members.shf_meeting_minutes')
-        expect(rendered).to match %r{<a href=\"\/shf_documents">#{text}}
+        expect(rendered).to match %r{<a href=\"\/dokument">#{text}}
       end
     end
 
@@ -168,12 +168,12 @@ RSpec.describe 'companies/index' do
 
       it 'renders menu link == member pages index' do
         text = t('menus.nav.members.member_pages')
-        expect(rendered).to match %r{<a href=\"\/member-pages\">#{text}}
+        expect(rendered).to match %r{<a href=\"\/medlemssidor\">#{text}}
       end
 
       it 'renders link to view SHF Board meeting minutes' do
         text = t('menus.nav.members.shf_meeting_minutes')
-        expect(rendered).to match %r{<a href=\"\/shf_documents">#{text}}
+        expect(rendered).to match %r{<a href=\"\/dokument">#{text}}
       end
     end
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/153313081


Changes proposed in this pull request:
1. Changed URL segments to Swedish

Screenshot: Here is how the affected routes look now:

<img width="860" alt="screen shot 2017-12-05 at 9 20 50 am" src="https://user-images.githubusercontent.com/9968213/33611796-a1e4be78-d99d-11e7-9afb-1bd0600e1f2f.png">

@thesuss - I think we should use "documents" instead of "document"??

Ready for review:
@AgileVentures/shf-project-team 