### PR TITLE
Add request URL, method, id; params to exception notification info

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,14 +70,52 @@ class ApplicationController < ActionController::Base
   end
 
 
-  # Set data that will be included when an exception notification is sent
-  #  current_user: so we know who was using the application when the error occured
-  #  remote_addr: IP address to help identify bots and webcrawlers
+  # Set data that will be included when an exception notification is sent.
+  # We have all of the data from the incoming *request* to work with and all other
+  # information and objects involved at this point (the current controller, etc.)
+  #
+  # Most information sent to the notification is from
+  # the *request* ActionDispatch::Request
+  #  See that class for more details
+  #
+  # Information sent:
+  #
+  #   * request_original_url: the full URL that is the source of the request
+  #     ex:  https://hitta.sverigeshundforetagare.se/hundforetag/57
+  #
+  #   * request_method:  the HTTP method used for the request
+  #     ex: GET or POST or PUT, etc.
+  #
+  #   * request_path: the portion of the URL specific to the SHF system;
+  #     the +String+ full path including params of the last URL requested
+  #     ex:  get "/articles?page=2"  will return
+  #       "/articles?page=2"
+  #
+  #   * params_to_json: the parameters for the request, converted .to_json
+  #
+  #   * params_inspect: the String returned from params.inspect
+  #     This will include the 'permitted' information, which is not included in the .to_json information
+  #
+  #   * current_user: so we know who was using the application when the error occured
+  #
+  #   * remote_addr: IP address to help identify bots and webcrawlers
+  #
+  #   * request_id: useful for tracking the request in logs
+  #     from ActionDispatch::Request  def request_id :
+  #       This unique ID is useful for tracing a request from end-to-end as part of
+  #       logging or debugging.
+  #
   def prepare_exception_notifier
     request.env["exception_notifier.exception_data"] = {
+        request_original_url: request.original_url,
+        request_method: request.request_method,
+        request_path: request.fullpath,
+        params_as_json: params.as_json,
+        params_inspect: params.inspect,
         current_user: current_user.inspect,
         remote_addr: request.env['REMOTE_ADDR'],
-        browser: request.env['HTTP_USER_AGENT']
+        browser: request.env['HTTP_USER_AGENT'],
+        request_id: request.request_id
 
     }
   end


### PR DESCRIPTION
### PT Story:  Add more information to prod exception notifications
https://www.pivotaltracker.com/story/show/154038871

### Changes proposed in this pull request:
1. added more info (mostly from the `request` info):
   - URL
   - id
   - method ('GET' etc)
   - params (added this both as `json` and the `.inspect` string; we can see what is/isn't useful to us over time

### Screenshots (Optional):
<img width="667" alt="exceptnotify-added-request-params" src="https://user-images.githubusercontent.com/673794/34583847-21a0e1b0-f14e-11e7-9c77-74013f6cb4fa.png">


Ready for review:
@AgileVentures/shf-project-team 
