### PR TITLE
136287611 - Allowed file types

### DIFF
--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -199,7 +199,7 @@ class ShfApplicationsController < ApplicationController
 
 
   def set_allowed_file_types
-    @allowed_file_types = UploadedFile::ALLOWED_FILE_TYPES.keys.flatten.join(' ')
+    @allowed_file_types = UploadedFile::ALLOWED_FILE_TYPES
   end
 
 

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -218,6 +218,7 @@ class ShfApplicationsController < ApplicationController
                                            filename: @uploaded_file.actual_file_file_name))
           successful = successful & true
         else
+          @shf_application.uploaded_files.delete(@uploaded_file)
           helpers.flash_message :alert, @uploaded_file.errors.messages.values.uniq.flatten.join(' ')
           successful = successful & false
         end

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -4,13 +4,12 @@ class ShfApplicationsController < ApplicationController
   before_action :get_shf_application, except: [:information, :index, :new, :create]
   before_action :authorize_shf_application
   before_action :set_other_waiting_reason, only: [:show, :edit, :update, :need_info]
-
+  before_action :set_allowed_file_types, only: [:edit, :new]
 
   def new
     @shf_application = ShfApplication.new(user: current_user)
     @all_business_categories = BusinessCategory.all
     @uploaded_file = @shf_application.uploaded_files.build
-    @allowed_file_types = UploadedFile::ALLOWED_FILE_TYPES.keys.flatten.join(' ')
   end
 
 
@@ -196,6 +195,11 @@ class ShfApplicationsController < ApplicationController
   def set_other_waiting_reason
     @other_waiting_reason_value = '-1'
     @other_waiting_reason_text = t('admin_only.member_app_waiting_reasons.other_custom_reason')
+  end
+
+
+  def set_allowed_file_types
+    @allowed_file_types = UploadedFile::ALLOWED_FILE_TYPES.keys.flatten.join(' ')
   end
 
 

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -4,7 +4,7 @@ class ShfApplicationsController < ApplicationController
   before_action :get_shf_application, except: [:information, :index, :new, :create]
   before_action :authorize_shf_application
   before_action :set_other_waiting_reason, only: [:show, :edit, :update, :need_info]
-  before_action :set_allowed_file_types, only: [:edit, :new]
+  before_action :set_allowed_file_types, only: [:edit, :new, :update, :create]
 
   def new
     @shf_application = ShfApplication.new(user: current_user)

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -10,6 +10,7 @@ class ShfApplicationsController < ApplicationController
     @shf_application = ShfApplication.new(user: current_user)
     @all_business_categories = BusinessCategory.all
     @uploaded_file = @shf_application.uploaded_files.build
+    @allowed_file_types = UploadedFile::ALLOWED_FILE_TYPES.keys.flatten.join(' ')
   end
 
 

--- a/app/models/uploaded_file.rb
+++ b/app/models/uploaded_file.rb
@@ -11,6 +11,7 @@ class UploadedFile < ApplicationRecord
     %w(.docx) => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     %w(.docm) => 'application/vnd.ms-word.document.macroEnabled.12'
   }
+
   belongs_to :shf_application
 
   has_attached_file :actual_file

--- a/app/models/uploaded_file.rb
+++ b/app/models/uploaded_file.rb
@@ -1,17 +1,20 @@
 class UploadedFile < ApplicationRecord
 
+  ALLOWED_FILE_TYPES = {
+    %w(.jpeg .jpg) => 'image/jpeg',
+    %w(.gif) => 'image/gif',
+    %w(.png) => 'image/png',
+    %w(.txt) => 'text/plain',
+    %w(.rtf) => 'text/rtf',
+    %w(.pdf) => 'application/pdf',
+    %w(.doc .dot) => 'application/msword',
+    %w(.docx) => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    %w(.docm) => 'application/vnd.ms-word.document.macroEnabled.12'
+  }
   belongs_to :shf_application
 
   has_attached_file :actual_file
-  validates_attachment :actual_file, content_type: {content_type: ['image/jpeg',
-                                                                   'image/gif',
-                                                                   'image/png',
-                                                                   'text/plain',
-                                                                   'text/rtf',
-                                                                   'application/pdf',
-                                                                   'application/msword',
-                                                                   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-                                                                   'application/vnd.ms-word.document.macroEnabled.12'],
+  validates_attachment :actual_file, content_type: {content_type: ALLOWED_FILE_TYPES.values,
                                                     message: I18n.t('shf_applications.uploads.invalid_upload_type')},
                                                     size: { in: 0..5.megabytes,
                                                             message: :file_too_large

--- a/app/views/shf_applications/_shf_application_fields.html.haml
+++ b/app/views/shf_applications/_shf_application_fields.html.haml
@@ -48,11 +48,16 @@
 
       %span{class: "btn btn-warning btn-file"}
         = t('shf_applications.new.upload_button')
-        = f.file_field 'actual_files[]', multiple: true, name: 'uploaded_file[actual_files][]', class: 'upload-field', id: 'upload-button'
+        = f.file_field 'actual_files[]',
+          multiple: true,
+          name: 'uploaded_file[actual_files][]',
+          class: 'upload-field',
+          id: 'upload-button',
+          accept: @allowed_file_types.values.join(',')
 
       - submit_label = @shf_application.new_record? ? t('submit') : t('save')
       %p= t('shf_applications.new.upload_allowed_file_types')
-      %p= @allowed_file_types
+      %p= @allowed_file_types.keys.flatten.join(' ')
 
       %h4.hidden.files-to-upload-title#files-to-upload-title= t('shf_applications.new.will_be_uploaded')
 

--- a/app/views/shf_applications/_shf_application_fields.html.haml
+++ b/app/views/shf_applications/_shf_application_fields.html.haml
@@ -46,11 +46,15 @@
 
       %h3.upload-button-pre= t('shf_applications.new.upload_files')
 
+
       %span{class: "btn btn-warning btn-file"}
         = t('shf_applications.new.upload_button')
         = f.file_field 'actual_files[]', multiple: true, name: 'uploaded_file[actual_files][]', class: 'upload-field', id: 'upload-button'
 
       - submit_label = @shf_application.new_record? ? t('submit') : t('save')
+      %p= t('shf_applications.new.upload_allowed_file_types')
+      %p= @allowed_file_types
+
       %h4.hidden.files-to-upload-title#files-to-upload-title= t('shf_applications.new.will_be_uploaded')
 
       -# The table that lists the files to be uploaded when the form is submitted:

--- a/app/views/shf_applications/_shf_application_fields.html.haml
+++ b/app/views/shf_applications/_shf_application_fields.html.haml
@@ -46,7 +46,6 @@
 
       %h3.upload-button-pre= t('shf_applications.new.upload_files')
 
-
       %span{class: "btn btn-warning btn-file"}
         = t('shf_applications.new.upload_button')
         = f.file_field 'actual_files[]', multiple: true, name: 'uploaded_file[actual_files][]', class: 'upload-field', id: 'upload-button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -290,6 +290,7 @@ en:
       upload_files_section: Documents to support your application (certifications, etc.)
       upload_files_instructions: 'The documents are very important for us to assess your application. We use them to authenticate your skills and education. This ensures that our membership standards remain high, which in turn means that the public know that the Swedish dog business is professional and reliable.'
       upload_files: 'Upload files from your computer:'
+      upload_allowed_file_types: 'Allowed file types:'
       upload_more_files: 'You can upload more files. After you submit your application, you may still edit the application and upload more files.'
       upload_button: Choose files to upload...
       will_be_uploaded: 'These files will be uploaded when you submit your application:'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -290,6 +290,7 @@ sv:
       upload_files_section: Underlag för att styrka min ansökan
       upload_files_instructions: 'Dokumenten är mycket viktiga för att vi ska kunna bedöma din ansökan. Vi använder dem för att verifiera dina kunskaper och utbildningar. Detta säkerställer att vår medlemsstandard är fortsatt hög, vilket i förlängningen innebär att allmänheten vet att Sveriges hundföretagare är professionella och att lita på.'
       upload_files: 'Ladda upp filer från datorn'
+      upload_allowed_file_types: 'Tillåtna filtyper:'
       upload_more_files: Du kan ladda upp fler filer genom att redigera din ansökan efter att du skickat in den.
       upload_button: Välj dina filer...
       will_be_uploaded: 'Dessa filer kommer att laddas upp när du skickar in din ansökan:'

--- a/spec/models/uploaded_file_spec.rb
+++ b/spec/models/uploaded_file_spec.rb
@@ -19,13 +19,7 @@ RSpec.describe UploadedFile, type: :model do
   describe 'Validations' do
 
     it { should validate_attachment_content_type(:actual_file)
-                    .allowing('image/jpeg', 'image/gif', 'image/png',
-                              'text/plain',
-                              'text/rtf',
-                              'application/pdf',
-                              'application/msword',
-                              'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-                              'application/vnd.ms-word.document.macroEnabled.12')
+                    .allowing(UploadedFile::ALLOWED_FILE_TYPES.values)
                     .rejecting('bin', 'exe') }
   end
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/136287611

Changes proposed in this pull request:
1. Mime types allowed on 'UploadedFile' model are picked from constant;
2. Same constant used on controller to let the view know which file extensions are allowed;

Screenshots:
![image](https://user-images.githubusercontent.com/3024789/35779336-aad7fdca-09cb-11e8-8546-0a2512280b54.png)
