### PR TITLE
Proof of membership - visibility to members

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -5,3 +5,12 @@ SHF_DEV_WEBHOOK_HOST = 'webhook_host_url'
 
 # Number of users to create in seeds.rb
 SHF_SEED_USERS = 25
+
+SHF_SHOW_FEATURE='yes'
+# ^^ This is used to support pre-release features that are delivered to
+# production but not yet made visible to users.
+# Most of the time, you WILL NOT define this var as the default logic used
+# in production code is to not make the specific feature visible.
+# Assign the var as shown if you wish to make it visible.
+# Also, if you want to toggle visibility for your tests, define (or not)
+# this var in .env.test

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ config/initializers/beta_test.rb
 .DS_Store
 .env
 .env.development
+.env.test
 
 # swaks is used to test sending SMTP email via CLI
 swaks

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -7,7 +7,8 @@
 
     != model_errors_helper(resource)
 
-    = render partial: 'member_photo', locals: { user: resource, f: f }
+    - if ENV['SHF_SHOW_FEATURE']
+      = render partial: 'member_photo', locals: { user: resource, f: f }
 
     .col-sm-12.wpcf7
       .field


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/154449352


Changes proposed in this pull request:
1. Use ENV var to turn on/off visibility (logic defaults to visibility == off if var not set)
2. Added `.env.test` to `.gitignore`
3. Fixed an unrelated cucumber test failure

**NOTE**: To see the "member photo upload" function, and to make sure that tests run locally, you'll need to add the line:
```
SHF_SHOW_FEATURE = 'yes'  # or any string, really
```
to both `.env.development` and `.env.test`.

(I have added the ENV to the semaphoreci configuration)

Ready for review:
@AgileVentures/shf-project-team 