### PR TITLE
[WIP] #317 Remove unnecessary fields from cucumber tests

### DIFF
--- a/features/admin_edits_app_config.feature
+++ b/features/admin_edits_app_config.feature
@@ -5,8 +5,8 @@ Feature: Admin edits application configuration
 
   Background:
     Given the following users exists
-      | email             | password | admin | member    | first_name | last_name |
-      | admin@random.com  | password | true  | false     | emma       | admin     |
+      | email             | password | admin |
+      | admin@random.com  | password | true  |
 
   Scenario: Admin uploads SHF logo and chairperson signature
     Given I am logged in as "admin@random.com"

--- a/features/emails/new-application-gets-ack-email.feature
+++ b/features/emails/new-application-gets-ack-email.feature
@@ -23,8 +23,8 @@ Feature: New Applicant gets an email acknowledging their application
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Emma                            | HappyMutts                     | 5562252998                          | 031-1234567                       | emma@happymutts.com                |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5562252998                          | 031-1234567                       | emma@happymutts.com                |
     And I select "Groomer" Category
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "landing" page

--- a/features/size_validation.feature
+++ b/features/size_validation.feature
@@ -19,8 +19,8 @@ Feature: Applicant uploads too large a file for their application
     Given I am logged in as "hans@new_applicant.se"
     And I am on the "submit new membership application" page
     When I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Hans                            | Newfoundland                   | 5560360793                          | 031-1234567                       | applicant_2@random.com             |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5560360793                          | 031-1234567                       | applicant_2@random.com             |
     And I choose a file named "diploma_huge.pdf" to upload
     When I click on t("shf_applications.new.submit_button_label")
     Then I should see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large")


### PR DESCRIPTION
PT Story: 

Fixes #317  - Remove unnecessary data fields from cucumber tests

Changes proposed in this pull request:

Unfortunately there seems to have been a practice to use first_name of a user as a look-up key for many tests. This has largely gone away (which is good), but a test or two probably still uses this.

Another reason to specify first_name in a test background is of the test looks for that name in the browser window. One or two tests probably do this.

For the rest, moving first_name from the membership_application background table to the user background table just moves useless data that clutters the test.

It seems a good idea to remove the unnecessary columns from feature files where it is not needed. I do think it would be good to slim the test data down to the minimum required for each test.


Ready for review:
(Not yet)
