### PR TITLE
fix membership granted email -  link to company show, not edit page

### DIFF
--- a/app/views/member_mailer/membership_granted.html.haml
+++ b/app/views/member_mailer/membership_granted.html.haml
@@ -8,7 +8,7 @@
 
   %p
     = t('youre_active', scope: message_scope)
-    = link_to(edit_company_url(@member.company),  edit_company_url(@member.company), target: '_blank')
+    = link_to(company_url(@member.company),  company_url(@member.company), target: '_blank')
 
   %p
     = t('access_fb_group', scope: message_scope)

--- a/app/views/member_mailer/membership_granted.text.haml
+++ b/app/views/member_mailer/membership_granted.text.haml
@@ -6,7 +6,7 @@
 = render layout: 'layouts/mail_from_membership' do
   = t('welcome', scope: message_scope) + '.'
   \
-  = t('youre_active', scope: message_scope)  + edit_company_url(@member.company)
+  = t('youre_active', scope: message_scope)  + company_url(@member.company)
   \
   = t('access_fb_group', scope: message_scope)
   = t('shf_facebook_group_url')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -841,11 +841,11 @@ en:
 
     member_mailer:
       membership_granted:
-        subject: &subject_welcome "Welcome to SHF! You're now a member"
+        subject: &subject_welcome "Welcome to SHF! You are now a member"
         greeting: *email_greeting
         message_text:
           welcome:  *subject_welcome
-          youre_active: "Your company is now H-tagged and you have been activated as a member of the system. You can login and manage your profile and build your business page. When you're signed in, you can edit your business page and pay your branding license fee here: "
+          youre_active: "Your company is now H-tagged and you have been activated as a member of the system. You can login and manage your profile and build your business page. When you are signed in, you can edit your business page and pay your branding license fee here: "
           access_fb_group: "As a member, you will also have access to our closed Facebook group: "
           and_member_pages: "as well as hidden pages in our member system: "
 

--- a/features/emails/email-applicant-membership-granted.feature
+++ b/features/emails/email-applicant-membership-granted.feature
@@ -4,6 +4,8 @@ Feature: Applicant gets an email when membership has been granted. (They are now
   So that I am notified that I am now a member
   and so I know what I should expect to happen next,
   I should get an email telling me I'm a member and explaining what I need to do next
+  And the email should include a link to my company page
+  So that I can pay the branding fee (if needed) and then perhaps edit my company information
 
 
   Background:
@@ -32,8 +34,8 @@ Feature: Applicant gets an email when membership has been granted. (They are now
 
 
   @time_adjust
-  Scenario: Applicant pays all fees, membership is granted; applicant gets email  (2017)
-    Given the date is set to "2017-12-01"
+  Scenario: Applicant pays all fees, membership is granted; applicant gets email
+    Given the date is set to "2018-01-01"
     When I am in "emma@happymutts.se" browser
     And I am logged in as "emma@happymutts.se"
     And I am on the "user details" page for "emma@happymutts.se"
@@ -41,14 +43,19 @@ Feature: Applicant gets an email when membership has been granted. (They are now
     Then I click on t("menus.nav.members.pay_membership")
     And I complete the payment
     And I should see t("payments.success.success")
-    #And I should see "2019-06-30"
+    And I should see "2018-12-31"
     Then "emma@happymutts.se" should receive an email
     And I am logged in as "emma@happymutts.se"
     And I open the email
     And I should see t("mailers.member_mailer.membership_granted.subject") in the email subject
     And I should see t("mailers.member_mailer.membership_granted.message_text.welcome") in the email body
     And I should see t("mailers.member_mailer.membership_granted.message_text.youre_active") in the email body
-    
+    And I should not see "http://localhost:3000/hundforetag/1/redigera" in the email body
+    And I should see "http://localhost:3000/hundforetag/1" in the email body
+    When I follow "http://localhost:3000/hundforetag/1" in the email
+    Then I should see "Happy Mutts"
+    And I should see "Groomer"
+
 
   @time_adjust   @selenium
   Scenario: [SAD PATH] Applicant does not pay all fees, membership is not granted; no email is sent (2017)

--- a/features/emails/email-applicant-when-app-approved.feature
+++ b/features/emails/email-applicant-when-app-approved.feature
@@ -4,6 +4,7 @@ Feature: Applicant gets an email when the application is approved
   So that I know that SHF has approved the application (still need to pay)
   and so I know what I should expect to happen next,
   I should get an email letting me know the application was approved and now I need to pay
+  And I should see a link to my account in the email so I can pay
 
 
   Background:
@@ -44,5 +45,11 @@ Feature: Applicant gets an email when the application is approved
     And I am logged in as "emma@happymutts.se"
     And I open the email
     And I should see t("mailers.shf_application_mailer.app_approved.subject") in the email subject
-
-
+    # must make sure this is not the edit page; it would also match the pattern for the show user page
+    And I should not see "http://localhost:3000/anvandare/1/redigera" in the email body
+    And I should see "http://localhost:3000/anvandare/1" in the email body
+    When I follow "http://localhost:3000/anvandare/1" in the email
+    Then I should see "Firstname Lastname"
+    And I should see t("users.show.email")
+    And I should see t("applications")
+    And I should not see t("users.show.membership_number")

--- a/features/emails/new-application-email-to-admins.feature
+++ b/features/emails/new-application-email-to-admins.feature
@@ -42,6 +42,10 @@ Feature: When a new application is received, all admins get an email notificatio
     And I should see t("mailers.admin_mailer.new_application_received.message_text.from") in the email body
     And I should see t("mailers.admin_mailer.new_application_received.message_text.view_app_here") in the email body
     And I should see t("mailers.admin_mailer.new_application_received.message_text.must_be_logged_in") in the email body
+    And I should not see "http://localhost:3000/ansokan/1/redigera" in the email body
+    And I should see "http://localhost:3000/ansokan/1" in the email body
+    When I follow "http://localhost:3000/ansokan/1" in the email
+    Then I should see t("shf_applications.show.title", user_full_name: 'Emma HappyMutts')
     And I am logged out
     And I am logged in as "admin2@shf.se"
     Then "admin2@shf.se" should receive an email
@@ -51,6 +55,10 @@ Feature: When a new application is received, all admins get an email notificatio
     And I should see t("mailers.admin_mailer.new_application_received.message_text.from") in the email body
     And I should see t("mailers.admin_mailer.new_application_received.message_text.view_app_here") in the email body
     And I should see t("mailers.admin_mailer.new_application_received.message_text.must_be_logged_in") in the email body
+    And I should not see "http://localhost:3000/ansokan/1/redigera" in the email body
+    And I should see "http://localhost:3000/ansokan/1" in the email body
+    When I follow "http://localhost:3000/ansokan/1" in the email
+    Then I should see t("shf_applications.show.title", user_full_name: 'Emma HappyMutts')
     Then "admin3@shf.se" should receive an email
     And I open the email
     And I should see t("mailers.admin_mailer.new_application_received.subject") in the email subject
@@ -58,7 +66,10 @@ Feature: When a new application is received, all admins get an email notificatio
     And I should see t("mailers.admin_mailer.new_application_received.message_text.from") in the email body
     And I should see t("mailers.admin_mailer.new_application_received.message_text.view_app_here") in the email body
     And I should see t("mailers.admin_mailer.new_application_received.message_text.must_be_logged_in") in the email body
-
+    And I should not see "http://localhost:3000/ansokan/1/redigera" in the email body
+    And I should see "http://localhost:3000/ansokan/1" in the email body
+    When I follow "http://localhost:3000/ansokan/1" in the email
+    Then I should see t("shf_applications.show.title", user_full_name: 'Emma HappyMutts')
 
   Scenario: User submits a new application app with bad info so it is not created, so no email sent [SAD PATH]
     Given I am logged in as "emma@happymutts.com"

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -118,7 +118,7 @@ Then /^(?:I|they) should see #{CAPTURE_STRING} in the email body$/ do |text|
 end
 
 Then /^(?:I|they) should not see #{CAPTURE_STRING} in the email body$/ do |text|
-  expect(current_email.default_part_body.to_s).not_to include(text)
+  expect(current_email.default_part_body.to_s).not_to include(text), "Should not see #{text}\n but did.  \n\nfull text:\n#{current_email.default_part_body.to_s}"
 end
 
 Then /^(?:I|they) should see \/([^"]*?)\/ in the email body$/ do |text|

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -118,7 +118,7 @@ Then /^(?:I|they) should see #{CAPTURE_STRING} in the email body$/ do |text|
 end
 
 Then /^(?:I|they) should not see #{CAPTURE_STRING} in the email body$/ do |text|
-  expect(current_email.default_part_body.to_s).not_to include(text), "Should not see #{text}\n but did.  \n\nfull text:\n#{current_email.default_part_body.to_s}"
+  expect(current_email.default_part_body.to_s).not_to include(text), "Should not see #{text}\n but did.  \n\nfull text:\n#{current_email.default_part_body}"
 end
 
 Then /^(?:I|they) should see \/([^"]*?)\/ in the email body$/ do |text|

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -97,12 +97,8 @@ end
 # Inspect the Email Contents
 #
 
-Then /^(?:I|they) should see (t\()?"([^"]*?)"(?:\)) in the email subject$/ do |translate, text|
-  if translate
-    expect(current_email).to have_subject(i18n_content(text))
-  else
-    expect(current_email).to have_subject(text)
-  end
+Then /^(?:I|they) should see #{CAPTURE_STRING} in the email subject$/ do |text|
+  expect(current_email).to have_subject(text)
 end
 
 Then /^(?:I|they) should see \/([^"]*?)\/ in the email subject$/ do |text|
@@ -117,15 +113,11 @@ Then /^(?:I|they) should not see \/([^"]*?)\/ in the email subject$/ do |text|
   expect(current_email).not_to have_subject(Regexp.new(text))
 end
 
-Then /^(?:I|they) should see (t\()?"([^"]*?)"(?:\)) in the email body$/ do |translate, text|
-  if translate
-    expect(current_email.default_part_body.to_s).to include(i18n_content(text))
-  else
+Then /^(?:I|they) should see #{CAPTURE_STRING} in the email body$/ do |text|
     expect(current_email.default_part_body.to_s).to include(text)
-  end
 end
 
-Then /^(?:I|they) should not see "([^"]*?)" in the email body$/ do |text|
+Then /^(?:I|they) should not see #{CAPTURE_STRING} in the email body$/ do |text|
   expect(current_email.default_part_body.to_s).not_to include(text)
 end
 
@@ -154,15 +146,15 @@ Then /^(?:I|they) should see \/([^\"]*)\/ in the email "([^"]*?)" header$/ do |t
 end
 
 Then /^I should see it is a multi\-part email$/ do
-    expect(current_email).to be_multipart
+  expect(current_email).to be_multipart
 end
 
 Then /^(?:I|they) should see "([^"]*?)" in the email html part body$/ do |text|
-    expect(current_email.html_part.body.to_s).to include(text)
+  expect(current_email.html_part.body.to_s).to include(text)
 end
 
 Then /^(?:I|they) should see "([^"]*?)" in the email text part body$/ do |text|
-    expect(current_email.text_part.body.to_s).to include(text)
+  expect(current_email.text_part.body.to_s).to include(text)
 end
 
 #
@@ -203,12 +195,8 @@ end
 # Interact with Email Contents
 #
 
-When /^(?:I|they|"([^"]*?)") follows? (t\()?"([^"]*?)"(?:\)) in the email$/ do |address, translate, link|
-  if translate
-    visit_in_email(i18n_content(link), address)
-  else
-    visit_in_email(link, address)
-  end
+When /^(?:I|they|"([^"]*?)") follows? #{CAPTURE_STRING} in the email$/ do |address, link|
+  visit_in_email(link, address)
 end
 
 When /^(?:I|they) click the first link in the email$/ do


### PR DESCRIPTION
### PT Story:  https://www.pivotaltracker.com/story/show/153348015

During the client review, it was noted that the link in the email should be to the company _show_ page, not the company _edit_ page.  (If the branding fee for the company has not been paid, they cannot edit the page!)

### Changes proposed in this pull request:
1.  Fixed the link in the email so it goes to the _show_ page for the company
2. Added the specification and a test for this in the feature file
3. Added specifications and test for the correct link in the feature files for the other emails sent out.
4. Use the very handy CAPTURE_STRING in the email steps to handle the translations in the steps we use
5. removed apostrophes from the English locale text for emails because they are displayed as the encoding instead of the apostrophe

### Screenshots (Optional):
<img width="499" alt="email-membership-granted-show-link-html" src="https://user-images.githubusercontent.com/673794/34542284-ca79de2c-f090-11e7-8599-9b6a33e3d2e5.png">


<img width="719" alt="email-membership-granted-show-link-text" src="https://user-images.githubusercontent.com/673794/34542285-ca922428-f090-11e7-8f14-756ca2088db8.png">


Ready for review:
@thesuss @patmbolger 
