### PR TITLE
Remove company number from membership application, restructure copy<>application associations

### DIFF
--- a/app/assets/javascripts/companies.js
+++ b/app/assets/javascripts/companies.js
@@ -19,8 +19,8 @@ $(function() {
   $('#companyCreateForm').on('ajax:success', function (e, data) {
     $('#' + data.id).html(data.html);
     if (data.status === 'success') {
-      $('#companyCreateErrors').html('');
-      $('#companyCreateModal').modal('hide');
+      $('#company-create-errors').html('');
+      $('#company-create-modal').modal('hide');
     }
   });
 });

--- a/app/assets/javascripts/companies.js
+++ b/app/assets/javascripts/companies.js
@@ -15,4 +15,12 @@ $(function() {
   $('#editBrandingStatusSubmit').click(function() {
     $('#edit-branding-modal').modal('hide');
   });
+
+  $('#companyCreateForm').on('ajax:success', function (e, data) {
+    $('#' + data.id).html(data.html);
+    if (data.status === 'success') {
+      $('#companyCreateErrors').html('');
+      $('#companyCreateModal').modal('hide');
+    }
+  });
 });

--- a/app/assets/javascripts/companies.js
+++ b/app/assets/javascripts/companies.js
@@ -19,8 +19,8 @@ $(function() {
   $('#companyCreateForm').on('ajax:success', function (e, data) {
     $('#' + data.id).html(data.html);
     if (data.status === 'success') {
-      $('#company-create-errors').html('');
       $('#company-create-modal').modal('hide');
+      $('#company-create-errors').html('');
     }
   });
 });

--- a/app/assets/stylesheets/shf-applications.scss
+++ b/app/assets/stylesheets/shf-applications.scss
@@ -53,7 +53,18 @@ $app-state-border-blue: rgb(142, 173, 206);
         margin-bottom: 0;
       }
 
+    .new-company-link {
+      margin-left: 30px;
+      display: inline-block;
+      vertical-align: middle;
     }
+
+    }
+  }
+
+  #company-number-entry {
+    width: 30%;
+    display: inline-block;
   }
 
   #supporting-files {

--- a/app/assets/stylesheets/shf-applications.scss
+++ b/app/assets/stylesheets/shf-applications.scss
@@ -53,18 +53,18 @@ $app-state-border-blue: rgb(142, 173, 206);
         margin-bottom: 0;
       }
 
-    .new-company-link {
-      margin-left: 30px;
-      display: inline-block;
-      vertical-align: middle;
-    }
+      .new-company-link {
+        display: inline-block;
+        margin-left: 30px;
+        vertical-align: middle;
+      }
 
     }
   }
 
   #company-number-entry {
-    width: 30%;
     display: inline-block;
+    width: 30%;
   }
 
   #supporting-files {

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -81,11 +81,11 @@ class CompaniesController < ApplicationController
       return
     end
 
-    # XHR request from ShfApplication create modal (for company create)
+    # XHR request from modal in ShfApplication create view (to create company)
     if saved
       status = 'success'
-      id = 'company-number-select'
-      html = helpers.company_number_selection_field(@company.id)
+      id = 'company-number-entry'
+      html = helpers.company_number_entry_field(@company.company_number)
     else
       status = 'errors'
       id = 'company-create-errors'

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -69,12 +69,30 @@ class CompaniesController < ApplicationController
 
     @company = Company.new(sanitize_params(company_params))
 
-    if @company.save
-      redirect_to @company, notice: t('.success')
-    else
-      flash.now[:alert] = t('.error')
-      render :new
+    saved = @company.save
+
+    unless request.xhr?
+      if @company.save
+        redirect_to @company, notice: t('.success')
+      else
+        flash.now[:alert] = t('.error')
+        render :new
+      end
+      return
     end
+
+    # XHR request from ShfApplication create modal (for company create)
+    if saved
+      status = 'success'
+      id = 'companyNumberSelect'
+      html = helpers.company_number_selection_field(@company.id)
+    else
+      status = 'errors'
+      id = 'companyCreateErrors'
+      html = helpers.model_errors_helper(@company)
+    end
+
+    render json: { status: status, id: id, html: html }
   end
 
 

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -84,11 +84,11 @@ class CompaniesController < ApplicationController
     # XHR request from ShfApplication create modal (for company create)
     if saved
       status = 'success'
-      id = 'companyNumberSelect'
+      id = 'company-number-select'
       html = helpers.company_number_selection_field(@company.id)
     else
       status = 'errors'
-      id = 'companyCreateErrors'
+      id = 'company-create-errors'
       html = helpers.model_errors_helper(@company)
     end
 

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -135,6 +135,8 @@ class ShfApplicationsController < ApplicationController
 
           old_co.destroy
 
+          app_params[:companies_attributes]['0'][:id] = nil
+
         else
 
           if old_co.company_number == new_co_number

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -52,6 +52,7 @@ class ShfApplicationsController < ApplicationController
     app_params = shf_application_params
 
     company_number = app_params[:companies_attributes]['0'][:company_number]
+    company = nil
 
     if company_number && (company = Company.find_by_company_number(company_number))
       app_params.delete(:companies_attributes)
@@ -60,6 +61,8 @@ class ShfApplicationsController < ApplicationController
     end
 
     @shf_application = ShfApplication.new(app_params.merge(user: current_user))
+
+    @shf_application.companies = [company] if company
 
     if @shf_application.save
 

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -44,8 +44,7 @@ class ShfApplicationsController < ApplicationController
 
 
   def edit
-    @all_business_categories = BusinessCategory.all
-    @company = @shf_application.companies.first
+    load_update_objects
   end
 
 
@@ -267,6 +266,7 @@ class ShfApplicationsController < ApplicationController
 
   def create_error(error_message)
     helpers.flash_message(:alert, error_message)
+    @company = Company.new
     @all_business_categories = BusinessCategory.all
     render :new
   end
@@ -278,9 +278,16 @@ class ShfApplicationsController < ApplicationController
       render json: @shf_application.errors.full_messages, status: :unprocessable_entity if request.xhr?
     else
       helpers.flash_message(:alert, error_message)
+      load_update_objects
       render :edit
     end
 
+  end
+
+  def load_update_objects
+    @all_business_categories = BusinessCategory.all
+    @new_company = Company.new   # In case user wants to create a new company
+    @company = @shf_application.companies.first
   end
 
 

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -104,7 +104,6 @@ class ShfApplicationsController < ApplicationController
       end
 
     else
-      debugger
       app_params = shf_application_params
 
       new_co_number = app_params[:companies_attributes]['0'][:company_number]

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -57,6 +57,7 @@ class ShfApplicationsController < ApplicationController
     if company_number && (company = Company.find_by_company_number(company_number))
       app_params.delete(:companies_attributes)
     else
+      # Default company email == application contact_email
       app_params[:companies_attributes]['0'][:email] = app_params[:contact_email]
     end
 

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -45,6 +45,7 @@ class ShfApplicationsController < ApplicationController
 
   def edit
     @all_business_categories = BusinessCategory.all
+    @shf_application.companies.build if @shf_application.companies.empty?
   end
 
 
@@ -107,7 +108,7 @@ class ShfApplicationsController < ApplicationController
 
       company_number = app_params[:companies_attributes]['0'][:company_number]
 
-      unless company_number.blank?
+      if company_number.present?
 
         company = Company.find_by_id(app_params[:companies_attributes]['0'][:id])
 
@@ -126,9 +127,11 @@ class ShfApplicationsController < ApplicationController
             app_params[:companies_attributes]['0'][:email] = @shf_application.contact_email
           end
         else
-          # Somehow we have no company association .... set default email
+          # No company association .... set default email
           app_params[:companies_attributes]['0'][:email] = @shf_application.contact_email
         end
+      else
+        app_params[:companies_attributes]['0'][:email] = @shf_application.contact_email
       end
 
       if @shf_application.update(app_params)

--- a/app/helpers/companies_helper.rb
+++ b/app/helpers/companies_helper.rb
@@ -80,6 +80,6 @@ module CompaniesHelper
   end
 
   def company_number_entry_field(company_number=nil)
-    number_field_tag :company_number, company_number, class: 'wpcf7-form-control'
+    number_field_tag :company_number, company_number
   end
 end

--- a/app/helpers/companies_helper.rb
+++ b/app/helpers/companies_helper.rb
@@ -78,4 +78,8 @@ module CompaniesHelper
        class: 'search_field',
        data: {language: "#{@locale}" }
   end
+
+  def company_number_entry_field(company_number=nil)
+    number_field_tag :company_number, company_number, class: 'wpcf7-form-control'
+  end
 end

--- a/app/helpers/companies_helper.rb
+++ b/app/helpers/companies_helper.rb
@@ -80,6 +80,7 @@ module CompaniesHelper
   end
 
   def company_number_entry_field(company_number=nil)
-    number_field_tag :company_number, company_number
+    number_field_tag :company_number, company_number,
+                     id: 'shf_application_company_number'
   end
 end

--- a/app/helpers/companies_helper.rb
+++ b/app/helpers/companies_helper.rb
@@ -70,4 +70,12 @@ module CompaniesHelper
                           type: Payment::PAYMENT_TYPE_BRANDING),
             { method: :post, class: 'btn btn-primary btn-xs' })
   end
+
+  def company_number_selection_field(company_id=nil)
+    select_tag :company_id,
+       options_from_collection_for_select(Company.order(:company_number),
+                  :id, :company_number, company_id),
+       class: 'search_field',
+       data: {language: "#{@locale}" }
+  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -17,7 +17,8 @@ class Company < ApplicationRecord
 
   before_save :sanitize_website, :sanitize_description
 
-  has_and_belongs_to_many :shf_applications
+  has_many :company_applications
+  has_many :shf_applications, through: :company_applications, dependent: :destroy
 
   has_many :users, through: :shf_applications
 

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -106,7 +106,6 @@ class Company < ApplicationRecord
 
   # do not delete a Company if it has ShfApplications that are accepted
   def error_if_has_accepted_applications?
-
     shf_applications.reload
 
     if shf_applications.where(state: 'accepted').any?

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -99,16 +99,16 @@ class Company < ApplicationRecord
 
   def destroy_checks
 
-    error_if_has_accepted_applications?
+    error_if_has_applications?
 
   end
 
 
   # do not delete a Company if it has ShfApplications that are accepted
-  def error_if_has_accepted_applications?
+  def error_if_has_applications?
     shf_applications.reload
 
-    if shf_applications.where(state: 'accepted').any?
+    if shf_applications.where.not(state: 'being_destroyed').any?
       errors.add(:base, 'activerecord.errors.models.company.company_has_active_memberships')
       # Rails 5: must throw
       throw(:abort)

--- a/app/models/company_application.rb
+++ b/app/models/company_application.rb
@@ -1,0 +1,8 @@
+class CompanyApplication < ApplicationRecord
+  belongs_to :company
+  belongs_to :shf_application
+
+  validates_presence_of :company, :shf_application
+
+  validates_uniqueness_of :company_id, scope: :shf_application
+end

--- a/app/models/concerns/has_swedish_organization.rb
+++ b/app/models/concerns/has_swedish_organization.rb
@@ -2,10 +2,14 @@ module HasSwedishOrganization
 
   extend ActiveSupport::Concern
 
+  KEY = 'activerecord.errors.models.shf_application.attributes.company_number.invalid'
+
   included do
 
     def swedish_organisationsnummer
-      errors.add(:company_number, "#{self.company_number} is not a valid company number") unless Orgnummer.new(self.company_number).valid?
+      unless Orgnummer.new(self.company_number).valid?
+        errors.add(:company_number, I18n.t(KEY, company_number: self.company_number))
+      end
     end
 
   end

--- a/app/models/shf_application.rb
+++ b/app/models/shf_application.rb
@@ -126,14 +126,11 @@ class ShfApplication < ApplicationRecord
 
 
   def reject_application
+
     user.update(membership_number: nil)
+
     destroy_uploaded_files
-
-    # Destroy associated company(s) if no other applications for that company
-    companies.all.each do |cmpy|
-      cmpy.destroy if cmpy.shf_applications.count == 1
-    end
-
+    
   end
 
 

--- a/app/models/shf_application.rb
+++ b/app/models/shf_application.rb
@@ -31,7 +31,6 @@ class ShfApplication < ApplicationRecord
   validates_uniqueness_of :user_id
 
   accepts_nested_attributes_for :uploaded_files, allow_destroy: true
-  accepts_nested_attributes_for :user, update_only: true
 
   accepts_nested_attributes_for :companies
 

--- a/app/models/shf_application.rb
+++ b/app/models/shf_application.rb
@@ -26,6 +26,8 @@ class ShfApplication < ApplicationRecord
 
   validates_presence_of :contact_email, :state
 
+  validates_presence_of :companies
+
   validates_format_of :contact_email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: [:create, :update]
 
   validates_uniqueness_of :user_id

--- a/app/models/shf_application.rb
+++ b/app/models/shf_application.rb
@@ -34,6 +34,14 @@ class ShfApplication < ApplicationRecord
 
   accepts_nested_attributes_for :companies
 
+  accepts_nested_attributes_for :user, update_only: true
+  # ^^ We are not explicitly using any user attributes in the app form.  However,
+  # we are delegating the "membership_number" getter and setter methods to
+  # User from ShfApplication ("membership_number" used to be an attribute of
+  # ShfApplication and was moved to User).
+  # The update to "membership_number" (via delegation) will not work without
+  # the above statement.
+
   scope :open, -> { where.not(state: [:accepted, :rejected]) }
 
   delegate :full_name, to: :user, prefix: true

--- a/app/models/shf_application.rb
+++ b/app/models/shf_application.rb
@@ -32,8 +32,6 @@ class ShfApplication < ApplicationRecord
 
   accepts_nested_attributes_for :uploaded_files, allow_destroy: true
 
-  accepts_nested_attributes_for :companies
-
   accepts_nested_attributes_for :user, update_only: true
   # ^^ We are not explicitly using any user attributes in the app form.  However,
   # we are delegating the "membership_number" getter and setter methods to
@@ -130,7 +128,7 @@ class ShfApplication < ApplicationRecord
     user.update(membership_number: nil)
 
     destroy_uploaded_files
-    
+
   end
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,7 @@ class User < ApplicationRecord
   end
 
   def has_shf_application?
-    ! shf_application.nil? && shf_application.valid?
+    shf_application&.valid?
   end
 
   def check_member_status
@@ -69,18 +69,16 @@ class User < ApplicationRecord
 
 
   def has_company?
-    companies.any?
+    shf_application&.companies&.any?
   end
 
-
-  def company
-    companies.last
-  end
 
   def companies
     return Company.all if admin?
 
-    super
+    return [] unless has_company?
+
+    shf_application.companies
   end
 
 
@@ -90,7 +88,7 @@ class User < ApplicationRecord
 
 
   def in_company_numbered?(company_num)
-    member? && shf_application&.companies.where(company_number: company_num).any?
+    member? && shf_application&.companies&.where(company_number: company_num)&.any?
   end
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,8 +10,6 @@ class User < ApplicationRecord
 
   has_one :shf_application
 
-  has_many :companies, through: :shf_application
-
   has_many :payments
   accepts_nested_attributes_for :payments
 
@@ -92,7 +90,7 @@ class User < ApplicationRecord
 
 
   def in_company_numbered?(company_num)
-    member? && companies.where(company_number: company_num).any?
+    member? && shf_application&.companies.where(company_number: company_num).any?
   end
 
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -41,4 +41,8 @@ class ApplicationPolicy
     user.admin? || ( record.respond_to?(:user) &&  record.user == user )
   end
 
+  def not_a_visitor
+    !user.is_a? Visitor
+  end
+
 end

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -10,8 +10,7 @@ class CompanyPolicy < ApplicationPolicy
   end
 
   def new?
-    true
-    # user.admin?
+    not_a_visitor
   end
 
   def create?

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -10,11 +10,13 @@ class CompanyPolicy < ApplicationPolicy
   end
 
   def new?
-    not_a_visitor
+    user.admin?
   end
 
   def create?
-    new?
+    # User needs to be able to create a company within the context of
+    # creating a membership application
+    not_a_visitor
   end
 
   def update?

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -10,7 +10,8 @@ class CompanyPolicy < ApplicationPolicy
   end
 
   def new?
-    user.admin?
+    true
+    # user.admin?
   end
 
   def create?

--- a/app/policies/shf_application_policy.rb
+++ b/app/policies/shf_application_policy.rb
@@ -158,9 +158,4 @@ class ShfApplicationPolicy < ApplicationPolicy
     record.respond_to?(:user) && record.user == user
   end
 
-
-  def not_a_visitor
-    !user.is_a? Visitor
-  end
-
 end

--- a/app/policies/shf_application_policy.rb
+++ b/app/policies/shf_application_policy.rb
@@ -103,7 +103,6 @@ class ShfApplicationPolicy < ApplicationPolicy
 
   def user_owner_attributes
     [
-        :company_number,
         :contact_email,
         :phone_number,
         { business_category_ids: [] },
@@ -116,8 +115,7 @@ class ShfApplicationPolicy < ApplicationPolicy
                                     :actual_file_content_type,
                                     :actual_file_updated_at,
                                     :_destroy],
-        user_attributes: [:first_name,
-                          :last_name]
+        companies_attributes: [:company_number]
     ]
   end
 

--- a/app/policies/shf_application_policy.rb
+++ b/app/policies/shf_application_policy.rb
@@ -115,8 +115,7 @@ class ShfApplicationPolicy < ApplicationPolicy
                                     :actual_file_file_size,
                                     :actual_file_content_type,
                                     :actual_file_updated_at,
-                                    :_destroy],
-        companies_attributes: [:id, :company_number]
+                                    :_destroy]
     ]
   end
 

--- a/app/policies/shf_application_policy.rb
+++ b/app/policies/shf_application_policy.rb
@@ -116,7 +116,7 @@ class ShfApplicationPolicy < ApplicationPolicy
                                     :actual_file_content_type,
                                     :actual_file_updated_at,
                                     :_destroy],
-        companies_attributes: [:company_number]
+        companies_attributes: [:id, :company_number]
     ]
   end
 

--- a/app/policies/shf_application_policy.rb
+++ b/app/policies/shf_application_policy.rb
@@ -51,12 +51,13 @@ class ShfApplicationPolicy < ApplicationPolicy
 
   # an Admin cannot create an Application because we currently have no way to say who the application is for (which User)
   def new?
-    super && !user.admin? && not_a_visitor
+    super && !user.admin? && not_a_visitor && !user_has_other_application?
   end
 
 
   def create?
-    record.is_a?(ShfApplication) ? owner? : !user.admin? && not_a_visitor
+    record.is_a?(ShfApplication) ? owner? : !user.admin? && not_a_visitor &&
+                                            !user_has_other_application?
   end
 
 

--- a/app/views/admin_mailer/new_member_application_received.text.haml
+++ b/app/views/admin_mailer/new_member_application_received.text.haml
@@ -9,7 +9,7 @@
 = '     ' + I18n.t('activerecord.attributes.shf_application.contact_email') + ': ' + @shf_app.contact_email
 
 = '        ' + I18n.t('activerecord.attributes.shf_application.phone_number') + ': ' + (@member_app.phone_number.nil? ? '' : @member_app.phone_number)
-= '        ' + I18n.t('activerecord.attributes.company.company_number') + ': ' + @shf_app.company_number
+= '        ' + I18n.t('activerecord.attributes.company.company_number') + ': ' + (@shf_app.companies.first&.company_number || '')
 
 = '        # ' + I18n.t('activerecord.attributes.shf_application.uploaded_files.many') + ': ' + @shf_app.uploaded_files.count.to_s
 - @shf_app.uploaded_files.each do |uploaded_file|

--- a/app/views/admin_mailer/new_shf_application_received.html.haml
+++ b/app/views/admin_mailer/new_shf_application_received.html.haml
@@ -9,7 +9,7 @@
   %p.user-name= @shf_app.user.full_name
   %p.user-email= I18n.t('activerecord.attributes.shf_application.contact_email') + ': ' +@shf_app.contact_email
   %p.phone-number= I18n.t('activerecord.attributes.shf_application.phone_number') + ': ' + (@shf_app.phone_number.nil? ? '' : @shf_app.phone_number)
-  %p.company-number= I18n.t('activerecord.attributes.company.company_number') +': ' + @shf_app.company_number
+  %p.company-number= I18n.t('activerecord.attributes.company.company_number') +': ' + (@shf_app.companies.first&.company_number || '')
 
   %p.number-files-uploaded= '# ' + I18n.t('activerecord.attributes.shf_application.uploaded_files.many') + ': ' + @shf_app.uploaded_files.count.to_s
 

--- a/app/views/companies/_company_create_modal.html.haml
+++ b/app/views/companies/_company_create_modal.html.haml
@@ -42,7 +42,7 @@
                   = f.text_field :email, class: 'wpcf7-form-control', size: 30
 
         .modal-footer
-          = f.submit t('submit'), class: "btn btn-primary",
+          = f.submit t('companies.create.create_submit'), class: "btn btn-primary",
                      id: 'companyCreateSubmit'
 
           %button(type='button' class='btn btn-default' data-dismiss='modal')

--- a/app/views/companies/_company_create_modal.html.haml
+++ b/app/views/companies/_company_create_modal.html.haml
@@ -1,0 +1,49 @@
+#companyCreateModal.modal.fade(tabindex='-1' role='dialog')
+  .modal-dialog(role='document')
+    .modal-content
+
+      = form_for company, url: companies_path,
+                 method: :post, remote: true,
+                 html: { id: 'companyCreateForm' } do |f|
+
+        .modal-header
+          %button(type='button' class='close' data-dismiss='modal')
+            %span(aria-hidden='true') &times;
+          %h3.modal-title.text-center
+            = t('companies.new.title')
+
+        .modal-body
+          .container-fluid
+
+            #companyCreateErrors
+              != model_errors_helper(company)
+
+            .form-group
+              .row
+                .col-sm-5
+
+                  = f.label :company_number, "#{t('companies.show.company_number')}",
+                            class: 'required'
+
+                  - title = 'companies.form.org_nr_tooltip'
+                  %span.glyphicon.glyphicon-info-sign{ title: "#{t(title)}",
+                                                       data: {toggle: 'tooltip'} }
+
+                .col-sm-7
+                  = f.text_field :company_number, class: 'wpcf7-form-control', size: 10
+
+              .row
+                .col-sm-5
+
+                  = f.label :email, "#{t('companies.show.email')}", class: 'required'
+
+                .col-sm-7
+
+                  = f.text_field :email, class: 'wpcf7-form-control', size: 30
+
+        .modal-footer
+          = f.submit t('submit'), class: "btn btn-primary",
+                     id: 'companyCreateSubmit'
+
+          %button(type='button' class='btn btn-default' data-dismiss='modal')
+            = t('cancel')

--- a/app/views/companies/_company_create_modal.html.haml
+++ b/app/views/companies/_company_create_modal.html.haml
@@ -1,4 +1,4 @@
-#companyCreateModal.modal.fade(tabindex='-1' role='dialog')
+.modal.fade#company-create-modal(tabindex='-1' role='dialog')
   .modal-dialog(role='document')
     .modal-content
 
@@ -15,7 +15,7 @@
         .modal-body
           .container-fluid
 
-            #companyCreateErrors
+            #company-create-errors
               != model_errors_helper(company)
 
             .form-group

--- a/app/views/member_mailer/membership_granted.html.haml
+++ b/app/views/member_mailer/membership_granted.html.haml
@@ -8,7 +8,8 @@
 
   %p
     = t('youre_active', scope: message_scope)
-    = link_to(company_url(@member.company),  company_url(@member.company), target: '_blank')
+    - company = @member.shf_application.companies.first
+    = link_to(company.name,  company_url(company), target: '_blank')
 
   %p
     = t('access_fb_group', scope: message_scope)
@@ -17,4 +18,3 @@
     %br
     = t('and_member_pages', scope: message_scope)
     = link_to(t('shf_medlemssystem_url'), t('shf_medlemssystem_url'), target: '_blank')
-

--- a/app/views/member_mailer/membership_granted.text.haml
+++ b/app/views/member_mailer/membership_granted.text.haml
@@ -6,7 +6,8 @@
 = render layout: 'layouts/mail_from_membership' do
   = t('welcome', scope: message_scope) + '.'
   \
-  = t('youre_active', scope: message_scope)  + company_url(@member.company)
+  - company = @member.shf_application.companies.first
+  = t('youre_active', scope: message_scope)  + company_url(company)
   \
   = t('access_fb_group', scope: message_scope)
   = t('shf_facebook_group_url')

--- a/app/views/shf_applications/_check_payment_status.html.haml
+++ b/app/views/shf_applications/_check_payment_status.html.haml
@@ -28,8 +28,9 @@
 
 
 - if current_user.has_company?
+  - company = current_user.companies.first
 
-  - if ! current_user.company.most_recent_branding_payment
+  - if ! company.most_recent_branding_payment
     -# User has never paid
 
     - need_to_pay = true
@@ -37,20 +38,20 @@
     %h4= t('shf_applications.information.check_payment_status.pay_h_here')
 
 
-  - elsif ! current_user.company.branding_license?
+  - elsif ! company.branding_license?
     -# User has paid but payment has expired
 
     - need_to_pay = true
 
     %h4
       = t('shf_applications.information.check_payment_status.h_expires')
-      %strong= current_user.company.branding_expire_date
+      %strong= company.branding_expire_date
 
 
 - if need_to_pay
 
 
 
-  = link_to(t('menus.nav.company.pay_branding_fee'), company_path(current_user.company), class: 'btn btn-info')
+  = link_to(t('menus.nav.company.pay_branding_fee'), company_path(company), class: 'btn btn-info')
   %br
   %br

--- a/app/views/shf_applications/_search_form.html.haml
+++ b/app/views/shf_applications/_search_form.html.haml
@@ -24,12 +24,12 @@
                         class: 'form-control search_field',
                         data: {language: "#{@locale}" } }
     .col-sm-2
-      = f.label :company_number_in,
+      = f.label :companies_company_number_in,
                 "#{t('shf_applications.index.org_nr')}",
                 class: 'control-label',
                 style: 'text-align: left; font-size: 12px;'
-      = f.collection_select :company_number_in,
-                      ShfApplication.order(:company_number).pluck(:company_number),
+      = f.collection_select :companies_company_number_in,
+                      ShfApplication.joins(:companies).order('companies.company_number').pluck('companies.company_number'),
                       :to_s, :to_s, { include_blank: false },
                       { multiple: true, size: 5, style: 'width: 100%;',
                         class: 'form-control search_field',

--- a/app/views/shf_applications/_shf_application_fields.html.haml
+++ b/app/views/shf_applications/_shf_application_fields.html.haml
@@ -49,11 +49,20 @@
       = f.label :membership_number, t('shf_applications.show.membership_number'), class: 'required'
       = f.text_field :membership_number, class: 'wpcf7-form-control'
 
+    = f.label :company_number, t('shf_applications.show.company_number'), class: 'required'
 
-    = f.fields_for :companies do |ffc|
-      = ffc.label :company_number, t('shf_applications.show.company_number'), class: 'required'
-      = ffc.number_field :company_number, class: 'wpcf7-form-control'
-    %p.field-instruction= t('shf_applications.show.org_nr_no_hyphens')
+    -# NOTE: Capybara cannot find link without 'href' attribute
+    %a.btn.btn-warning.btn-xs{href: '#', 'data-toggle': 'modal',
+                              'data-target': '#companyCreateModal',
+                              style: 'float: right;'}
+
+      = t('companies.new.title')
+
+    %p.field-instruction= t('shf_applications.new.select_company_number')
+    #companyNumberSelect
+      - cmpy_id = local_assigns.has_key?(:company_id) ? company_id : nil
+      = company_number_selection_field(cmpy_id)
+    %br
 
     = f.label :contact_email, t('shf_applications.show.contact_email'), class: 'required'
     %p.field-instruction= t('shf_applications.new.can_be_same_email')

--- a/app/views/shf_applications/_shf_application_fields.html.haml
+++ b/app/views/shf_applications/_shf_application_fields.html.haml
@@ -59,9 +59,10 @@
       = t('companies.new.title')
 
     %p.field-instruction= t('shf_applications.new.select_company_number')
-    #company-number-select
-      - cmpy_id = local_assigns.has_key?(:company_id) ? company_id : nil
-      = company_number_selection_field(cmpy_id)
+    
+    #company-number-entry
+      = company_number_entry_field(company.company_number)
+
     %br
 
     = f.label :contact_email, t('shf_applications.show.contact_email'), class: 'required'

--- a/app/views/shf_applications/_shf_application_fields.html.haml
+++ b/app/views/shf_applications/_shf_application_fields.html.haml
@@ -62,8 +62,7 @@
 
         -# NOTE: Capybara cannot find link without 'href' attribute
         %a.btn.btn-warning.btn-sm{ href: '#', 'data-toggle': 'modal',
-                                   'data-target': '#company-create-modal',
-                                   style: 'float: right;' }
+                                   'data-target': '#company-create-modal' }
 
           = t('companies.new.title')
 

--- a/app/views/shf_applications/_shf_application_fields.html.haml
+++ b/app/views/shf_applications/_shf_application_fields.html.haml
@@ -51,15 +51,7 @@
 
     = f.label :company_number, t('shf_applications.show.company_number'), class: 'required'
 
-    -# NOTE: Capybara cannot find link without 'href' attribute
-    -# %a.btn.btn-warning.btn-sm{ href: '#', 'data-toggle': 'modal',
-    -#                            'data-target': '#company-create-modal',
-    -#                            style: 'float: right;' }
-    -#
-    -#   = t('companies.new.title')
-
-    %p.field-instruction= t('shf_applications.new.select_company_number')
-
+    %p.field-instruction= t('shf_applications.new.enter_company_number')
 
     .div
 

--- a/app/views/shf_applications/_shf_application_fields.html.haml
+++ b/app/views/shf_applications/_shf_application_fields.html.haml
@@ -52,14 +52,14 @@
     = f.label :company_number, t('shf_applications.show.company_number'), class: 'required'
 
     -# NOTE: Capybara cannot find link without 'href' attribute
-    %a.btn.btn-warning.btn-xs{ href: '#', 'data-toggle': 'modal',
+    %a.btn.btn-warning.btn-sm{ href: '#', 'data-toggle': 'modal',
                                'data-target': '#company-create-modal',
                                style: 'float: right;' }
 
       = t('companies.new.title')
 
     %p.field-instruction= t('shf_applications.new.select_company_number')
-    
+
     #company-number-entry
       = company_number_entry_field(company.company_number)
 

--- a/app/views/shf_applications/_shf_application_fields.html.haml
+++ b/app/views/shf_applications/_shf_application_fields.html.haml
@@ -6,17 +6,9 @@
       = f.text_field :membership_number, class: 'wpcf7-form-control'
 
 
-    = f.fields_for :user do |ff|
-      = ff.label :first_name, t('shf_applications.show.first_name'), class: 'required'
-      = ff.text_field :first_name, class: 'wpcf7-form-control'
-
-
-      = ff.label :last_name, t('shf_applications.show.last_name'), class: 'required'
-      = ff.text_field :last_name, class: 'wpcf7-form-control'
-
-
-    = f.label :company_number, t('shf_applications.show.company_number'), class: 'required'
-    = f.number_field :company_number, class: 'wpcf7-form-control'
+    = f.fields_for :companies do |ffc|
+      = ffc.label :company_number, t('shf_applications.show.company_number'), class: 'required'
+      = ffc.number_field :company_number, class: 'wpcf7-form-control'
     %p.field-instruction= t('shf_applications.show.org_nr_no_hyphens')
 
 

--- a/app/views/shf_applications/_shf_application_fields.html.haml
+++ b/app/views/shf_applications/_shf_application_fields.html.haml
@@ -52,9 +52,9 @@
     = f.label :company_number, t('shf_applications.show.company_number'), class: 'required'
 
     -# NOTE: Capybara cannot find link without 'href' attribute
-    %a.btn.btn-warning.btn-xs{href: '#', 'data-toggle': 'modal',
-                              'data-target': '#companyCreateModal',
-                              style: 'float: right;'}
+    %a.btn.btn-warning.btn-xs{ href: '#', 'data-toggle': 'modal',
+                               'data-target': '#companyCreateModal',
+                               style: 'float: right;' }
 
       = t('companies.new.title')
 

--- a/app/views/shf_applications/_shf_application_fields.html.haml
+++ b/app/views/shf_applications/_shf_application_fields.html.haml
@@ -54,7 +54,6 @@
       = ffc.label :company_number, t('shf_applications.show.company_number'), class: 'required'
       = ffc.number_field :company_number, class: 'wpcf7-form-control'
     %p.field-instruction= t('shf_applications.show.org_nr_no_hyphens')
-    = f.number_field :company_number, class: 'wpcf7-form-control'
 
     = f.label :contact_email, t('shf_applications.show.contact_email'), class: 'required'
     %p.field-instruction= t('shf_applications.new.can_be_same_email')

--- a/app/views/shf_applications/_shf_application_fields.html.haml
+++ b/app/views/shf_applications/_shf_application_fields.html.haml
@@ -52,16 +52,30 @@
     = f.label :company_number, t('shf_applications.show.company_number'), class: 'required'
 
     -# NOTE: Capybara cannot find link without 'href' attribute
-    %a.btn.btn-warning.btn-sm{ href: '#', 'data-toggle': 'modal',
-                               'data-target': '#company-create-modal',
-                               style: 'float: right;' }
-
-      = t('companies.new.title')
+    -# %a.btn.btn-warning.btn-sm{ href: '#', 'data-toggle': 'modal',
+    -#                            'data-target': '#company-create-modal',
+    -#                            style: 'float: right;' }
+    -#
+    -#   = t('companies.new.title')
 
     %p.field-instruction= t('shf_applications.new.select_company_number')
 
-    #company-number-entry
-      = company_number_entry_field(company.company_number)
+
+    .div
+
+      #company-number-entry
+        = company_number_entry_field(company.company_number)
+
+      .new-company-link
+
+        -# NOTE: Capybara cannot find link without 'href' attribute
+        %a.btn.btn-warning.btn-sm{ href: '#', 'data-toggle': 'modal',
+                                   'data-target': '#company-create-modal',
+                                   style: 'float: right;' }
+
+          = t('companies.new.title')
+
+    .clearfix
 
     %br
 

--- a/app/views/shf_applications/_shf_application_fields.html.haml
+++ b/app/views/shf_applications/_shf_application_fields.html.haml
@@ -53,13 +53,13 @@
 
     -# NOTE: Capybara cannot find link without 'href' attribute
     %a.btn.btn-warning.btn-xs{ href: '#', 'data-toggle': 'modal',
-                               'data-target': '#companyCreateModal',
+                               'data-target': '#company-create-modal',
                                style: 'float: right;' }
 
       = t('companies.new.title')
 
     %p.field-instruction= t('shf_applications.new.select_company_number')
-    #companyNumberSelect
+    #company-number-select
       - cmpy_id = local_assigns.has_key?(:company_id) ? company_id : nil
       = company_number_selection_field(cmpy_id)
     %br

--- a/app/views/shf_applications/_shf_applications_list.html.haml
+++ b/app/views/shf_applications/_shf_applications_list.html.haml
@@ -24,7 +24,8 @@
         %tr.applicant
           %td.membership_number= shf_application.membership_number
           %td.name= link_to "#{shf_application.user.last_name + ', ' + shf_application.user.first_name}", user_path(shf_application.user)
-          %td.company_number= shf_application.company_id == nil ? shf_application.company_number : link_to(shf_application.company_number, company_path(shf_application.company_id))
+          - company = shf_application.companies&.first
+          %td.company_number= company == nil ? '' : link_to(company.company_number, company_path(company))
           %td.state=  shf_application.aasm.human_state
           %td.action= link_to "#{t('manage')}", shf_application_path(shf_application.id)
 

--- a/app/views/shf_applications/edit.html.haml
+++ b/app/views/shf_applications/edit.html.haml
@@ -19,3 +19,5 @@
 
         = render 'application/required_fields'
         = f.submit t('.submit_button_label')
+
+= render partial: 'companies/company_create_modal', locals: { company: @new_company }

--- a/app/views/shf_applications/edit.html.haml
+++ b/app/views/shf_applications/edit.html.haml
@@ -15,7 +15,7 @@
         != model_errors_helper(@shf_application)
 
         = render partial: 'shf_application_fields',
-                 locals: { f: f, user: @shf_application.user, company_id:  @company.id }
+                 locals: { f: f, user: @shf_application.user, company:  @company }
 
         = render 'application/required_fields'
         = f.submit t('.submit_button_label')

--- a/app/views/shf_applications/edit.html.haml
+++ b/app/views/shf_applications/edit.html.haml
@@ -15,6 +15,7 @@
         != model_errors_helper(@shf_application)
 
         = render partial: 'shf_application_fields',
-                 locals: { f: f, user: @shf_application.user }
+                 locals: { f: f, user: @shf_application.user, company_id:  @company.id }
+
         = render 'application/required_fields'
         = f.submit t('.submit_button_label')

--- a/app/views/shf_applications/new.html.haml
+++ b/app/views/shf_applications/new.html.haml
@@ -12,7 +12,9 @@
 
         != model_errors_helper(@shf_application)
 
-        = render partial: 'shf_application_fields', locals: {f: f}
+        = render partial: 'shf_application_fields',
+                          locals: { f: f, company: @company }
+                          
         = render 'application/required_fields'
 
         = f.submit t('.submit_button_label')

--- a/app/views/shf_applications/new.html.haml
+++ b/app/views/shf_applications/new.html.haml
@@ -7,6 +7,7 @@
   .entry-content
     .wpcf7
       .instructions= t('shf_applications.new.instructions_html')
+
       = form_for @shf_application, html: {multipart: true}, url: shf_applications_path do |f|
 
         != model_errors_helper(@shf_application)
@@ -15,3 +16,6 @@
         = render 'application/required_fields'
 
         = f.submit t('.submit_button_label')
+
+= render partial: 'companies/company_create_modal',
+         locals: { company: @company }

--- a/app/views/shf_applications/new.html.haml
+++ b/app/views/shf_applications/new.html.haml
@@ -17,5 +17,4 @@
 
         = f.submit t('.submit_button_label')
 
-= render partial: 'companies/company_create_modal',
-         locals: { company: @company }
+= render partial: 'companies/company_create_modal', locals: { company: @company }

--- a/app/views/shf_applications/new.html.haml
+++ b/app/views/shf_applications/new.html.haml
@@ -12,9 +12,8 @@
 
         != model_errors_helper(@shf_application)
 
-        = render partial: 'shf_application_fields',
-                          locals: { f: f, company: @company }
-                          
+        = render partial: 'shf_application_fields', locals: { f: f, company: @company }
+
         = render 'application/required_fields'
 
         = f.submit t('.submit_button_label')

--- a/app/views/shf_applications/show.html.haml
+++ b/app/views/shf_applications/show.html.haml
@@ -21,7 +21,7 @@
     - if @shf_application.phone_number
       %p #{t('.phone_number')}: #{@shf_application.phone_number}
 
-    %p #{t('.company_number')}: #{@shf_application.company_number}
+    %p #{t('.company_number')}: #{@shf_application.companies.first&.company_number}
 
     - unless assocation_empty?(@categories)
       %h4 #{t('.with_categories')}:

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -52,8 +52,10 @@
                   %span.yes= i18n_state
                 - else
                   %span.maybe= i18n_state
-              %td= link_to(app.company_number, shf_application_path(app))
-              %td= app.company&.name
+              - company = app.companies.first
+              - if company
+                %td= link_to(company.company_number, shf_application_path(app))
+                %td= company&.name
 
   .col-sm-12
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -290,7 +290,7 @@ en:
       last_name: *last_name
       phone_number: Phone number
       company_number: *company_number
-      select_company_number: Enter your company number (or create a new company
+      enter_company_number: Enter your company number (or create a new company
                              if not yet in the system)
       contact_email: *contact_email
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -288,7 +288,7 @@ en:
       last_name: *last_name
       phone_number: Phone number
       company_number: *company_number
-      org_nr_no_hyphens: &orgnr_no_hyphens  "Numbers only (no hyphens)"
+      select_company_number: Select your company number (or create a new company if not present)
       contact_email: *contact_email
 
       can_be_same_email: Can be the same that you logged in with, but need not be.
@@ -316,7 +316,6 @@ en:
       title: Edit Membership Application
       is_ready_for_review: Is Ready for Review
       submit_button_label: *save
-      org_nr_no_hyphens: *orgnr_no_hyphens
 
     update:
       success: The application was updated.
@@ -329,7 +328,6 @@ en:
       last_name: *last_name
       phone_number: Phone number
       company_number: *company_number
-      org_nr_no_hyphens: *orgnr_no_hyphens
       contact_email: *contact_email
       app_status: Application status
       change_status: Change the status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,6 +490,7 @@ en:
     create:
       error: One or more problems prevented the company from being created.
       success: The company was created successfully.
+      create_submit: Create Company
     edit:
       title: 'Editing: %{company_name}'
     update:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -255,6 +255,8 @@ en:
           attributes:
             company_number:
               invalid: "%{company_number} is not a valid Swedish company number"
+            companies:
+              blank: '- Specify an existing company number (or create new company)'
 
 
       messages:
@@ -288,7 +290,8 @@ en:
       last_name: *last_name
       phone_number: Phone number
       company_number: *company_number
-      select_company_number: Select your company number (or create a new company if not present)
+      select_company_number: Enter your company number (or create a new company
+                             if not yet in the system)
       contact_email: *contact_email
 
       can_be_same_email: Can be the same that you logged in with, but need not be.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,6 +169,7 @@ en:
         state/ready_for_review: &status_ready_for_review Ready for review
         state/accepted: &status_accepted Approved
         state/rejected: &status_rejected Rejected
+        state/being_destroyed: &status_being_destroyed Being Destroyed
 
 
       address:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -169,6 +169,7 @@ sv:
         state/ready_for_review: &status_ready_for_review Redo för granskning
         state/accepted: &status_accepted Godkänd
         state/rejected: &status_rejected Avböjd
+        state/being_destroyed: &status_being_destroyed Förstört
 
 
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -291,7 +291,7 @@ sv:
       first_name: *first_name
       last_name: *last_name
       company_number: *company_number
-      select_company_number: Ange ditt företagsnummer (eller skapa ett nytt
+      enter_company_number: Ange ditt företagsnummer (eller skapa ett nytt
                              företag om det inte finns i systemet)
       contact_email: *contact_email
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -256,6 +256,8 @@ sv:
           attributes:
             company_number:
               invalid: "%{company_number} är inte ett svenskt organisationsnummer"
+            companies:
+              blank: '- Ange ett befintligt företagsnummer (eller skapa ett nytt företag)'
 
       messages:
         record_invalid: 'Ett fel uppstod: %{errors}'
@@ -289,7 +291,8 @@ sv:
       first_name: *first_name
       last_name: *last_name
       company_number: *company_number
-      select_company_number: Välj ditt företagsnummer (eller skapa ett nytt företag om det inte finns)
+      select_company_number: Ange ditt företagsnummer (eller skapa ett nytt
+                             företag om det inte finns i systemet)
       contact_email: *contact_email
 
       can_be_same_email: Kan vara samma som du loggar in med, men behöver inte vara det.

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -494,6 +494,7 @@ sv:
     create:
       error: Ett eller flera problem hindrade företaget från att skapas.
       success: Företaget har skapats.
+      create_submit: Skapa företag
     update:
       error: Ett problem förhindrade uppdatering av företaget.
       success: Företaget har uppdaterats.

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -289,7 +289,7 @@ sv:
       first_name: *first_name
       last_name: *last_name
       company_number: *company_number
-      org_nr_no_hyphens: &orgnr_no_hyphens "Endast siffror (ej bindestreck)"
+      select_company_number: Välj ditt företagsnummer (eller skapa ett nytt företag om det inte finns)
       contact_email: *contact_email
 
       can_be_same_email: Kan vara samma som du loggar in med, men behöver inte vara det.
@@ -317,7 +317,6 @@ sv:
       title: Redigera ansökan om medlemskap
       is_ready_for_review: Redo för granskning
       submit_button_label: *save
-      org_nr_no_hyphens: *orgnr_no_hyphens
 
     update:
       success: Ansökan har uppdaterats.
@@ -330,7 +329,6 @@ sv:
       last_name: *last_name
       phone_number: *phone_number
       company_number: *company_number
-      org_nr_no_hyphens: *orgnr_no_hyphens
       contact_email: *contact_email
       app_status: Ansökans status
       change_status: Ändra status

--- a/db/migrate/20180219132317_remove_cmpy_number_from_application.rb
+++ b/db/migrate/20180219132317_remove_cmpy_number_from_application.rb
@@ -49,7 +49,7 @@ class RemoveCmpyNumberFromApplication < ActiveRecord::Migration[5.1]
             # Removing the second association (join record will be destroy,
             # NOT the actual company)
             second_company = app.companies_tmp.second
-            app.companies_tmp.destroy(second_company)
+            app.companies_tmp = [second_company]
           end
 
           if (app.companies.count == 0) && app.company_number &&

--- a/db/migrate/20180219132317_remove_cmpy_number_from_application.rb
+++ b/db/migrate/20180219132317_remove_cmpy_number_from_application.rb
@@ -1,0 +1,102 @@
+class RemoveCmpyNumberFromApplication < ActiveRecord::Migration[5.1]
+
+  # Define temp models using both old and new associations
+  class Company < ApplicationRecord
+    has_and_belongs_to_many :shf_applications
+
+    has_many :company_applications
+    has_many :shf_applications_tmp, through: :company_applications,
+                                    source: :shf_application, dependent: :destroy
+  end
+
+  class ShfApplication < ApplicationRecord
+    has_and_belongs_to_many :companies
+
+    has_many :company_applications
+    has_many :companies_tmp, through: :company_applications,
+                             source: :company, dependent: :destroy
+  end
+
+  class CompanyApplication < ApplicationRecord
+    belongs_to :company
+    belongs_to :shf_application
+  end
+
+  def change
+
+    # This logic here assumes that there is only one company (at most)
+    # associated with an application.  This is the situation in production
+    # at the time of this migration.
+
+    reversible do |dir|
+      dir.up do
+
+        # Create table for CompanyApplication model
+        create_table :company_applications do |t|
+          t.references :company, foreign_key: true, null: false
+          t.references :shf_application, foreign_key: true, null: false
+
+          t.timestamps
+        end
+
+        ShfApplication.all.each do |app|
+
+          app.companies_tmp = app.companies
+
+          if app.state == 'rejected'
+
+            app.companies[0].destroy if (app.companies[0]&.count == 1)
+
+          elsif app.company_number &&
+                ! Company.find_by(company_number: app.company_number)
+
+            app.companies_tmp << Company
+              .create(company_number: app.company_number,
+                      email: app.contact_email)
+          end
+        end
+
+        remove_column :shf_applications, :company_number
+
+        remove_column :shf_applications, :company_id
+
+        # Drop unneeded join table
+        drop_table :companies_shf_applications
+      end
+
+      dir.down do
+        # Recreate join table
+        create_join_table :shf_applications, :companies do |t|
+          t.index [:shf_application_id, :company_id],
+                  name: 'index_application_company'
+          t.index [:company_id, :shf_application_id],
+                  name: 'index_company_application'
+        end
+
+        # Add column company_number to shf_applications table
+        add_column :shf_applications, :company_number, :string
+
+        add_column :shf_applications, :company_id, :integer
+
+        ShfApplication.all.each do |app|
+
+          if app.state == 'accepted'
+
+            app.companies = app.companies_tmp
+            app.company_number = app.companies[0]&.company_number
+            app.save
+
+          elsif app.companies_tmp.count > 0
+
+            app.company_number = app.companies_tmp[0].company_number
+            app.save
+
+            app.companies_tmp[0].destroy
+          end
+        end
+
+        drop_table :company_applications
+      end
+    end
+  end
+end

--- a/db/migrate/20180219132317_remove_cmpy_number_from_application.rb
+++ b/db/migrate/20180219132317_remove_cmpy_number_from_application.rb
@@ -43,12 +43,7 @@ class RemoveCmpyNumberFromApplication < ActiveRecord::Migration[5.1]
 
           app.companies_tmp = app.companies
 
-          if app.state == 'rejected'
-
-            app.companies[0].destroy if (app.companies[0]&.count == 1)
-
-          elsif app.company_number &&
-                ! Company.find_by(company_number: app.company_number)
+          if app.company_number && ! Company.find_by(company_number: app.company_number)
 
             app.companies_tmp << Company
               .create(company_number: app.company_number,
@@ -65,7 +60,7 @@ class RemoveCmpyNumberFromApplication < ActiveRecord::Migration[5.1]
       end
 
       dir.down do
-        # Recreate join table
+        # Recreate join table has HABTM associations
         create_join_table :shf_applications, :companies do |t|
           t.index [:shf_application_id, :company_id],
                   name: 'index_application_company'
@@ -73,7 +68,6 @@ class RemoveCmpyNumberFromApplication < ActiveRecord::Migration[5.1]
                   name: 'index_company_application'
         end
 
-        # Add column company_number to shf_applications table
         add_column :shf_applications, :company_number, :string
 
         add_column :shf_applications, :company_id, :integer

--- a/db/migrate/20180219132317_remove_cmpy_number_from_application.rb
+++ b/db/migrate/20180219132317_remove_cmpy_number_from_application.rb
@@ -43,7 +43,20 @@ class RemoveCmpyNumberFromApplication < ActiveRecord::Migration[5.1]
 
           app.companies_tmp = app.companies
 
-          if app.company_number && ! Company.find_by(company_number: app.company_number)
+          if app.companies_tmp.count == 2
+            # At this time (Mar 14, 2018) there is *one* application in production
+            # that has the same company associated with it twice.
+            # Removing the second association (join record will be destroy,
+            # NOT the actual company)
+            second_company = app.companies_tmp.second
+            app.companies_tmp.destroy(second_company)
+          end
+
+          if (app.companies.count == 0) && app.company_number &&
+             ! Company.find_by(company_number: app.company_number)
+             # This logic prevents creating a second company for an
+             # application that was accepted and subsequently the
+             # user changed the company_number in that company
 
             app.companies_tmp << Company
               .create(company_number: app.company_number,

--- a/db/migrate/20180219132317_remove_cmpy_number_from_application.rb
+++ b/db/migrate/20180219132317_remove_cmpy_number_from_application.rb
@@ -48,8 +48,13 @@ class RemoveCmpyNumberFromApplication < ActiveRecord::Migration[5.1]
             # that has the same company associated with it twice.
             # Removing the second association (join record will be destroy,
             # NOT the actual company)
+            first_company = app.companies_tmp.first
             second_company = app.companies_tmp.second
-            app.companies_tmp = [second_company]
+
+            app.companies_tmp.destroy(first_company)
+
+            app.companies_tmp << second_company if app.companies_tmp.count == 0
+            # ^^ In case first and second company are the same
           end
 
           if (app.companies.count == 0) && app.company_number &&

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180116141245) do
+ActiveRecord::Schema.define(version: 20180210142858) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,17 +141,15 @@ ActiveRecord::Schema.define(version: 20180116141245) do
   end
 
   create_table "shf_applications", force: :cascade do |t|
-    t.string "company_number"
     t.string "phone_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.string "contact_email"
-    t.bigint "company_id"
     t.string "state", default: "new"
     t.integer "member_app_waiting_reasons_id"
     t.string "custom_reason_text"
-    t.index ["company_id"], name: "index_shf_applications_on_company_id"
+    t.string "company_number"
     t.index ["member_app_waiting_reasons_id"], name: "index_shf_applications_on_member_app_waiting_reasons_id"
     t.index ["user_id"], name: "index_shf_applications_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,15 +15,15 @@ ActiveRecord::Schema.define(version: 20180219132317) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "addresses", force: :cascade do |t|
+  create_table "addresses", id: :serial, force: :cascade do |t|
     t.string "street_address"
     t.string "post_code"
     t.string "city"
     t.string "country", default: "Sverige", null: false
-    t.bigint "region_id"
+    t.integer "region_id"
     t.string "addressable_type"
-    t.bigint "addressable_id"
-    t.bigint "kommun_id"
+    t.integer "addressable_id"
+    t.integer "kommun_id"
     t.float "latitude"
     t.float "longitude"
     t.string "visibility", default: "street_address"
@@ -47,21 +47,21 @@ ActiveRecord::Schema.define(version: 20180219132317) do
     t.datetime "shf_logo_updated_at"
   end
 
-  create_table "business_categories", force: :cascade do |t|
+  create_table "business_categories", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "business_categories_shf_applications", force: :cascade do |t|
-    t.bigint "shf_application_id"
-    t.bigint "business_category_id"
+  create_table "business_categories_shf_applications", id: :serial, force: :cascade do |t|
+    t.integer "shf_application_id"
+    t.integer "business_category_id"
     t.index ["business_category_id"], name: "index_on_categories"
     t.index ["shf_application_id"], name: "index_on_applications"
   end
 
-  create_table "ckeditor_assets", force: :cascade do |t|
+  create_table "ckeditor_assets", id: :serial, force: :cascade do |t|
     t.string "data_file_name", null: false
     t.string "data_content_type"
     t.integer "data_file_size"
@@ -71,12 +71,12 @@ ActiveRecord::Schema.define(version: 20180219132317) do
     t.integer "height"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "company_id"
+    t.integer "company_id"
     t.index ["company_id"], name: "index_ckeditor_assets_on_company_id"
     t.index ["type"], name: "index_ckeditor_assets_on_type"
   end
 
-  create_table "companies", force: :cascade do |t|
+  create_table "companies", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "company_number"
     t.string "phone_number"
@@ -97,13 +97,13 @@ ActiveRecord::Schema.define(version: 20180219132317) do
     t.index ["shf_application_id"], name: "index_company_applications_on_shf_application_id"
   end
 
-  create_table "kommuns", force: :cascade do |t|
+  create_table "kommuns", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "member_app_waiting_reasons", force: :cascade, comment: "reasons why SHF is waiting for more info from applicant. Add more columns when more locales needed." do |t|
+  create_table "member_app_waiting_reasons", id: :serial, force: :cascade, comment: "reasons why SHF is waiting for more info from applicant. Add more columns when more locales needed." do |t|
     t.string "name_sv", comment: "name of the reason in svenska/Swedish"
     t.string "description_sv", comment: "description for the reason in svenska/Swedish"
     t.string "name_en", comment: "name of the reason in engelsk/English"
@@ -113,7 +113,7 @@ ActiveRecord::Schema.define(version: 20180219132317) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "member_pages", force: :cascade do |t|
+  create_table "member_pages", id: :serial, force: :cascade do |t|
     t.string "filename", null: false
     t.string "title"
     t.datetime "created_at", null: false
@@ -135,18 +135,18 @@ ActiveRecord::Schema.define(version: 20180219132317) do
     t.index ["user_id"], name: "index_payments_on_user_id"
   end
 
-  create_table "regions", force: :cascade do |t|
+  create_table "regions", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "shf_applications", force: :cascade do |t|
+  create_table "shf_applications", id: :serial, force: :cascade do |t|
     t.string "phone_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
+    t.integer "user_id"
     t.string "contact_email"
     t.string "state", default: "new"
     t.integer "member_app_waiting_reasons_id"
@@ -155,8 +155,8 @@ ActiveRecord::Schema.define(version: 20180219132317) do
     t.index ["user_id"], name: "index_shf_applications_on_user_id"
   end
 
-  create_table "shf_documents", force: :cascade do |t|
-    t.bigint "uploader_id", null: false
+  create_table "shf_documents", id: :serial, force: :cascade do |t|
+    t.integer "uploader_id", null: false
     t.string "title"
     t.text "description"
     t.datetime "created_at", null: false
@@ -168,18 +168,18 @@ ActiveRecord::Schema.define(version: 20180219132317) do
     t.index ["uploader_id"], name: "index_shf_documents_on_uploader_id"
   end
 
-  create_table "uploaded_files", force: :cascade do |t|
+  create_table "uploaded_files", id: :serial, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "actual_file_file_name"
     t.string "actual_file_content_type"
     t.integer "actual_file_file_size"
     t.datetime "actual_file_updated_at"
-    t.bigint "shf_application_id"
+    t.integer "shf_application_id"
     t.index ["shf_application_id"], name: "index_uploaded_files_on_shf_application_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :serial, force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,15 +15,15 @@ ActiveRecord::Schema.define(version: 20180219132317) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "addresses", id: :serial, force: :cascade do |t|
+  create_table "addresses", force: :cascade do |t|
     t.string "street_address"
     t.string "post_code"
     t.string "city"
     t.string "country", default: "Sverige", null: false
-    t.integer "region_id"
+    t.bigint "region_id"
     t.string "addressable_type"
-    t.integer "addressable_id"
-    t.integer "kommun_id"
+    t.bigint "addressable_id"
+    t.bigint "kommun_id"
     t.float "latitude"
     t.float "longitude"
     t.string "visibility", default: "street_address"
@@ -47,21 +47,21 @@ ActiveRecord::Schema.define(version: 20180219132317) do
     t.datetime "shf_logo_updated_at"
   end
 
-  create_table "business_categories", id: :serial, force: :cascade do |t|
+  create_table "business_categories", force: :cascade do |t|
     t.string "name"
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "business_categories_shf_applications", id: :serial, force: :cascade do |t|
-    t.integer "shf_application_id"
-    t.integer "business_category_id"
+  create_table "business_categories_shf_applications", force: :cascade do |t|
+    t.bigint "shf_application_id"
+    t.bigint "business_category_id"
     t.index ["business_category_id"], name: "index_on_categories"
     t.index ["shf_application_id"], name: "index_on_applications"
   end
 
-  create_table "ckeditor_assets", id: :serial, force: :cascade do |t|
+  create_table "ckeditor_assets", force: :cascade do |t|
     t.string "data_file_name", null: false
     t.string "data_content_type"
     t.integer "data_file_size"
@@ -71,12 +71,12 @@ ActiveRecord::Schema.define(version: 20180219132317) do
     t.integer "height"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "company_id"
+    t.bigint "company_id"
     t.index ["company_id"], name: "index_ckeditor_assets_on_company_id"
     t.index ["type"], name: "index_ckeditor_assets_on_type"
   end
 
-  create_table "companies", id: :serial, force: :cascade do |t|
+  create_table "companies", force: :cascade do |t|
     t.string "name"
     t.string "company_number"
     t.string "phone_number"
@@ -97,13 +97,13 @@ ActiveRecord::Schema.define(version: 20180219132317) do
     t.index ["shf_application_id"], name: "index_company_applications_on_shf_application_id"
   end
 
-  create_table "kommuns", id: :serial, force: :cascade do |t|
+  create_table "kommuns", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "member_app_waiting_reasons", id: :serial, force: :cascade, comment: "reasons why SHF is waiting for more info from applicant. Add more columns when more locales needed." do |t|
+  create_table "member_app_waiting_reasons", force: :cascade, comment: "reasons why SHF is waiting for more info from applicant. Add more columns when more locales needed." do |t|
     t.string "name_sv", comment: "name of the reason in svenska/Swedish"
     t.string "description_sv", comment: "description for the reason in svenska/Swedish"
     t.string "name_en", comment: "name of the reason in engelsk/English"
@@ -113,7 +113,7 @@ ActiveRecord::Schema.define(version: 20180219132317) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "member_pages", id: :serial, force: :cascade do |t|
+  create_table "member_pages", force: :cascade do |t|
     t.string "filename", null: false
     t.string "title"
     t.datetime "created_at", null: false
@@ -135,18 +135,18 @@ ActiveRecord::Schema.define(version: 20180219132317) do
     t.index ["user_id"], name: "index_payments_on_user_id"
   end
 
-  create_table "regions", id: :serial, force: :cascade do |t|
+  create_table "regions", force: :cascade do |t|
     t.string "name"
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "shf_applications", id: :serial, force: :cascade do |t|
+  create_table "shf_applications", force: :cascade do |t|
     t.string "phone_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id"
+    t.bigint "user_id"
     t.string "contact_email"
     t.string "state", default: "new"
     t.integer "member_app_waiting_reasons_id"
@@ -155,8 +155,8 @@ ActiveRecord::Schema.define(version: 20180219132317) do
     t.index ["user_id"], name: "index_shf_applications_on_user_id"
   end
 
-  create_table "shf_documents", id: :serial, force: :cascade do |t|
-    t.integer "uploader_id", null: false
+  create_table "shf_documents", force: :cascade do |t|
+    t.bigint "uploader_id", null: false
     t.string "title"
     t.text "description"
     t.datetime "created_at", null: false
@@ -168,18 +168,18 @@ ActiveRecord::Schema.define(version: 20180219132317) do
     t.index ["uploader_id"], name: "index_shf_documents_on_uploader_id"
   end
 
-  create_table "uploaded_files", id: :serial, force: :cascade do |t|
+  create_table "uploaded_files", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "actual_file_file_name"
     t.string "actual_file_content_type"
     t.integer "actual_file_file_size"
     t.datetime "actual_file_updated_at"
-    t.integer "shf_application_id"
+    t.bigint "shf_application_id"
     t.index ["shf_application_id"], name: "index_uploaded_files_on_shf_application_id"
   end
 
-  create_table "users", id: :serial, force: :cascade do |t|
+  create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180210142858) do
+ActiveRecord::Schema.define(version: 20180219132317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,11 +88,13 @@ ActiveRecord::Schema.define(version: 20180210142858) do
     t.index ["company_number"], name: "index_companies_on_company_number", unique: true
   end
 
-  create_table "companies_shf_applications", id: false, force: :cascade do |t|
-    t.bigint "shf_application_id", null: false
+  create_table "company_applications", force: :cascade do |t|
     t.bigint "company_id", null: false
-    t.index ["company_id", "shf_application_id"], name: "index_company_application"
-    t.index ["shf_application_id", "company_id"], name: "index_application_company"
+    t.bigint "shf_application_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["company_id"], name: "index_company_applications_on_company_id"
+    t.index ["shf_application_id"], name: "index_company_applications_on_shf_application_id"
   end
 
   create_table "kommuns", force: :cascade do |t|
@@ -149,7 +151,6 @@ ActiveRecord::Schema.define(version: 20180210142858) do
     t.string "state", default: "new"
     t.integer "member_app_waiting_reasons_id"
     t.string "custom_reason_text"
-    t.string "company_number"
     t.index ["member_app_waiting_reasons_id"], name: "index_shf_applications_on_member_app_waiting_reasons_id"
     t.index ["user_id"], name: "index_shf_applications_on_user_id"
   end
@@ -208,6 +209,8 @@ ActiveRecord::Schema.define(version: 20180210142858) do
   add_foreign_key "addresses", "kommuns"
   add_foreign_key "addresses", "regions"
   add_foreign_key "ckeditor_assets", "companies"
+  add_foreign_key "company_applications", "companies"
+  add_foreign_key "company_applications", "shf_applications"
   add_foreign_key "payments", "companies"
   add_foreign_key "payments", "users"
   add_foreign_key "shf_applications", "member_app_waiting_reasons", column: "member_app_waiting_reasons_id"

--- a/db/seed_helpers.rb
+++ b/db/seed_helpers.rb
@@ -21,7 +21,7 @@ module SeedHelper
   end
 
 
-  def get_company_number(r)
+  def get_company_number(r=Random.new)
     company_number = nil
     100.times do
       # loop until done or we find a valid Org number
@@ -82,7 +82,7 @@ module SeedHelper
   end
 
 
-  def make_n_save_app(user, state, co_number = get_company_number(Random.new))
+  def make_n_save_app(user, state, co_number = get_company_number)
     # create a basic app
     ma = make_app(user)
 

--- a/db/seed_helpers.rb
+++ b/db/seed_helpers.rb
@@ -29,7 +29,7 @@ module SeedHelper
       next unless org_number.valid?
 
       # keep going if number already used
-      unless ShfApplication.find_by_company_number(org_number.number)
+      unless Company.find_by_company_number(org_number.number)
         company_number = org_number.number
         break
       end
@@ -84,13 +84,13 @@ module SeedHelper
 
   def make_n_save_app(user, state, co_number = get_company_number(Random.new))
     # create a basic app
-    ma = make_app(user, co_number )
+    ma = make_app(user)
 
     ma.state = state
 
     if state == MA_ACCEPTED_STATE then
       # make a full company object (instance) for the accepted membership application
-      ma.companies << make_new_company(ma.company_number)
+      ma.companies << make_new_company(co_number)
 
       # do not send emails
       user.grant_membership(send_email: false)
@@ -153,16 +153,16 @@ module SeedHelper
   end
 
 
-  def make_app(u, company_number)
+  def make_app(user)
 
     r = Random.new
 
     business_categories = BusinessCategory.all.to_a
 
     # for 1 in 8 apps, use a different contact email than the user's email
-    ma = ShfApplication.new(contact_email: ( (Random.new.rand(1..8)) == 0 ? FFaker::InternetSE.disposable_email : u.email),
-                            company_number: company_number,
-                            user: u)
+    email = (Random.new.rand(1..8) == 0) ? FFaker::InternetSE.disposable_email : user.email
+
+    ma = ShfApplication.new(contact_email: email, user: user)
 
     # add 1 to 3 business_categories, picked at random from them
     cats = FFaker.fetch_sample(business_categories, { count: (r.rand(1..3)) })

--- a/db/seed_helpers.rb
+++ b/db/seed_helpers.rb
@@ -83,37 +83,38 @@ module SeedHelper
 
 
   def make_n_save_app(user, state, co_number = get_company_number)
+
     # create a basic app
     ma = make_app(user)
 
+    ma.companies = [] # We validate that this association is present
+
     ma.state = state
 
-    if state == MA_ACCEPTED_STATE then
-      # make a full company object (instance) for the accepted membership application
-      ma.companies << make_new_company(co_number)
+    # make a full company object (instance) for the membership application
+    ma.companies << make_new_company(co_number)
 
-      # do not send emails
-      user.grant_membership(send_email: false)
+    # do not send emails
+    user.grant_membership(send_email: false)
 
-      start_date, expire_date = User.next_membership_payment_dates(user.id)
+    start_date, expire_date = User.next_membership_payment_dates(user.id)
 
-      user.payments << Payment.create(payment_type: Payment::PAYMENT_TYPE_MEMBER,
-                                      user_id: user.id,
-                                      hips_id: 'none',
-                                      status: Payment.order_to_payment_status('successful'),
-                                      start_date: start_date,
-                                      expire_date: expire_date)
+    user.payments << Payment.create(payment_type: Payment::PAYMENT_TYPE_MEMBER,
+                                    user_id: user.id,
+                                    hips_id: 'none',
+                                    status: Payment.order_to_payment_status('successful'),
+                                    start_date: start_date,
+                                    expire_date: expire_date)
 
-      start_date, expire_date = Company.next_branding_payment_dates(ma.companies[0].id)
+    start_date, expire_date = Company.next_branding_payment_dates(ma.companies[0].id)
 
-      ma.companies[0].payments << Payment.create(payment_type: Payment::PAYMENT_TYPE_BRANDING,
-                                      user_id: user.id,
-                                      company_id: ma.companies[0].id,
-                                      hips_id: 'none',
-                                      status: Payment.order_to_payment_status('successful'),
-                                      start_date: start_date,
-                                      expire_date: expire_date)
-    end
+    ma.companies[0].payments << Payment.create(payment_type: Payment::PAYMENT_TYPE_BRANDING,
+                                    user_id: user.id,
+                                    company_id: ma.companies[0].id,
+                                    hips_id: 'none',
+                                    status: Payment.order_to_payment_status('successful'),
+                                    start_date: start_date,
+                                    expire_date: expire_date)
 
     user.shf_application = ma
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,11 +44,12 @@ BusinessCategory.find_or_create_by(name: 'Sociala tjänstehundar', description: 
 BusinessCategory.find_or_create_by(name: 'Civila tjänstehundar', description: 'Assistanshundar dvs hundar som jobbar åt sin ägare som service-, signal, diabetes, PH-hund mm')
 
 puts 'Creating admin user'
+
+email = env_invalid_blank('SHF_ADMIN_EMAIL')
+pwd = env_invalid_blank('SHF_ADMIN_PWD')
+
 if Rails.env.production?
   begin
-    email = env_invalid_blank('SHF_ADMIN_EMAIL')
-    pwd = env_invalid_blank('SHF_ADMIN_PWD')
-
     User.create!(email: email, password: pwd, admin: true,
                  first_name: 'SHF', last_name: 'Admin')
   rescue => e
@@ -57,8 +58,6 @@ if Rails.env.production?
     raise
   end
 else
-  email = 'admin@sverigeshundforetagare.se'
-  pwd = 'hundapor'
   User.create(email: email, password: pwd, admin: true,
               first_name: 'SHF', last_name: 'Admin')
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -253,13 +253,35 @@ ALTER SEQUENCE public.companies_id_seq OWNED BY public.companies.id;
 
 
 --
--- Name: companies_shf_applications; Type: TABLE; Schema: public; Owner: -
+-- Name: company_applications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.companies_shf_applications (
+CREATE TABLE public.company_applications (
+    id bigint NOT NULL,
+    company_id bigint NOT NULL,
     shf_application_id bigint NOT NULL,
-    company_id bigint NOT NULL
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
 );
+
+
+--
+-- Name: company_applications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.company_applications_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: company_applications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.company_applications_id_seq OWNED BY public.company_applications.id;
 
 
 --
@@ -499,13 +521,11 @@ CREATE TABLE public.schema_migrations (
 
 CREATE TABLE public.shf_applications (
     id bigint NOT NULL,
-    company_number character varying,
     phone_number character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     user_id bigint,
     contact_email character varying,
-    company_id bigint,
     state character varying DEFAULT 'new'::character varying,
     member_app_waiting_reasons_id integer,
     custom_reason_text character varying
@@ -695,6 +715,13 @@ ALTER TABLE ONLY public.companies ALTER COLUMN id SET DEFAULT nextval('public.co
 
 
 --
+-- Name: company_applications id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.company_applications ALTER COLUMN id SET DEFAULT nextval('public.company_applications_id_seq'::regclass);
+
+
+--
 -- Name: kommuns id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -814,6 +841,14 @@ ALTER TABLE ONLY public.companies
 
 
 --
+-- Name: company_applications company_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.company_applications
+    ADD CONSTRAINT company_applications_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: kommuns kommuns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -922,13 +957,6 @@ CREATE INDEX index_addresses_on_region_id ON public.addresses USING btree (regio
 
 
 --
--- Name: index_application_company; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_application_company ON public.companies_shf_applications USING btree (shf_application_id, company_id);
-
-
---
 -- Name: index_ckeditor_assets_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -950,10 +978,17 @@ CREATE UNIQUE INDEX index_companies_on_company_number ON public.companies USING 
 
 
 --
--- Name: index_company_application; Type: INDEX; Schema: public; Owner: -
+-- Name: index_company_applications_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_company_application ON public.companies_shf_applications USING btree (company_id, shf_application_id);
+CREATE INDEX index_company_applications_on_company_id ON public.company_applications USING btree (company_id);
+
+
+--
+-- Name: index_company_applications_on_shf_application_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_company_applications_on_shf_application_id ON public.company_applications USING btree (shf_application_id);
 
 
 --
@@ -982,13 +1017,6 @@ CREATE INDEX index_payments_on_company_id ON public.payments USING btree (compan
 --
 
 CREATE INDEX index_payments_on_user_id ON public.payments USING btree (user_id);
-
-
---
--- Name: index_shf_applications_on_company_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_shf_applications_on_company_id ON public.shf_applications USING btree (company_id);
 
 
 --
@@ -1105,6 +1133,22 @@ ALTER TABLE ONLY public.shf_applications
 
 
 --
+-- Name: company_applications fk_rails_cf393e2864; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.company_applications
+    ADD CONSTRAINT fk_rails_cf393e2864 FOREIGN KEY (company_id) REFERENCES public.companies(id);
+
+
+--
+-- Name: company_applications fk_rails_cfd957fb2a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.company_applications
+    ADD CONSTRAINT fk_rails_cfd957fb2a FOREIGN KEY (shf_application_id) REFERENCES public.shf_applications(id);
+
+
+--
 -- Name: addresses fk_rails_f7aa0f06a9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1174,6 +1218,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171213174816'),
 ('20180103171241'),
 ('20180110215208'),
-('20180116141245');
+('20180116141245'),
+('20180219132317');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -31,15 +31,15 @@ SET default_with_oids = false;
 --
 
 CREATE TABLE public.addresses (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     street_address character varying,
     post_code character varying,
     city character varying,
     country character varying DEFAULT 'Sverige'::character varying NOT NULL,
-    region_id bigint,
+    region_id integer,
     addressable_type character varying,
-    addressable_id bigint,
-    kommun_id bigint,
+    addressable_id integer,
+    kommun_id integer,
     latitude double precision,
     longitude double precision,
     visibility character varying DEFAULT 'street_address'::character varying,
@@ -121,7 +121,7 @@ CREATE TABLE public.ar_internal_metadata (
 --
 
 CREATE TABLE public.business_categories (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     name character varying,
     description character varying,
     created_at timestamp without time zone NOT NULL,
@@ -153,9 +153,9 @@ ALTER SEQUENCE public.business_categories_id_seq OWNED BY public.business_catego
 --
 
 CREATE TABLE public.business_categories_shf_applications (
-    id bigint NOT NULL,
-    shf_application_id bigint,
-    business_category_id bigint
+    id integer NOT NULL,
+    shf_application_id integer,
+    business_category_id integer
 );
 
 
@@ -183,7 +183,7 @@ ALTER SEQUENCE public.business_categories_shf_applications_id_seq OWNED BY publi
 --
 
 CREATE TABLE public.ckeditor_assets (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     data_file_name character varying NOT NULL,
     data_content_type character varying,
     data_file_size integer,
@@ -193,7 +193,7 @@ CREATE TABLE public.ckeditor_assets (
     height integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    company_id bigint
+    company_id integer
 );
 
 
@@ -221,7 +221,7 @@ ALTER SEQUENCE public.ckeditor_assets_id_seq OWNED BY public.ckeditor_assets.id;
 --
 
 CREATE TABLE public.companies (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     name character varying,
     company_number character varying,
     phone_number character varying,
@@ -289,7 +289,7 @@ ALTER SEQUENCE public.company_applications_id_seq OWNED BY public.company_applic
 --
 
 CREATE TABLE public.kommuns (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     name character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
@@ -320,7 +320,7 @@ ALTER SEQUENCE public.kommuns_id_seq OWNED BY public.kommuns.id;
 --
 
 CREATE TABLE public.member_app_waiting_reasons (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     name_sv character varying,
     description_sv character varying,
     name_en character varying,
@@ -397,7 +397,7 @@ ALTER SEQUENCE public.member_app_waiting_reasons_id_seq OWNED BY public.member_a
 --
 
 CREATE TABLE public.member_pages (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     filename character varying NOT NULL,
     title character varying,
     created_at timestamp without time zone NOT NULL,
@@ -479,7 +479,7 @@ ALTER SEQUENCE public.payments_id_seq OWNED BY public.payments.id;
 --
 
 CREATE TABLE public.regions (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     name character varying,
     code character varying,
     created_at timestamp without time zone NOT NULL,
@@ -520,11 +520,11 @@ CREATE TABLE public.schema_migrations (
 --
 
 CREATE TABLE public.shf_applications (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     phone_number character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    user_id bigint,
+    user_id integer,
     contact_email character varying,
     state character varying DEFAULT 'new'::character varying,
     member_app_waiting_reasons_id integer,
@@ -556,8 +556,8 @@ ALTER SEQUENCE public.shf_applications_id_seq OWNED BY public.shf_applications.i
 --
 
 CREATE TABLE public.shf_documents (
-    id bigint NOT NULL,
-    uploader_id bigint NOT NULL,
+    id integer NOT NULL,
+    uploader_id integer NOT NULL,
     title character varying,
     description text,
     created_at timestamp without time zone NOT NULL,
@@ -593,14 +593,14 @@ ALTER SEQUENCE public.shf_documents_id_seq OWNED BY public.shf_documents.id;
 --
 
 CREATE TABLE public.uploaded_files (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     actual_file_file_name character varying,
     actual_file_content_type character varying,
     actual_file_file_size integer,
     actual_file_updated_at timestamp without time zone,
-    shf_application_id bigint
+    shf_application_id integer
 );
 
 
@@ -628,7 +628,7 @@ ALTER SEQUENCE public.uploaded_files_id_seq OWNED BY public.uploaded_files.id;
 --
 
 CREATE TABLE public.users (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     email character varying DEFAULT ''::character varying NOT NULL,
     encrypted_password character varying DEFAULT ''::character varying NOT NULL,
     reset_password_token character varying,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -254,13 +254,35 @@ ALTER SEQUENCE companies_id_seq OWNED BY companies.id;
 
 
 --
--- Name: companies_shf_applications; Type: TABLE; Schema: public; Owner: -
+-- Name: company_applications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE companies_shf_applications (
+CREATE TABLE company_applications (
+    id bigint NOT NULL,
+    company_id bigint NOT NULL,
     shf_application_id bigint NOT NULL,
-    company_id bigint NOT NULL
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
 );
+
+
+--
+-- Name: company_applications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE company_applications_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: company_applications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE company_applications_id_seq OWNED BY company_applications.id;
 
 
 --
@@ -500,13 +522,11 @@ CREATE TABLE schema_migrations (
 
 CREATE TABLE shf_applications (
     id bigint NOT NULL,
-    company_number character varying,
     phone_number character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     user_id bigint,
     contact_email character varying,
-    company_id bigint,
     state character varying DEFAULT 'new'::character varying,
     member_app_waiting_reasons_id integer,
     custom_reason_text character varying
@@ -696,6 +716,13 @@ ALTER TABLE ONLY companies ALTER COLUMN id SET DEFAULT nextval('companies_id_seq
 
 
 --
+-- Name: company_applications id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY company_applications ALTER COLUMN id SET DEFAULT nextval('company_applications_id_seq'::regclass);
+
+
+--
 -- Name: kommuns id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -815,6 +842,14 @@ ALTER TABLE ONLY companies
 
 
 --
+-- Name: company_applications company_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY company_applications
+    ADD CONSTRAINT company_applications_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: kommuns kommuns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -923,13 +958,6 @@ CREATE INDEX index_addresses_on_region_id ON addresses USING btree (region_id);
 
 
 --
--- Name: index_application_company; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_application_company ON companies_shf_applications USING btree (shf_application_id, company_id);
-
-
---
 -- Name: index_ckeditor_assets_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -951,10 +979,17 @@ CREATE UNIQUE INDEX index_companies_on_company_number ON companies USING btree (
 
 
 --
--- Name: index_company_application; Type: INDEX; Schema: public; Owner: -
+-- Name: index_company_applications_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_company_application ON companies_shf_applications USING btree (company_id, shf_application_id);
+CREATE INDEX index_company_applications_on_company_id ON company_applications USING btree (company_id);
+
+
+--
+-- Name: index_company_applications_on_shf_application_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_company_applications_on_shf_application_id ON company_applications USING btree (shf_application_id);
 
 
 --
@@ -983,13 +1018,6 @@ CREATE INDEX index_payments_on_company_id ON payments USING btree (company_id);
 --
 
 CREATE INDEX index_payments_on_user_id ON payments USING btree (user_id);
-
-
---
--- Name: index_shf_applications_on_company_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_shf_applications_on_company_id ON shf_applications USING btree (company_id);
 
 
 --
@@ -1106,6 +1134,22 @@ ALTER TABLE ONLY shf_applications
 
 
 --
+-- Name: company_applications fk_rails_cf393e2864; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY company_applications
+    ADD CONSTRAINT fk_rails_cf393e2864 FOREIGN KEY (company_id) REFERENCES companies(id);
+
+
+--
+-- Name: company_applications fk_rails_cfd957fb2a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY company_applications
+    ADD CONSTRAINT fk_rails_cfd957fb2a FOREIGN KEY (shf_application_id) REFERENCES shf_applications(id);
+
+
+--
 -- Name: addresses fk_rails_f7aa0f06a9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1175,6 +1219,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171213174816'),
 ('20180103171241'),
 ('20180110215208'),
-('20180116141245');
+('20180116141245'),
+('20180219132317');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -31,15 +31,15 @@ SET default_with_oids = false;
 --
 
 CREATE TABLE public.addresses (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     street_address character varying,
     post_code character varying,
     city character varying,
     country character varying DEFAULT 'Sverige'::character varying NOT NULL,
-    region_id integer,
+    region_id bigint,
     addressable_type character varying,
-    addressable_id integer,
-    kommun_id integer,
+    addressable_id bigint,
+    kommun_id bigint,
     latitude double precision,
     longitude double precision,
     visibility character varying DEFAULT 'street_address'::character varying,
@@ -121,7 +121,7 @@ CREATE TABLE public.ar_internal_metadata (
 --
 
 CREATE TABLE public.business_categories (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     name character varying,
     description character varying,
     created_at timestamp without time zone NOT NULL,
@@ -153,9 +153,9 @@ ALTER SEQUENCE public.business_categories_id_seq OWNED BY public.business_catego
 --
 
 CREATE TABLE public.business_categories_shf_applications (
-    id integer NOT NULL,
-    shf_application_id integer,
-    business_category_id integer
+    id bigint NOT NULL,
+    shf_application_id bigint,
+    business_category_id bigint
 );
 
 
@@ -183,7 +183,7 @@ ALTER SEQUENCE public.business_categories_shf_applications_id_seq OWNED BY publi
 --
 
 CREATE TABLE public.ckeditor_assets (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     data_file_name character varying NOT NULL,
     data_content_type character varying,
     data_file_size integer,
@@ -193,7 +193,7 @@ CREATE TABLE public.ckeditor_assets (
     height integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    company_id integer
+    company_id bigint
 );
 
 
@@ -221,7 +221,7 @@ ALTER SEQUENCE public.ckeditor_assets_id_seq OWNED BY public.ckeditor_assets.id;
 --
 
 CREATE TABLE public.companies (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     name character varying,
     company_number character varying,
     phone_number character varying,
@@ -289,7 +289,7 @@ ALTER SEQUENCE public.company_applications_id_seq OWNED BY public.company_applic
 --
 
 CREATE TABLE public.kommuns (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     name character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
@@ -320,7 +320,7 @@ ALTER SEQUENCE public.kommuns_id_seq OWNED BY public.kommuns.id;
 --
 
 CREATE TABLE public.member_app_waiting_reasons (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     name_sv character varying,
     description_sv character varying,
     name_en character varying,
@@ -397,7 +397,7 @@ ALTER SEQUENCE public.member_app_waiting_reasons_id_seq OWNED BY public.member_a
 --
 
 CREATE TABLE public.member_pages (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     filename character varying NOT NULL,
     title character varying,
     created_at timestamp without time zone NOT NULL,
@@ -479,7 +479,7 @@ ALTER SEQUENCE public.payments_id_seq OWNED BY public.payments.id;
 --
 
 CREATE TABLE public.regions (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     name character varying,
     code character varying,
     created_at timestamp without time zone NOT NULL,
@@ -520,11 +520,11 @@ CREATE TABLE public.schema_migrations (
 --
 
 CREATE TABLE public.shf_applications (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     phone_number character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    user_id integer,
+    user_id bigint,
     contact_email character varying,
     state character varying DEFAULT 'new'::character varying,
     member_app_waiting_reasons_id integer,
@@ -556,8 +556,8 @@ ALTER SEQUENCE public.shf_applications_id_seq OWNED BY public.shf_applications.i
 --
 
 CREATE TABLE public.shf_documents (
-    id integer NOT NULL,
-    uploader_id integer NOT NULL,
+    id bigint NOT NULL,
+    uploader_id bigint NOT NULL,
     title character varying,
     description text,
     created_at timestamp without time zone NOT NULL,
@@ -593,14 +593,14 @@ ALTER SEQUENCE public.shf_documents_id_seq OWNED BY public.shf_documents.id;
 --
 
 CREATE TABLE public.uploaded_files (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     actual_file_file_name character varying,
     actual_file_content_type character varying,
     actual_file_file_size integer,
     actual_file_updated_at timestamp without time zone,
-    shf_application_id integer
+    shf_application_id bigint
 );
 
 
@@ -628,7 +628,7 @@ ALTER SEQUENCE public.uploaded_files_id_seq OWNED BY public.uploaded_files.id;
 --
 
 CREATE TABLE public.users (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     email character varying DEFAULT ''::character varying NOT NULL,
     encrypted_password character varying DEFAULT ''::character varying NOT NULL,
     reset_password_token character varying,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3,6 +3,7 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
@@ -21,8 +22,6 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
-SET search_path = public, pg_catalog;
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -31,7 +30,7 @@ SET default_with_oids = false;
 -- Name: addresses; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE addresses (
+CREATE TABLE public.addresses (
     id bigint NOT NULL,
     street_address character varying,
     post_code character varying,
@@ -52,7 +51,7 @@ CREATE TABLE addresses (
 -- Name: addresses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE addresses_id_seq
+CREATE SEQUENCE public.addresses_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -64,14 +63,14 @@ CREATE SEQUENCE addresses_id_seq
 -- Name: addresses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE addresses_id_seq OWNED BY addresses.id;
+ALTER SEQUENCE public.addresses_id_seq OWNED BY public.addresses.id;
 
 
 --
 -- Name: app_configurations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE app_configurations (
+CREATE TABLE public.app_configurations (
     id bigint NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
@@ -90,7 +89,7 @@ CREATE TABLE app_configurations (
 -- Name: app_configurations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE app_configurations_id_seq
+CREATE SEQUENCE public.app_configurations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -102,14 +101,14 @@ CREATE SEQUENCE app_configurations_id_seq
 -- Name: app_configurations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE app_configurations_id_seq OWNED BY app_configurations.id;
+ALTER SEQUENCE public.app_configurations_id_seq OWNED BY public.app_configurations.id;
 
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ar_internal_metadata (
+CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
     created_at timestamp without time zone NOT NULL,
@@ -121,7 +120,7 @@ CREATE TABLE ar_internal_metadata (
 -- Name: business_categories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE business_categories (
+CREATE TABLE public.business_categories (
     id bigint NOT NULL,
     name character varying,
     description character varying,
@@ -134,7 +133,7 @@ CREATE TABLE business_categories (
 -- Name: business_categories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE business_categories_id_seq
+CREATE SEQUENCE public.business_categories_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -146,14 +145,14 @@ CREATE SEQUENCE business_categories_id_seq
 -- Name: business_categories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE business_categories_id_seq OWNED BY business_categories.id;
+ALTER SEQUENCE public.business_categories_id_seq OWNED BY public.business_categories.id;
 
 
 --
 -- Name: business_categories_shf_applications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE business_categories_shf_applications (
+CREATE TABLE public.business_categories_shf_applications (
     id bigint NOT NULL,
     shf_application_id bigint,
     business_category_id bigint
@@ -164,7 +163,7 @@ CREATE TABLE business_categories_shf_applications (
 -- Name: business_categories_shf_applications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE business_categories_shf_applications_id_seq
+CREATE SEQUENCE public.business_categories_shf_applications_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -176,14 +175,14 @@ CREATE SEQUENCE business_categories_shf_applications_id_seq
 -- Name: business_categories_shf_applications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE business_categories_shf_applications_id_seq OWNED BY business_categories_shf_applications.id;
+ALTER SEQUENCE public.business_categories_shf_applications_id_seq OWNED BY public.business_categories_shf_applications.id;
 
 
 --
 -- Name: ckeditor_assets; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ckeditor_assets (
+CREATE TABLE public.ckeditor_assets (
     id bigint NOT NULL,
     data_file_name character varying NOT NULL,
     data_content_type character varying,
@@ -202,7 +201,7 @@ CREATE TABLE ckeditor_assets (
 -- Name: ckeditor_assets_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE ckeditor_assets_id_seq
+CREATE SEQUENCE public.ckeditor_assets_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -214,14 +213,14 @@ CREATE SEQUENCE ckeditor_assets_id_seq
 -- Name: ckeditor_assets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE ckeditor_assets_id_seq OWNED BY ckeditor_assets.id;
+ALTER SEQUENCE public.ckeditor_assets_id_seq OWNED BY public.ckeditor_assets.id;
 
 
 --
 -- Name: companies; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE companies (
+CREATE TABLE public.companies (
     id bigint NOT NULL,
     name character varying,
     company_number character varying,
@@ -238,7 +237,7 @@ CREATE TABLE companies (
 -- Name: companies_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE companies_id_seq
+CREATE SEQUENCE public.companies_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -250,14 +249,14 @@ CREATE SEQUENCE companies_id_seq
 -- Name: companies_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE companies_id_seq OWNED BY companies.id;
+ALTER SEQUENCE public.companies_id_seq OWNED BY public.companies.id;
 
 
 --
 -- Name: company_applications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE company_applications (
+CREATE TABLE public.company_applications (
     id bigint NOT NULL,
     company_id bigint NOT NULL,
     shf_application_id bigint NOT NULL,
@@ -270,7 +269,7 @@ CREATE TABLE company_applications (
 -- Name: company_applications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE company_applications_id_seq
+CREATE SEQUENCE public.company_applications_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -282,14 +281,14 @@ CREATE SEQUENCE company_applications_id_seq
 -- Name: company_applications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE company_applications_id_seq OWNED BY company_applications.id;
+ALTER SEQUENCE public.company_applications_id_seq OWNED BY public.company_applications.id;
 
 
 --
 -- Name: kommuns; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE kommuns (
+CREATE TABLE public.kommuns (
     id bigint NOT NULL,
     name character varying,
     created_at timestamp without time zone NOT NULL,
@@ -301,7 +300,7 @@ CREATE TABLE kommuns (
 -- Name: kommuns_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE kommuns_id_seq
+CREATE SEQUENCE public.kommuns_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -313,14 +312,14 @@ CREATE SEQUENCE kommuns_id_seq
 -- Name: kommuns_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE kommuns_id_seq OWNED BY kommuns.id;
+ALTER SEQUENCE public.kommuns_id_seq OWNED BY public.kommuns.id;
 
 
 --
 -- Name: member_app_waiting_reasons; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE member_app_waiting_reasons (
+CREATE TABLE public.member_app_waiting_reasons (
     id bigint NOT NULL,
     name_sv character varying,
     description_sv character varying,
@@ -336,49 +335,49 @@ CREATE TABLE member_app_waiting_reasons (
 -- Name: TABLE member_app_waiting_reasons; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON TABLE member_app_waiting_reasons IS 'reasons why SHF is waiting for more info from applicant. Add more columns when more locales needed.';
+COMMENT ON TABLE public.member_app_waiting_reasons IS 'reasons why SHF is waiting for more info from applicant. Add more columns when more locales needed.';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.name_sv; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN member_app_waiting_reasons.name_sv IS 'name of the reason in svenska/Swedish';
+COMMENT ON COLUMN public.member_app_waiting_reasons.name_sv IS 'name of the reason in svenska/Swedish';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.description_sv; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN member_app_waiting_reasons.description_sv IS 'description for the reason in svenska/Swedish';
+COMMENT ON COLUMN public.member_app_waiting_reasons.description_sv IS 'description for the reason in svenska/Swedish';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.name_en; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN member_app_waiting_reasons.name_en IS 'name of the reason in engelsk/English';
+COMMENT ON COLUMN public.member_app_waiting_reasons.name_en IS 'name of the reason in engelsk/English';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.description_en; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN member_app_waiting_reasons.description_en IS 'description for the reason in engelsk/English';
+COMMENT ON COLUMN public.member_app_waiting_reasons.description_en IS 'description for the reason in engelsk/English';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.is_custom; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN member_app_waiting_reasons.is_custom IS 'was this entered as a new ''custom'' reason?';
+COMMENT ON COLUMN public.member_app_waiting_reasons.is_custom IS 'was this entered as a new ''custom'' reason?';
 
 
 --
 -- Name: member_app_waiting_reasons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE member_app_waiting_reasons_id_seq
+CREATE SEQUENCE public.member_app_waiting_reasons_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -390,14 +389,14 @@ CREATE SEQUENCE member_app_waiting_reasons_id_seq
 -- Name: member_app_waiting_reasons_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE member_app_waiting_reasons_id_seq OWNED BY member_app_waiting_reasons.id;
+ALTER SEQUENCE public.member_app_waiting_reasons_id_seq OWNED BY public.member_app_waiting_reasons.id;
 
 
 --
 -- Name: member_pages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE member_pages (
+CREATE TABLE public.member_pages (
     id bigint NOT NULL,
     filename character varying NOT NULL,
     title character varying,
@@ -410,7 +409,7 @@ CREATE TABLE member_pages (
 -- Name: member_pages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE member_pages_id_seq
+CREATE SEQUENCE public.member_pages_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -422,14 +421,14 @@ CREATE SEQUENCE member_pages_id_seq
 -- Name: member_pages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE member_pages_id_seq OWNED BY member_pages.id;
+ALTER SEQUENCE public.member_pages_id_seq OWNED BY public.member_pages.id;
 
 
 --
 -- Name: membership_number_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE membership_number_seq
+CREATE SEQUENCE public.membership_number_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -441,7 +440,7 @@ CREATE SEQUENCE membership_number_seq
 -- Name: payments; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE payments (
+CREATE TABLE public.payments (
     id bigint NOT NULL,
     user_id bigint,
     company_id bigint,
@@ -460,7 +459,7 @@ CREATE TABLE payments (
 -- Name: payments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE payments_id_seq
+CREATE SEQUENCE public.payments_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -472,14 +471,14 @@ CREATE SEQUENCE payments_id_seq
 -- Name: payments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE payments_id_seq OWNED BY payments.id;
+ALTER SEQUENCE public.payments_id_seq OWNED BY public.payments.id;
 
 
 --
 -- Name: regions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE regions (
+CREATE TABLE public.regions (
     id bigint NOT NULL,
     name character varying,
     code character varying,
@@ -492,7 +491,7 @@ CREATE TABLE regions (
 -- Name: regions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE regions_id_seq
+CREATE SEQUENCE public.regions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -504,14 +503,14 @@ CREATE SEQUENCE regions_id_seq
 -- Name: regions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE regions_id_seq OWNED BY regions.id;
+ALTER SEQUENCE public.regions_id_seq OWNED BY public.regions.id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schema_migrations (
+CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
 
@@ -520,7 +519,7 @@ CREATE TABLE schema_migrations (
 -- Name: shf_applications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE shf_applications (
+CREATE TABLE public.shf_applications (
     id bigint NOT NULL,
     phone_number character varying,
     created_at timestamp without time zone NOT NULL,
@@ -537,7 +536,7 @@ CREATE TABLE shf_applications (
 -- Name: shf_applications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE shf_applications_id_seq
+CREATE SEQUENCE public.shf_applications_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -549,14 +548,14 @@ CREATE SEQUENCE shf_applications_id_seq
 -- Name: shf_applications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE shf_applications_id_seq OWNED BY shf_applications.id;
+ALTER SEQUENCE public.shf_applications_id_seq OWNED BY public.shf_applications.id;
 
 
 --
 -- Name: shf_documents; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE shf_documents (
+CREATE TABLE public.shf_documents (
     id bigint NOT NULL,
     uploader_id bigint NOT NULL,
     title character varying,
@@ -574,7 +573,7 @@ CREATE TABLE shf_documents (
 -- Name: shf_documents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE shf_documents_id_seq
+CREATE SEQUENCE public.shf_documents_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -586,14 +585,14 @@ CREATE SEQUENCE shf_documents_id_seq
 -- Name: shf_documents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE shf_documents_id_seq OWNED BY shf_documents.id;
+ALTER SEQUENCE public.shf_documents_id_seq OWNED BY public.shf_documents.id;
 
 
 --
 -- Name: uploaded_files; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE uploaded_files (
+CREATE TABLE public.uploaded_files (
     id bigint NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
@@ -609,7 +608,7 @@ CREATE TABLE uploaded_files (
 -- Name: uploaded_files_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE uploaded_files_id_seq
+CREATE SEQUENCE public.uploaded_files_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -621,14 +620,14 @@ CREATE SEQUENCE uploaded_files_id_seq
 -- Name: uploaded_files_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE uploaded_files_id_seq OWNED BY uploaded_files.id;
+ALTER SEQUENCE public.uploaded_files_id_seq OWNED BY public.uploaded_files.id;
 
 
 --
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE users (
+CREATE TABLE public.users (
     id bigint NOT NULL,
     email character varying DEFAULT ''::character varying NOT NULL,
     encrypted_password character varying DEFAULT ''::character varying NOT NULL,
@@ -658,7 +657,7 @@ CREATE TABLE users (
 -- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE users_id_seq
+CREATE SEQUENCE public.users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -670,126 +669,126 @@ CREATE SEQUENCE users_id_seq
 -- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE users_id_seq OWNED BY users.id;
+ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
 -- Name: addresses id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY addresses ALTER COLUMN id SET DEFAULT nextval('addresses_id_seq'::regclass);
+ALTER TABLE ONLY public.addresses ALTER COLUMN id SET DEFAULT nextval('public.addresses_id_seq'::regclass);
 
 
 --
 -- Name: app_configurations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY app_configurations ALTER COLUMN id SET DEFAULT nextval('app_configurations_id_seq'::regclass);
+ALTER TABLE ONLY public.app_configurations ALTER COLUMN id SET DEFAULT nextval('public.app_configurations_id_seq'::regclass);
 
 
 --
 -- Name: business_categories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY business_categories ALTER COLUMN id SET DEFAULT nextval('business_categories_id_seq'::regclass);
+ALTER TABLE ONLY public.business_categories ALTER COLUMN id SET DEFAULT nextval('public.business_categories_id_seq'::regclass);
 
 
 --
 -- Name: business_categories_shf_applications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY business_categories_shf_applications ALTER COLUMN id SET DEFAULT nextval('business_categories_shf_applications_id_seq'::regclass);
+ALTER TABLE ONLY public.business_categories_shf_applications ALTER COLUMN id SET DEFAULT nextval('public.business_categories_shf_applications_id_seq'::regclass);
 
 
 --
 -- Name: ckeditor_assets id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ckeditor_assets ALTER COLUMN id SET DEFAULT nextval('ckeditor_assets_id_seq'::regclass);
+ALTER TABLE ONLY public.ckeditor_assets ALTER COLUMN id SET DEFAULT nextval('public.ckeditor_assets_id_seq'::regclass);
 
 
 --
 -- Name: companies id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY companies ALTER COLUMN id SET DEFAULT nextval('companies_id_seq'::regclass);
+ALTER TABLE ONLY public.companies ALTER COLUMN id SET DEFAULT nextval('public.companies_id_seq'::regclass);
 
 
 --
 -- Name: company_applications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY company_applications ALTER COLUMN id SET DEFAULT nextval('company_applications_id_seq'::regclass);
+ALTER TABLE ONLY public.company_applications ALTER COLUMN id SET DEFAULT nextval('public.company_applications_id_seq'::regclass);
 
 
 --
 -- Name: kommuns id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY kommuns ALTER COLUMN id SET DEFAULT nextval('kommuns_id_seq'::regclass);
+ALTER TABLE ONLY public.kommuns ALTER COLUMN id SET DEFAULT nextval('public.kommuns_id_seq'::regclass);
 
 
 --
 -- Name: member_app_waiting_reasons id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY member_app_waiting_reasons ALTER COLUMN id SET DEFAULT nextval('member_app_waiting_reasons_id_seq'::regclass);
+ALTER TABLE ONLY public.member_app_waiting_reasons ALTER COLUMN id SET DEFAULT nextval('public.member_app_waiting_reasons_id_seq'::regclass);
 
 
 --
 -- Name: member_pages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY member_pages ALTER COLUMN id SET DEFAULT nextval('member_pages_id_seq'::regclass);
+ALTER TABLE ONLY public.member_pages ALTER COLUMN id SET DEFAULT nextval('public.member_pages_id_seq'::regclass);
 
 
 --
 -- Name: payments id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY payments ALTER COLUMN id SET DEFAULT nextval('payments_id_seq'::regclass);
+ALTER TABLE ONLY public.payments ALTER COLUMN id SET DEFAULT nextval('public.payments_id_seq'::regclass);
 
 
 --
 -- Name: regions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY regions ALTER COLUMN id SET DEFAULT nextval('regions_id_seq'::regclass);
+ALTER TABLE ONLY public.regions ALTER COLUMN id SET DEFAULT nextval('public.regions_id_seq'::regclass);
 
 
 --
 -- Name: shf_applications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY shf_applications ALTER COLUMN id SET DEFAULT nextval('shf_applications_id_seq'::regclass);
+ALTER TABLE ONLY public.shf_applications ALTER COLUMN id SET DEFAULT nextval('public.shf_applications_id_seq'::regclass);
 
 
 --
 -- Name: shf_documents id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY shf_documents ALTER COLUMN id SET DEFAULT nextval('shf_documents_id_seq'::regclass);
+ALTER TABLE ONLY public.shf_documents ALTER COLUMN id SET DEFAULT nextval('public.shf_documents_id_seq'::regclass);
 
 
 --
 -- Name: uploaded_files id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY uploaded_files ALTER COLUMN id SET DEFAULT nextval('uploaded_files_id_seq'::regclass);
+ALTER TABLE ONLY public.uploaded_files ALTER COLUMN id SET DEFAULT nextval('public.uploaded_files_id_seq'::regclass);
 
 
 --
 -- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
 
 
 --
 -- Name: addresses addresses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY addresses
+ALTER TABLE ONLY public.addresses
     ADD CONSTRAINT addresses_pkey PRIMARY KEY (id);
 
 
@@ -797,7 +796,7 @@ ALTER TABLE ONLY addresses
 -- Name: app_configurations app_configurations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY app_configurations
+ALTER TABLE ONLY public.app_configurations
     ADD CONSTRAINT app_configurations_pkey PRIMARY KEY (id);
 
 
@@ -805,7 +804,7 @@ ALTER TABLE ONLY app_configurations
 -- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ar_internal_metadata
+ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
@@ -813,7 +812,7 @@ ALTER TABLE ONLY ar_internal_metadata
 -- Name: business_categories business_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY business_categories
+ALTER TABLE ONLY public.business_categories
     ADD CONSTRAINT business_categories_pkey PRIMARY KEY (id);
 
 
@@ -821,7 +820,7 @@ ALTER TABLE ONLY business_categories
 -- Name: business_categories_shf_applications business_categories_shf_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY business_categories_shf_applications
+ALTER TABLE ONLY public.business_categories_shf_applications
     ADD CONSTRAINT business_categories_shf_applications_pkey PRIMARY KEY (id);
 
 
@@ -829,7 +828,7 @@ ALTER TABLE ONLY business_categories_shf_applications
 -- Name: ckeditor_assets ckeditor_assets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ckeditor_assets
+ALTER TABLE ONLY public.ckeditor_assets
     ADD CONSTRAINT ckeditor_assets_pkey PRIMARY KEY (id);
 
 
@@ -837,7 +836,7 @@ ALTER TABLE ONLY ckeditor_assets
 -- Name: companies companies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY companies
+ALTER TABLE ONLY public.companies
     ADD CONSTRAINT companies_pkey PRIMARY KEY (id);
 
 
@@ -845,7 +844,7 @@ ALTER TABLE ONLY companies
 -- Name: company_applications company_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY company_applications
+ALTER TABLE ONLY public.company_applications
     ADD CONSTRAINT company_applications_pkey PRIMARY KEY (id);
 
 
@@ -853,7 +852,7 @@ ALTER TABLE ONLY company_applications
 -- Name: kommuns kommuns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY kommuns
+ALTER TABLE ONLY public.kommuns
     ADD CONSTRAINT kommuns_pkey PRIMARY KEY (id);
 
 
@@ -861,7 +860,7 @@ ALTER TABLE ONLY kommuns
 -- Name: member_app_waiting_reasons member_app_waiting_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY member_app_waiting_reasons
+ALTER TABLE ONLY public.member_app_waiting_reasons
     ADD CONSTRAINT member_app_waiting_reasons_pkey PRIMARY KEY (id);
 
 
@@ -869,7 +868,7 @@ ALTER TABLE ONLY member_app_waiting_reasons
 -- Name: member_pages member_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY member_pages
+ALTER TABLE ONLY public.member_pages
     ADD CONSTRAINT member_pages_pkey PRIMARY KEY (id);
 
 
@@ -877,7 +876,7 @@ ALTER TABLE ONLY member_pages
 -- Name: payments payments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY payments
+ALTER TABLE ONLY public.payments
     ADD CONSTRAINT payments_pkey PRIMARY KEY (id);
 
 
@@ -885,7 +884,7 @@ ALTER TABLE ONLY payments
 -- Name: regions regions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY regions
+ALTER TABLE ONLY public.regions
     ADD CONSTRAINT regions_pkey PRIMARY KEY (id);
 
 
@@ -893,7 +892,7 @@ ALTER TABLE ONLY regions
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schema_migrations
+ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
@@ -901,7 +900,7 @@ ALTER TABLE ONLY schema_migrations
 -- Name: shf_applications shf_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY shf_applications
+ALTER TABLE ONLY public.shf_applications
     ADD CONSTRAINT shf_applications_pkey PRIMARY KEY (id);
 
 
@@ -909,7 +908,7 @@ ALTER TABLE ONLY shf_applications
 -- Name: shf_documents shf_documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY shf_documents
+ALTER TABLE ONLY public.shf_documents
     ADD CONSTRAINT shf_documents_pkey PRIMARY KEY (id);
 
 
@@ -917,7 +916,7 @@ ALTER TABLE ONLY shf_documents
 -- Name: uploaded_files uploaded_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY uploaded_files
+ALTER TABLE ONLY public.uploaded_files
     ADD CONSTRAINT uploaded_files_pkey PRIMARY KEY (id);
 
 
@@ -925,7 +924,7 @@ ALTER TABLE ONLY uploaded_files
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users
+ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
@@ -933,228 +932,228 @@ ALTER TABLE ONLY users
 -- Name: index_addresses_on_addressable_type_and_addressable_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_addresses_on_addressable_type_and_addressable_id ON addresses USING btree (addressable_type, addressable_id);
+CREATE INDEX index_addresses_on_addressable_type_and_addressable_id ON public.addresses USING btree (addressable_type, addressable_id);
 
 
 --
 -- Name: index_addresses_on_kommun_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_addresses_on_kommun_id ON addresses USING btree (kommun_id);
+CREATE INDEX index_addresses_on_kommun_id ON public.addresses USING btree (kommun_id);
 
 
 --
 -- Name: index_addresses_on_latitude_and_longitude; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_addresses_on_latitude_and_longitude ON addresses USING btree (latitude, longitude);
+CREATE INDEX index_addresses_on_latitude_and_longitude ON public.addresses USING btree (latitude, longitude);
 
 
 --
 -- Name: index_addresses_on_region_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_addresses_on_region_id ON addresses USING btree (region_id);
+CREATE INDEX index_addresses_on_region_id ON public.addresses USING btree (region_id);
 
 
 --
 -- Name: index_ckeditor_assets_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ckeditor_assets_on_company_id ON ckeditor_assets USING btree (company_id);
+CREATE INDEX index_ckeditor_assets_on_company_id ON public.ckeditor_assets USING btree (company_id);
 
 
 --
 -- Name: index_ckeditor_assets_on_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ckeditor_assets_on_type ON ckeditor_assets USING btree (type);
+CREATE INDEX index_ckeditor_assets_on_type ON public.ckeditor_assets USING btree (type);
 
 
 --
 -- Name: index_companies_on_company_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_companies_on_company_number ON companies USING btree (company_number);
+CREATE UNIQUE INDEX index_companies_on_company_number ON public.companies USING btree (company_number);
 
 
 --
 -- Name: index_company_applications_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_company_applications_on_company_id ON company_applications USING btree (company_id);
+CREATE INDEX index_company_applications_on_company_id ON public.company_applications USING btree (company_id);
 
 
 --
 -- Name: index_company_applications_on_shf_application_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_company_applications_on_shf_application_id ON company_applications USING btree (shf_application_id);
+CREATE INDEX index_company_applications_on_shf_application_id ON public.company_applications USING btree (shf_application_id);
 
 
 --
 -- Name: index_on_applications; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_on_applications ON business_categories_shf_applications USING btree (shf_application_id);
+CREATE INDEX index_on_applications ON public.business_categories_shf_applications USING btree (shf_application_id);
 
 
 --
 -- Name: index_on_categories; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_on_categories ON business_categories_shf_applications USING btree (business_category_id);
+CREATE INDEX index_on_categories ON public.business_categories_shf_applications USING btree (business_category_id);
 
 
 --
 -- Name: index_payments_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_payments_on_company_id ON payments USING btree (company_id);
+CREATE INDEX index_payments_on_company_id ON public.payments USING btree (company_id);
 
 
 --
 -- Name: index_payments_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_payments_on_user_id ON payments USING btree (user_id);
+CREATE INDEX index_payments_on_user_id ON public.payments USING btree (user_id);
 
 
 --
 -- Name: index_shf_applications_on_member_app_waiting_reasons_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_shf_applications_on_member_app_waiting_reasons_id ON shf_applications USING btree (member_app_waiting_reasons_id);
+CREATE INDEX index_shf_applications_on_member_app_waiting_reasons_id ON public.shf_applications USING btree (member_app_waiting_reasons_id);
 
 
 --
 -- Name: index_shf_applications_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_shf_applications_on_user_id ON shf_applications USING btree (user_id);
+CREATE INDEX index_shf_applications_on_user_id ON public.shf_applications USING btree (user_id);
 
 
 --
 -- Name: index_shf_documents_on_uploader_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_shf_documents_on_uploader_id ON shf_documents USING btree (uploader_id);
+CREATE INDEX index_shf_documents_on_uploader_id ON public.shf_documents USING btree (uploader_id);
 
 
 --
 -- Name: index_uploaded_files_on_shf_application_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_uploaded_files_on_shf_application_id ON uploaded_files USING btree (shf_application_id);
+CREATE INDEX index_uploaded_files_on_shf_application_id ON public.uploaded_files USING btree (shf_application_id);
 
 
 --
 -- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_email ON users USING btree (email);
+CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
 
 
 --
 -- Name: index_users_on_membership_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_membership_number ON users USING btree (membership_number);
+CREATE UNIQUE INDEX index_users_on_membership_number ON public.users USING btree (membership_number);
 
 
 --
 -- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_reset_password_token ON users USING btree (reset_password_token);
+CREATE UNIQUE INDEX index_users_on_reset_password_token ON public.users USING btree (reset_password_token);
 
 
 --
 -- Name: payments fk_rails_081dc04a02; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY payments
-    ADD CONSTRAINT fk_rails_081dc04a02 FOREIGN KEY (user_id) REFERENCES users(id);
+ALTER TABLE ONLY public.payments
+    ADD CONSTRAINT fk_rails_081dc04a02 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
 -- Name: payments fk_rails_0fc68a9316; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY payments
-    ADD CONSTRAINT fk_rails_0fc68a9316 FOREIGN KEY (company_id) REFERENCES companies(id);
+ALTER TABLE ONLY public.payments
+    ADD CONSTRAINT fk_rails_0fc68a9316 FOREIGN KEY (company_id) REFERENCES public.companies(id);
 
 
 --
 -- Name: ckeditor_assets fk_rails_1b8d2a3863; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ckeditor_assets
-    ADD CONSTRAINT fk_rails_1b8d2a3863 FOREIGN KEY (company_id) REFERENCES companies(id);
+ALTER TABLE ONLY public.ckeditor_assets
+    ADD CONSTRAINT fk_rails_1b8d2a3863 FOREIGN KEY (company_id) REFERENCES public.companies(id);
 
 
 --
 -- Name: uploaded_files fk_rails_2224289299; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY uploaded_files
-    ADD CONSTRAINT fk_rails_2224289299 FOREIGN KEY (shf_application_id) REFERENCES shf_applications(id);
+ALTER TABLE ONLY public.uploaded_files
+    ADD CONSTRAINT fk_rails_2224289299 FOREIGN KEY (shf_application_id) REFERENCES public.shf_applications(id);
 
 
 --
 -- Name: shf_applications fk_rails_3ee395b045; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY shf_applications
-    ADD CONSTRAINT fk_rails_3ee395b045 FOREIGN KEY (member_app_waiting_reasons_id) REFERENCES member_app_waiting_reasons(id);
+ALTER TABLE ONLY public.shf_applications
+    ADD CONSTRAINT fk_rails_3ee395b045 FOREIGN KEY (member_app_waiting_reasons_id) REFERENCES public.member_app_waiting_reasons(id);
 
 
 --
 -- Name: addresses fk_rails_76a66052a5; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY addresses
-    ADD CONSTRAINT fk_rails_76a66052a5 FOREIGN KEY (kommun_id) REFERENCES kommuns(id);
+ALTER TABLE ONLY public.addresses
+    ADD CONSTRAINT fk_rails_76a66052a5 FOREIGN KEY (kommun_id) REFERENCES public.kommuns(id);
 
 
 --
 -- Name: shf_documents fk_rails_bb6df17516; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY shf_documents
-    ADD CONSTRAINT fk_rails_bb6df17516 FOREIGN KEY (uploader_id) REFERENCES users(id);
+ALTER TABLE ONLY public.shf_documents
+    ADD CONSTRAINT fk_rails_bb6df17516 FOREIGN KEY (uploader_id) REFERENCES public.users(id);
 
 
 --
 -- Name: shf_applications fk_rails_be394644c4; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY shf_applications
-    ADD CONSTRAINT fk_rails_be394644c4 FOREIGN KEY (user_id) REFERENCES users(id);
+ALTER TABLE ONLY public.shf_applications
+    ADD CONSTRAINT fk_rails_be394644c4 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
 -- Name: company_applications fk_rails_cf393e2864; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY company_applications
-    ADD CONSTRAINT fk_rails_cf393e2864 FOREIGN KEY (company_id) REFERENCES companies(id);
+ALTER TABLE ONLY public.company_applications
+    ADD CONSTRAINT fk_rails_cf393e2864 FOREIGN KEY (company_id) REFERENCES public.companies(id);
 
 
 --
 -- Name: company_applications fk_rails_cfd957fb2a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY company_applications
-    ADD CONSTRAINT fk_rails_cfd957fb2a FOREIGN KEY (shf_application_id) REFERENCES shf_applications(id);
+ALTER TABLE ONLY public.company_applications
+    ADD CONSTRAINT fk_rails_cfd957fb2a FOREIGN KEY (shf_application_id) REFERENCES public.shf_applications(id);
 
 
 --
 -- Name: addresses fk_rails_f7aa0f06a9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY addresses
-    ADD CONSTRAINT fk_rails_f7aa0f06a9 FOREIGN KEY (region_id) REFERENCES regions(id);
+ALTER TABLE ONLY public.addresses
+    ADD CONSTRAINT fk_rails_f7aa0f06a9 FOREIGN KEY (region_id) REFERENCES public.regions(id);
 
 
 --

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -86,6 +86,7 @@ Feature: Create a new membership application
     And I fill in t("companies.show.email") with "info@craft.se"
     And I click on t("companies.create.create_submit")
     And I wait for all ajax requests to complete
+    And I wait 2 seconds
     And I click on t("shf_applications.new.submit_button_label")
 
     Then I should be on the "user instructions" page

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -3,6 +3,10 @@ Feature: Create a new membership application
   As a user
   In order to get a membership with SHF (which makes my business more valuable )
   I need to be able to submit a Membership Application
+  And as part of the process of creating an application,
+  I need to either select an existing company number for my company, or,
+  If that is not available, I need to create a new company
+
   PT: https://www.pivotaltracker.com/story/show/133940725
   &: https://www.pivotaltracker.com/story/show/135027425
 
@@ -26,6 +30,10 @@ Feature: Create a new membership application
       | Psychologist |
       | Trainer      |
 
+    And the following companies exist:
+      | name                 | company_number | email                  | region     |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.com | Stockholm  |
+
     And the following applications exist:
       | user_email        | company_number | state    |
       | member@random.com | 5560360793     | accepted |
@@ -37,9 +45,10 @@ Feature: Create a new membership application
     Given I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 5562252998                          | 031-1234567                       | info@craft.se                      |
+      | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 031-1234567                       | info@craft.se                      |
     And I select "Groomer" Category
+    And I select "5560360793" in select list "company_id"
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: info@craft.se)
@@ -57,22 +66,30 @@ Feature: Create a new membership application
     Given I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 5562252998                          | 031-1234567                       | info@craft.se                      |
+      | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 031-1234567                       | info@craft.se                      |
+    And I select "5560360793" in select list "company_id"
     And I select "Trainer" Category
     And I select "Psychologist" Category
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: info@craft.se)
 
-
+  @selenium
   Scenario: A user can submit a new Membership Application with no categories
-    Given I am on the "landing" page
-    And I click on t("menus.nav.users.apply_for_membership")
+    Given I am on the "new application" page
     And I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 5562252998                          | 031-1234567                       | info@craft.se                      |
+      | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 031-1234567                       | info@craft.se                      |
+
+    # Create new company in modal
+    And I click on t("companies.new.title")
+    And I fill in t("companies.show.company_number") with "2286411992"
+    And I fill in t("companies.show.email") with "info@craft.se"
+    And I click on t("companies.create.create_submit")
+    And I wait for all ajax requests to complete
     And I click on t("shf_applications.new.submit_button_label")
+
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: info@craft.se)
 
@@ -91,74 +108,116 @@ Feature: Create a new membership application
     And the field t("shf_applications.new.phone_number") should not have a required field indicator
     And I should see t("is_required_field")
 
-
+  @selenium
   Scenario: Two users can submit a new Membership Application (with empty membershipnumbers)
     Given I am logged in as "applicant_1@random.com"
-    And I am on the "landing" page
-    And I click on t("menus.nav.users.apply_for_membership")
+    And I am on the "new application" page
     And I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 5562252998                          | 031-1234567                       | applicant_1@random.com             |
+      | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 031-1234567                       | applicant_1@random.com             |
+
+    # Create new company in modal
+    And I click on t("companies.new.title")
+    And I fill in t("companies.show.company_number") with "5562252998"
+    And I fill in t("companies.show.email") with "info@craft.se"
+    And I click on t("companies.create.create_submit")
+    And I wait for all ajax requests to complete
     And I click on t("shf_applications.new.submit_button_label")
+
     Then I should see t("shf_applications.create.success", email_address: applicant_1@random.com)
+
     Given I am logged in as "applicant_2@random.com"
-    And I am on the "landing" page
-    And I click on t("menus.nav.users.apply_for_membership")
+    And I am on the "new application" page
     And I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 2120000142                          | 031-1234567                       | applicant_2@random.com             |
+      | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 031-1234567                       | applicant_2@random.com             |
+
+    # Create new company in modal
+    And I click on t("companies.new.title")
+    And I fill in t("companies.show.company_number") with "2120000142"
+    And I fill in t("companies.show.email") with "info@craft.se"
+    And I click on t("companies.create.create_submit")
+    And I wait for all ajax requests to complete
     And I click on t("shf_applications.new.submit_button_label")
+
     Then I should see t("shf_applications.create.success", email_address: applicant_2@random.com)
 
 
-  Scenario Outline: Apply for membership - when things go wrong
-    Given I am on the "landing" page
-    And I click on t("menus.nav.users.apply_for_membership")
+  Scenario Outline: Apply for membership - when things go wrong with application data
+    Given I am on the "new application" page
     And I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.contact_email | shf_applications.new.phone_number |
-      | <c_number>                          | <c_email>                          | <phone>                           |
-
+      | shf_applications.new.contact_email | shf_applications.new.phone_number |
+      | <c_email>                          | <phone>                           |
     When I click on t("shf_applications.new.submit_button_label")
     Then I should see error <model_attribute> <error>
     And I should receive no emails
     And "admin@shf.se" should receive no emails
 
+    Scenarios:
+      | c_email       | phone      | model_attribute                                             | error                            |
+      |               | 0706898525 | t("activerecord.attributes.shf_application.contact_email")  | t("errors.messages.blank")       |
+      | kicki@imminu  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")  | t("errors.messages.invalid")     |
+      | kickiimmi.nu  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")  | t("errors.messages.invalid")     |
+
+
+  @selenium
+  Scenario Outline: Apply for membership - when things go wrong with company create
+    Given I am on the "new application" page
+    And I fill in the translated form with data:
+      | shf_applications.new.contact_email | shf_applications.new.phone_number |
+      | <c_email>                          | <phone>                           |
+
+    # Create new company in modal
+    And I click on t("companies.new.title")
+    And I fill in the translated form with data:
+      | companies.show.company_number | companies.show.email |
+      | <c_number>                    | <c_email>            |
+
+    And I click on t("companies.create.create_submit")
+
+    Then I should see error <model_attribute> <error>
+    And I should receive no emails
+    And "admin@shf.se" should receive no emails
 
     Scenarios:
-      | c_number   | c_email       | phone      | model_attribute                                             | error                            |
-    #  |            | kicki@immi.nu | 0706898525 | t("activerecord.attributes.shf_application.company_number") | t("errors.messages.blank")        |
-      | 5562252998 |               | 0706898525 | t("activerecord.attributes.shf_application.contact_email")  | t("errors.messages.blank")       |
-      | 5562252998 | kicki@imminu  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")  | t("errors.messages.invalid")     |
-      | 5562252998 | kickiimmi.nu  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")  | t("errors.messages.invalid")     |
+      | c_number   | c_email       | phone      | model_attribute                                     | error                        |
+      |            | kicki@immi.nu | 0706898525 | t("activerecord.attributes.company.company_number") | t("errors.messages.blank")   |
+      | 5562252998 |               | 0706898525 | t("activerecord.attributes.company.email")          | t("errors.messages.invalid") |
 
 
   Scenario Outline: Apply for membership: company number wrong length
-    Given I am on the "landing" page
-    And I click on t("menus.nav.users.apply_for_membership")
-    And I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.contact_email | shf_applications.new.phone_number |
-      | <c_number>                          | <c_email>                          | <phone>                           |
+    Given I am on the "new application" page
 
-    And I click on t("shf_applications.new.submit_button_label")
+    # Create new company in modal
+    And I click on t("companies.new.title")
+    And I fill in the translated form with data:
+      | companies.show.company_number | companies.show.email |
+      | <c_number>                    | <c_email>            |
+
+    And I click on t("companies.create.create_submit")
     Then I should see <error>
 
     Scenarios:
-      | c_number | c_email       | phone      | error                                        |
-      | 00       | kicki@immi.nu | 0706898525 | t("errors.messages.wrong_length", count: 10) |
+      | c_number | c_email       | error                                        |
+      | 00       | kicki@immi.nu | t("errors.messages.wrong_length", count: 10) |
 
 
-  Scenario: Cannot change locale if there are errors in the new application
-    Given I am on the "landing" page
-    And I click on t("menus.nav.users.apply_for_membership")
+  Scenario Outline: Cannot change locale if there are errors in the new application
+    Given I am on the "new application" page
+
     And I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.contact_email | shf_applications.new.phone_number |
-      | 1                                   | kicki@immi.n                       | 0706898525                        |
+      | shf_applications.new.contact_email | shf_applications.new.phone_number |
+      | <c_email>                          | <phone>                           |
 
     And I click on t("shf_applications.new.submit_button_label")
-    Then I should see t("errors.messages.wrong_length", count: 10)
+    Then I should see error <model_attribute> <error>
     And I should not see t("show_in_swedish") image
     And I should not see t("show_in_english") image
     And I should see t("cannot_change_language") image
+
+    Scenarios:
+      | c_email       | phone      | model_attribute                                             | error                            |
+      | kickiimmi.nu  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")  | t("errors.messages.invalid")     |
 
 
   Scenario: A member with existing application cannot submit a new application

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -14,11 +14,11 @@ Feature: Create a new membership application
 
   Background:
     Given the following users exists
-      | email                  | admin | member |
-      | applicant_1@random.com |       |        |
-      | applicant_2@random.com |       |        |
-      | member@random.com      |       | true   |
-      | admin@shf.se           | yes   |        |
+      | email                  | admin | member | first_name | last_name |
+      | applicant_1@random.com |       |        | Kicki      | Andersson |
+      | applicant_2@random.com |       |        |            |           |
+      | member@random.com      |       | true   | Lars       | IsaMember |
+      | admin@shf.se           | yes   |        |            |           |
 
     And the following business categories exist
       | name         |
@@ -37,15 +37,13 @@ Feature: Create a new membership application
     Given I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Kicki                           | Andersson                      | 5562252998                          | 031-1234567                       | info@craft.se                      |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5562252998                          | 031-1234567                       | info@craft.se                      |
     And I select "Groomer" Category
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: info@craft.se)
     When I am on the "edit my application" page
-    Then the t("shf_applications.new.first_name") field should be set to "Kicki"
-    And the t("shf_applications.new.last_name") field should be set to "Andersson"
     Then "applicant_1@random.com" should receive an email
     And I open the email
     And I should see t("mailers.shf_application_mailer.acknowledge_received.subject") in the email subject
@@ -59,8 +57,8 @@ Feature: Create a new membership application
     Given I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Kicki                           | Andersson                      | 5562252998                          | 031-1234567                       | info@craft.se                      |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5562252998                          | 031-1234567                       | info@craft.se                      |
     And I select "Trainer" Category
     And I select "Psychologist" Category
     And I click on t("shf_applications.new.submit_button_label")
@@ -72,8 +70,8 @@ Feature: Create a new membership application
     Given I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Kicki                                  | Andersson                             | 5562252998                                 | 031-1234567                              | info@craft.se                             |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5562252998                          | 031-1234567                       | info@craft.se                      |
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: info@craft.se)
@@ -88,9 +86,7 @@ Feature: Create a new membership application
   Scenario: Applicant can see which fields are required
     Given I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
-    Then the field t("shf_applications.new.first_name") should have a required field indicator
     And the field t("shf_applications.new.company_number") should have a required field indicator
-    And the field t("shf_applications.new.last_name") should have a required field indicator
     And the field t("shf_applications.new.contact_email") should have a required field indicator
     And the field t("shf_applications.new.phone_number") should not have a required field indicator
     And I should see t("is_required_field")
@@ -101,16 +97,16 @@ Feature: Create a new membership application
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Applicant1                      | Andersson                      | 5562252998                          | 031-1234567                       | applicant_1@random.com             |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5562252998                          | 031-1234567                       | applicant_1@random.com             |
     And I click on t("shf_applications.new.submit_button_label")
     Then I should see t("shf_applications.create.success", email_address: applicant_1@random.com)
     Given I am logged in as "applicant_2@random.com"
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Applicant2                      | Andersson                      | 2120000142                          | 031-1234567                       | applicant_2@random.com             |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 2120000142                          | 031-1234567                       | applicant_2@random.com             |
     And I click on t("shf_applications.new.submit_button_label")
     Then I should see t("shf_applications.create.success", email_address: applicant_2@random.com)
 
@@ -119,8 +115,8 @@ Feature: Create a new membership application
     Given I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.contact_email | shf_applications.new.phone_number |
-      | <f_name>                        | <l_name>                       | <c_number>                          | <c_email>                          | <phone>                           |
+      | shf_applications.new.company_number | shf_applications.new.contact_email | shf_applications.new.phone_number |
+      | <c_number>                          | <c_email>                          | <phone>                           |
 
     When I click on t("shf_applications.new.submit_button_label")
     Then I should see error <model_attribute> <error>
@@ -129,36 +125,34 @@ Feature: Create a new membership application
 
 
     Scenarios:
-      | f_name | c_number   | l_name    | c_email       | phone      | model_attribute                                             | error                        |
-      | Kicki  |            | Andersson | kicki@immi.nu | 0706898525 | t("activerecord.attributes.shf_application.company_number") | t("errors.messages.blank")   |
-      | Kicki  | 5562252998 |           | kicki@immi.nu | 0706898525 | t("activerecord.attributes.shf_application.last_name")      | t("errors.messages.blank")   |
-      | Kicki  | 5562252998 | Andersson |               | 0706898525 | t("activerecord.attributes.shf_application.contact_email")  | t("errors.messages.blank")   |
-      |        | 5562252998 | Andersson | kicki@immi.nu | 0706898525 | t("activerecord.attributes.shf_application.first_name")     | t("errors.messages.blank")   |
-      | Kicki  | 5562252998 | Andersson | kicki@imminu  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")  | t("errors.messages.invalid") |
-      | Kicki  | 5562252998 | Andersson | kickiimmi.nu  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")  | t("errors.messages.invalid") |
+      | c_number   | c_email       | phone      | model_attribute                                             | error                            |
+    #  |            | kicki@immi.nu | 0706898525 | t("activerecord.attributes.shf_application.company_number") | t("errors.messages.blank")        |
+      | 5562252998 |               | 0706898525 | t("activerecord.attributes.shf_application.contact_email")  | t("errors.messages.blank")       |
+      | 5562252998 | kicki@imminu  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")  | t("errors.messages.invalid")     |
+      | 5562252998 | kickiimmi.nu  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")  | t("errors.messages.invalid")     |
 
 
   Scenario Outline: Apply for membership: company number wrong length
     Given I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.contact_email | shf_applications.new.phone_number |
-      | <f_name>                        | <l_name>                       | <c_number>                          | <c_email>                          | <phone>                           |
+      | shf_applications.new.company_number | shf_applications.new.contact_email | shf_applications.new.phone_number |
+      | <c_number>                          | <c_email>                          | <phone>                           |
 
     And I click on t("shf_applications.new.submit_button_label")
     Then I should see <error>
 
     Scenarios:
-      | f_name | c_number | l_name    | c_email       | phone      | error                                        |
-      | Kicki  | 00       | Andersson | kicki@immi.nu | 0706898525 | t("errors.messages.wrong_length", count: 10) |
+      | c_number | c_email       | phone      | error                                        |
+      | 00       | kicki@immi.nu | 0706898525 | t("errors.messages.wrong_length", count: 10) |
 
 
   Scenario: Cannot change locale if there are errors in the new application
     Given I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.contact_email | shf_applications.new.phone_number |
-      | Kicki                           | Andersson                      | 1                                   | kicki@immi.n                       | 0706898525                        |
+      | shf_applications.new.company_number | shf_applications.new.contact_email | shf_applications.new.phone_number |
+      | 1                                   | kicki@immi.n                       | 0706898525                        |
 
     And I click on t("shf_applications.new.submit_button_label")
     Then I should see t("errors.messages.wrong_length", count: 10)
@@ -169,20 +163,20 @@ Feature: Create a new membership application
 
   # Note: this functional integration test passes; it proves that a member can submit a new application.
   # However, our application does not currently provide a menu option or other way for the Member to do this!
+  @selenium_browser
   Scenario: A member can submit a new application
     Given I am logged out
     And I am logged in as "member@random.com"
     And I am on the "new application" page
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Lars                                   | IsaMember                             | 5562252998                                 | 031-1234567                              | member@random.com                         |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5562252998                          | 031-1234567                       | member@random.com                  |
+    And I wait 20 seconds
     And I select "Groomer" Category
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: member@random.com  )
     When I am on the "edit my application" page
-    Then the t("shf_applications.new.first_name") field should be set to "Lars"
-    And the t("shf_applications.new.last_name") field should be set to "IsaMember"
     Then "member@random.com" should receive an email
     And I open the email
     And I should see t("mailers.shf_application_mailer.acknowledge_received.subject") in the email subject

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -45,10 +45,9 @@ Feature: Create a new membership application
     Given I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 031-1234567                       | info@craft.se                      |
+      | shf_applications.show.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5560360793                           | 031-1234567                       | info@craft.se                      |
     And I select "Groomer" Category
-    And I select "5560360793" in select list "company_id"
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: info@craft.se)
@@ -66,9 +65,8 @@ Feature: Create a new membership application
     Given I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 031-1234567                       | info@craft.se                      |
-    And I select "5560360793" in select list "company_id"
+      | shf_applications.show.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5560360793                           | 031-1234567                       | info@craft.se                      |
     And I select "Trainer" Category
     And I select "Psychologist" Category
     And I click on t("shf_applications.new.submit_button_label")

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -86,7 +86,6 @@ Feature: Create a new membership application
     And I fill in t("companies.show.email") with "info@craft.se"
     And I click on t("companies.create.create_submit")
     And I wait for all ajax requests to complete
-    And I wait 2 seconds
     And I click on t("shf_applications.new.submit_button_label")
 
     Then I should be on the "user instructions" page

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -161,29 +161,11 @@ Feature: Create a new membership application
     And I should see t("cannot_change_language") image
 
 
-  # Note: this functional integration test passes; it proves that a member can submit a new application.
-  # However, our application does not currently provide a menu option or other way for the Member to do this!
-  @selenium_browser
-  Scenario: A member can submit a new application
+  Scenario: A member with existing application cannot submit a new application
     Given I am logged out
     And I am logged in as "member@random.com"
     And I am on the "new application" page
-    And I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 5562252998                          | 031-1234567                       | member@random.com                  |
-    And I wait 20 seconds
-    And I select "Groomer" Category
-    And I click on t("shf_applications.new.submit_button_label")
-    Then I should be on the "user instructions" page
-    And I should see t("shf_applications.create.success", email_address: member@random.com  )
-    When I am on the "edit my application" page
-    Then "member@random.com" should receive an email
-    And I open the email
-    And I should see t("mailers.shf_application_mailer.acknowledge_received.subject") in the email subject
-    And I am logged in as "admin@shf.se"
-    Then "admin@shf.se" should receive an email
-    And I open the email
-    And I should see t("mailers.admin_mailer.new_application_received.subject") in the email subject
+    Then I should see t("errors.not_permitted")
 
 
   Scenario: An admin cannot submit a new application because we don't know which User it is for

--- a/features/delete-company.feature
+++ b/features/delete-company.feature
@@ -4,7 +4,8 @@ Feature: As an admin
 
   PT: https://www.pivotaltracker.com/story/show/138063171
 
-  Only delete a company if it is not associated with any accepted ShfApplications
+  Only delete a company if it is not associated with any ShfApplications,
+  other than applications with status == :being_destroyed.
 
   Only delete the business categories associated with a company
   if those business categories are not associated with any other companies.
@@ -130,7 +131,7 @@ Feature: As an admin
     And I should see "6" companies
 
   @selenium
-  Scenario: Admin deletes a company that has applications with that company number, but are not accepted or rejected
+  Scenario: Admin tries to delete a company that has applications
     Given I am logged in as "admin@shf.se"
     When I am on the "business categories" page
     Then I should see "8" business categories
@@ -139,13 +140,7 @@ Feature: As an admin
     When I am on the "all companies" page
     Then I should see "7" companies
     When I click and accept the t("delete") action for the row with "Kats"
-    Then I should see t("companies.destroy.success")
-    And I should not see "Kats"
-    And I should see "6" companies
-    When I am on the "business categories" page
-    Then I should see "8" business categories
-    When I am on the "landing" page
-    Then I should see "11" applications
+    Then I should see t("companies.destroy.error")
 
   @selenium
   Scenario: Admin cannot delete a company with 2 (accepted) membership applications
@@ -170,7 +165,7 @@ Feature: As an admin
     Then I should see "11" applications
 
   @selenium
-  Scenario: Admin deletes a company with 2 rejected membership applications associated with it
+  Scenario: Admin tries to delete a company with 2 rejected membership applications
     Given I am logged in as "admin@shf.se"
     When I am on the "business categories" page
     Then I should see "8" business categories
@@ -179,18 +174,11 @@ Feature: As an admin
     When I am on the "all companies" page
     Then I should see "7" companies
     When I click and accept the t("delete") action for the row with "Kitties"
-    Then I should see t("companies.destroy.success")
-    And I should not see "Kitties"
-    And I should see "6" companies
-    When I am on the "business categories" page
-    Then I should see "8" business categories
-    When I am on the "landing" page
-    # We do NOT destroy applications when a company is destroyed
-    Then I should see "11" applications
+    Then I should see t("companies.destroy.error")
 
 
   @selenium
-  Scenario: Admin deletes a company with 2 rejected membership applications and 2 categories (only co. with them)
+  Scenario: Admin tries to delete a company with 2 rejected applications and 2 categories (only co. with them)
     Given I am logged in as "admin@shf.se"
     When I am on the "business categories" page
     Then I should see "8" business categories
@@ -199,18 +187,14 @@ Feature: As an admin
     When I am on the "all companies" page
     Then I should see "7" companies
     When I click and accept the t("delete") action for the row with "No More Snarky Barky"
-    Then I should see t("companies.destroy.success")
-    And I should not see "No More Snarky Barky"
-    And I should see "6" companies
-    When I am on the "business categories" page
-    Then I should see "8" business categories
-    When I am on the "landing" page
+    Then I should see t("companies.destroy.error")
+    Then I am on the "landing" page
     # We do NOT destroy applications when a company is destroyed
     Then I should see "11" applications
 
 
   @selenium @focus
-  Scenario: Admin deletes a company with 1 rejected membership app, 1 categories (only co. associated with it)
+  Scenario: Admin tries to delete a company with 1 rejected app, 1 category (only co. associated with it)
     Given I am logged in as "admin@shf.se"
     When I am on the "business categories" page
     Then I should see "8" business categories
@@ -219,10 +203,8 @@ Feature: As an admin
     When I am on the "all companies" page
     Then I should see "7" companies
     When I click and accept the t("delete") action for the row with "WOOF"
-    Then I should see t("companies.destroy.success")
-    And I should not see "WOOF"
-    And I should see "6" companies
-    When I am on the "business categories" page
+    Then I should see t("companies.destroy.error")
+    Then I am on the "business categories" page
     Then I should see "8" business categories
     When I am on the "landing" page
     # We do NOT destroy applications when a company is destroyed

--- a/features/delete_shf_application.feature
+++ b/features/delete_shf_application.feature
@@ -97,5 +97,4 @@ Feature: As an admin
     Then I should see t("shf_applications.application_deleted")
     And I should not see "Wils"
     When I am on the "all companies" page
-    # We do NOT destroy a company when an app is destroyed
-    Then I should see "3" companies
+    Then I should see "2" companies

--- a/features/edit_shf_application.feature
+++ b/features/edit_shf_application.feature
@@ -26,11 +26,10 @@ Feature: As an applicant
     And I am on the "landing" page
     And I click on t("menus.nav.users.my_application")
     Then I should be on "Edit My Application" page
-    And I fill in t("shf_applications.show.contact_email") with "sussimmi.nu"
-    And I fill in t("shf_applications.show.company_number") with ""
+    And I fill in t("shf_applications.show.contact_email") with ""
     And I click on t("shf_applications.edit.submit_button_label")
     Then I should see t("shf_applications.update.error")
-    And I should see error t("shf_applications.show.company_number") t("errors.messages.blank")
+    And I should see error t("shf_applications.show.contact_email") t("errors.messages.blank")
     And I should see button t("shf_applications.edit.submit_button_label")
 
   Scenario: Applicant can not edit applications not created by him

--- a/features/edit_shf_application.feature
+++ b/features/edit_shf_application.feature
@@ -21,17 +21,6 @@ Feature: As an applicant
       | nils@random.com   | 2120000142     | accepted              |
       | bob@barkybobs.com | 5560360793     | rejected              |
 
-  Scenario: Applicant wants to edit his own application
-    Given I am logged in as "emma@random.com"
-    And I am on the "landing" page
-    And I click on t("menus.nav.users.my_application")
-    Then I should be on "Edit My Application" page
-    And I fill in t("shf_applications.show.first_name") with "Anna"
-    And I click on t("shf_applications.edit.submit_button_label")
-    Then I should see t("shf_applications.update.success")
-    And I should be on the "application" page for "emma@random.com"
-    And I should see "Anna Lastname"
-
   Scenario: Applicant makes mistake when editing his own application
     Given I am logged in as "emma@random.com"
     And I am on the "landing" page

--- a/features/edit_shf_application.feature
+++ b/features/edit_shf_application.feature
@@ -81,7 +81,6 @@ Feature: As an applicant
     And I click on t("menus.nav.users.my_application")
     Then I should be on "Edit My Application" page
     And I fill in t("shf_applications.show.contact_email") with "sussimmi.nu"
-    And I fill in t("shf_applications.show.company_number") with ""
     And I click on t("shf_applications.edit.submit_button_label")
     Then I should see t("shf_applications.update.error")
     And I should not see t("show_in_swedish") image

--- a/features/emails/new-application-email-to-admins.feature
+++ b/features/emails/new-application-email-to-admins.feature
@@ -10,11 +10,11 @@ Feature: When a new application is received, all admins get an email notificatio
   Background:
 
     Given the following users exists
-      | email               | admin |
-      | admin1@shf.se       | yes   |
-      | admin2@shf.se       | yes   |
-      | admin3@shf.se       | yes   |
-      | emma@happymutts.com |       |
+      | email               | admin | first_name | last_name  |
+      | admin1@shf.se       | yes   |            |            |
+      | admin2@shf.se       | yes   |            |            |
+      | admin3@shf.se       | yes   |            |            |
+      | emma@happymutts.com |       | Emma       | HappyMutts |
 
 
     And the following business categories exist
@@ -26,8 +26,8 @@ Feature: When a new application is received, all admins get an email notificatio
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Emma                            | HappyMutts                     | 5562252998                          | 031-1234567                       | emma@happymutts.com                |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5562252998                          | 031-1234567                       | emma@happymutts.com                |
     And I select "Groomer" Category
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
@@ -75,8 +75,8 @@ Feature: When a new application is received, all admins get an email notificatio
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Emma                            | 031-1234567                       | emma@happymutts.com                |
+      | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 031-1234567                       | emma@happymutts.com                |
     And I select "Groomer" Category
     And I click on t("shf_applications.new.submit_button_label")
     And I should see t("shf_applications.create.error")

--- a/features/emails/new-application-email-to-admins.feature
+++ b/features/emails/new-application-email-to-admins.feature
@@ -29,11 +29,13 @@ Feature: When a new application is received, all admins get an email notificatio
     Given I am logged in as "emma@happymutts.com"
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
+
     And I fill in the translated form with data:
-      | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 031-1234567                       | emma@happymutts.com                |
+      | shf_applications.show.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5560360793                           | 031-1234567                       | emma@happymutts.com                |
+
     And I select "Groomer" Category
-    And I select "5560360793" in select list "company_id"
+
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: 'emma@happymutts.com')
@@ -80,10 +82,9 @@ Feature: When a new application is received, all admins get an email notificatio
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 031-1234567                       | emmahappymutts.com                 |
+      | shf_applications.show.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5560360793                           | 031-1234567                       | emmahappymutts.com                 |
     And I select "Groomer" Category
-    And I select "5560360793" in select list "company_id"
     And I click on t("shf_applications.new.submit_button_label")
     And I should see t("shf_applications.create.error")
     Then "admin1@shf.se" should receive 0 email

--- a/features/emails/new-application-email-to-admins.feature
+++ b/features/emails/new-application-email-to-admins.feature
@@ -21,14 +21,19 @@ Feature: When a new application is received, all admins get an email notificatio
       | name         |
       | Groomer      |
 
+    And the following companies exist:
+      | name                 | company_number | email                  | region     |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.com | Stockholm  |
+
   Scenario: User submits a new application and email is sent to all 3 admins
     Given I am logged in as "emma@happymutts.com"
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 5562252998                          | 031-1234567                       | emma@happymutts.com                |
+      | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 031-1234567                       | emma@happymutts.com                |
     And I select "Groomer" Category
+    And I select "5560360793" in select list "company_id"
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: 'emma@happymutts.com')
@@ -76,8 +81,9 @@ Feature: When a new application is received, all admins get an email notificatio
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
       | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 031-1234567                       | emma@happymutts.com                |
+      | 031-1234567                       | emmahappymutts.com                 |
     And I select "Groomer" Category
+    And I select "5560360793" in select list "company_id"
     And I click on t("shf_applications.new.submit_button_label")
     And I should see t("shf_applications.create.error")
     Then "admin1@shf.se" should receive 0 email

--- a/features/emails/new-application-gets-ack-email.feature
+++ b/features/emails/new-application-gets-ack-email.feature
@@ -23,8 +23,8 @@ Feature: New Applicant gets an email acknowledging their application
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Emma                            | HappyMutts                     | 5562252998                          | 031-1234567                       | emma@happymutts.com                |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5562252998                          | 031-1234567                       | emma@happymutts.com                |
     And I select "Groomer" Category
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
@@ -40,8 +40,8 @@ Feature: New Applicant gets an email acknowledging their application
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Emma                            | 031-1234567                       | emma@happymutts.com                |
+      | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 031-1234567                       | emma@happymutts.com                |
     And I select "Groomer" Category
     And I click on t("shf_applications.new.submit_button_label")
     And I should see t("shf_applications.create.error")

--- a/features/emails/new-application-gets-ack-email.feature
+++ b/features/emails/new-application-gets-ack-email.feature
@@ -17,15 +17,20 @@ Feature: New Applicant gets an email acknowledging their application
       | name         |
       | Groomer      |
 
+    And the following companies exist:
+      | name                 | company_number | email                  | region     |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.com | Stockholm  |
+
 
   Scenario: User submits a new application and email is sent
     Given I am logged in as "emma@happymutts.com"
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 5562252998                          | 031-1234567                       | emma@happymutts.com                |
+      | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 031-1234567                       | emma@happymutts.com                |
     And I select "Groomer" Category
+    And I select "5560360793" in select list "company_id"
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: 'emma@happymutts.com')
@@ -41,8 +46,9 @@ Feature: New Applicant gets an email acknowledging their application
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
       | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 031-1234567                       | emma@happymutts.com                |
+      | 031-1234567                       | emmahappymutts.com                 |
     And I select "Groomer" Category
+    And I select "5560360793" in select list "company_id"
     And I click on t("shf_applications.new.submit_button_label")
     And I should see t("shf_applications.create.error")
     Then "emma@happymutts.com" should receive 0 email

--- a/features/emails/new-application-gets-ack-email.feature
+++ b/features/emails/new-application-gets-ack-email.feature
@@ -27,10 +27,9 @@ Feature: New Applicant gets an email acknowledging their application
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 031-1234567                       | emma@happymutts.com                |
+      | shf_applications.show.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5560360793                           | 031-1234567                       | emma@happymutts.com                |
     And I select "Groomer" Category
-    And I select "5560360793" in select list "company_id"
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: 'emma@happymutts.com')
@@ -45,10 +44,9 @@ Feature: New Applicant gets an email acknowledging their application
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 031-1234567                       | emmahappymutts.com                 |
+      | shf_applications.show.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5560360793                           | 031-1234567                       | emmahappymutts.com                 |
     And I select "Groomer" Category
-    And I select "5560360793" in select list "company_id"
     And I click on t("shf_applications.new.submit_button_label")
     And I should see t("shf_applications.create.error")
     Then "emma@happymutts.com" should receive 0 email

--- a/features/show-company.feature
+++ b/features/show-company.feature
@@ -34,16 +34,18 @@ Feature: As a visitor,
       | Company8 | 7736362901     | cmpy8@mail.com | Stockholm    | Alingsås | street_address |
 
     And the following users exists
-      | email               | admin | member |
-      | emma@happymutts.com |       | true   |
-      | a@happymutts.com    |       | true   |
-      | b@happymutts.com    |       | false  |
-      | member@cmpy6.com    |       | true   |
-      | admin@shf.se        | true  | false  |
+      | email           | admin | member |
+      | user1@mutts.com |       | true   |
+      | user2@mutts.com |       | true   |
+      | user3@mutts.com |       | true   |
+      | user4@mutts.com |       | true   |
+      | user5@mutts.com |       | true   |
+      | admin@shf.se    | true  | false  |
 
     Given the following payments exist
-      | user_email       | start_date | expire_date | payment_type | status | hips_id |
-      | member@cmpy6.com | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |
+      | user_email      | start_date | expire_date | payment_type | status | hips_id |
+      | user2@mutts.com | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |
+      | user3@mutts.com | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |
 
 
     And the following business categories exist
@@ -56,16 +58,12 @@ Feature: As a visitor,
       | JustForFun   |
 
     And the following applications exist:
-      | user_email          | company_number | categories              | state    |
-      | emma@happymutts.com | 5560360793     | Groomer, JustForFun     | accepted |
-      | a@happymutts.com    | 2120000142     | Groomer, Trainer, Rehab | accepted |
-      | emma@happymutts.com | 2120000142     | Psychologist, Groomer   | accepted |
-      | a@happymutts.com    | 6613265393     | Groomer                 | accepted |
-      | a@happymutts.com    | 6222279082     | Groomer                 | accepted |
-      | a@happymutts.com    | 8025085252     | Groomer                 | accepted |
-      | member@cmpy6.com    | 6914762726     | Groomer                 | accepted |
-      | a@happymutts.com    | 7661057765     | Groomer                 | rejected |
-      | b@happymutts.com    | 7736362901     | Groomer                 | accepted |
+      | user_email      | company_number | categories              | state    |
+      | user1@mutts.com | 5560360793     | Groomer, JustForFun     | accepted |
+      | user2@mutts.com | 2120000142     | Groomer, Trainer, Rehab | accepted |
+      | user3@mutts.com | 6914762726     | Psychologist, Groomer   | accepted |
+      | user4@mutts.com | 6613265393     | Groomer                 | accepted |
+      | user5@mutts.com | 2120000142     | Psychologist            | accepted |
 
     And the following payments exist
       | user_email   | start_date | expire_date | payment_type | status | hips_id | company_number |
@@ -107,8 +105,8 @@ Feature: As a visitor,
     And I should see "Harplinge"
     And I should see "http://www.example.com"
 
-  Scenario: Show company details to member of the company, but don't show the org nr.
-    Given I am logged in as "emma@happymutts.com"
+  Scenario: Show company details to member of the company.
+    Given I am logged in as "user1@mutts.com"
     And I am the page for company number "5560360793"
     Then I should not see "5560360793"
     And I should see "Company1"
@@ -160,7 +158,7 @@ Feature: As a visitor,
   @time_adjust
   Scenario: Show company address to member regardless of visibility setting
     Given the date is set to "2017-10-01"
-    Given I am logged in as "member@cmpy6.com"
+    Given I am logged in as "user3@mutts.com"
     And I am the page for company number "6914762726"
     And I should see "Hundforetagarevägen 1"
     And I should see "310 40"

--- a/features/size_validation.feature
+++ b/features/size_validation.feature
@@ -12,7 +12,11 @@ Feature: Applicant uploads too large a file for their application
 
     And the following applications exist:
       | user_email         | company_number | state        |
-      | emma@happymutts.se | 5560360793     | under_review |
+      | emma@happymutts.se | 5562252998     | under_review |
+
+    And the following companies exist:
+      | name                 | company_number | email                  | region     |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.com | Stockholm  |
 
 
   Scenario: New application - Uploads a file that is too large

--- a/features/size_validation.feature
+++ b/features/size_validation.feature
@@ -22,9 +22,9 @@ Feature: Applicant uploads too large a file for their application
   Scenario: New application - Uploads a file that is too large
     Given I am logged in as "hans@new_applicant.se"
     And I am on the "submit new membership application" page
-    When I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 5560360793                          | 031-1234567                       | applicant_2@random.com             |
+    When I fill in the form with data:
+      | shf_application_company_number | shf_application_phone_number | shf_application_contact_email |
+      | 5560360793                     | 031-1234567                  | applicant_2@random.com        |
     And I choose a file named "diploma_huge.pdf" to upload
     When I click on t("shf_applications.new.submit_button_label")
     Then I should see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large")
@@ -34,9 +34,9 @@ Feature: Applicant uploads too large a file for their application
   Scenario: New application - Uploads a file just under the size limit
     Given I am logged in as "hans@new_applicant.se"
     And I am on the "submit new membership application" page
-    When I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 5560360793                          | 031-1234567                       | applicant_2@random.com             |
+    When I fill in the form with data:
+      | shf_application_company_number | shf_application_phone_number | shf_application_contact_email |
+      | 5560360793                     | 031-1234567                  | applicant_2@random.com        |
     And I choose a file named "upload-just-under-limit.pdf" to upload
     When I click on t("shf_applications.new.submit_button_label")
     Then I should not see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large")

--- a/features/size_validation.feature
+++ b/features/size_validation.feature
@@ -19,8 +19,8 @@ Feature: Applicant uploads too large a file for their application
     Given I am logged in as "hans@new_applicant.se"
     And I am on the "submit new membership application" page
     When I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Hans                            | Newfoundland                   | 5560360793                          | 031-1234567                       | applicant_2@random.com             |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5560360793                          | 031-1234567                       | applicant_2@random.com             |
     And I choose a file named "diploma_huge.pdf" to upload
     When I click on t("shf_applications.new.submit_button_label")
     Then I should see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large")
@@ -31,8 +31,8 @@ Feature: Applicant uploads too large a file for their application
     Given I am logged in as "hans@new_applicant.se"
     And I am on the "submit new membership application" page
     When I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Hans                            | Newfoundland                   | 5560360793                          | 031-1234567                       | applicant_2@random.com             |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5560360793                          | 031-1234567                       | applicant_2@random.com             |
     And I choose a file named "upload-just-under-limit.pdf" to upload
     When I click on t("shf_applications.new.submit_button_label")
     Then I should not see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large")
@@ -90,5 +90,3 @@ Feature: Applicant uploads too large a file for their application
     When I click on t("shf_applications.edit.submit_button_label")
     Then I should not see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large", locale: :sv)
     And I set the locale to "sv"
-
-

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -260,6 +260,8 @@ Then "{capture_string} should{negate} have {capture_string} selected" do | selec
     raise
   end
 
+  # https://www.seleniumhq.org/exceptions/stale_element_reference.jsp
+
   expect(field_value).send( (negate ? :not_to : :to),  eq(expected_string) )
 
 end

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -235,20 +235,30 @@ end
 # Checks that a certain option is selected for a text field (from https://github.com/makandra/spreewald)
 Then "{capture_string} should{negate} have {capture_string} selected" do | select_list, negate, expected_string |
 
-  field = find_field(select_list)
+  try_again = true
 
-  field_value = case field.tag_name
-                  when 'select'
-                    options = field.all('option')
-                    selected_option = options.detect(&:selected?) || options.first
-                    if selected_option && selected_option.text.present?
-                      selected_option.text.strip
+  begin
+    field = find_field(select_list)
+
+    field_value = case field.tag_name
+                    when 'select'
+                      options = field.all('option')
+                      selected_option = options.detect(&:selected?) || options.first
+                      if selected_option && selected_option.text.present?
+                        selected_option.text.strip
+                      else
+                        ''
+                      end
                     else
-                      ''
-                    end
-                  else
-                    field.value
-                end
+                      field.value
+                  end
+  rescue Selenium::WebDriver::Error::StaleElementReferenceError
+    if try_again
+      try_again = false
+      retry
+    end
+    raise
+  end
 
   expect(field_value).send( (negate ? :not_to : :to),  eq(expected_string) )
 

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -1,5 +1,5 @@
 And(/^the following applications exist:$/) do |table|
- table.hashes.each do |hash|
+ table.hashes.each do |hash|   
    attributes = hash.except('user_email', 'categories', 'company_name')
    user = User.find_by(email: hash[:user_email].downcase)
 

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -8,7 +8,7 @@ Given(/^the following users exist(?:s|)$/) do |table|
     user.delete('last_name') if user['last_name'].blank?
     user.delete('first_name') if user['first_name'].blank?
 
-    is_legacy == 'true' ? FactoryGirl.create(:user_without_first_and_lastname, user) : FactoryGirl.create(:user, user)
+    is_legacy == 'true' ? FactoryBot.create(:user_without_first_and_lastname, user) : FactoryBot.create(:user, user)
 
   end
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -5,6 +5,9 @@ Given(/^the following users exist(?:s|)$/) do |table|
 
     is_legacy = user.delete('is_legacy')
 
+    user.delete('last_name') if user['last_name'].blank?
+    user.delete('first_name') if user['first_name'].blank?
+
     is_legacy == 'true' ? FactoryGirl.create(:user_without_first_and_lastname, user) : FactoryGirl.create(:user, user)
 
   end

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -190,7 +190,6 @@ Feature: SHF Application status is changed
     Given I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
     And I am on the "edit my application" page
     Then I should see the checkbox with id "shf_application_marked_ready_for_review" unchecked
-    And I fill in t("shf_applications.show.last_name") with "ForInfo"
     And I click on t("shf_applications.edit.submit_button_label")
     Then I should see t("shf_applications.update.success")
     And I should not see status line with status t("shf_applications.ready_for_review")
@@ -201,7 +200,6 @@ Feature: SHF Application status is changed
     Given I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
     And I am on the "edit my application" page
     Then I should see the checkbox with id "shf_application_marked_ready_for_review" unchecked
-    And I fill in t("shf_applications.show.last_name") with "ForInfo"
     When I check the checkbox with id "shf_application_marked_ready_for_review"
     And I click on t("shf_applications.edit.submit_button_label")
     Then I should see t("shf_applications.update.success")
@@ -257,7 +255,6 @@ Feature: SHF Application status is changed
   Scenario: 'Waiting for applicant' status is not changed if admin edits the application
     Given I am on the "application" page for "anna_waiting_for_info@nosnarkybarky.se"
     And I click on t("shf_applications.edit_shf_application")
-    And I fill in t("shf_applications.show.last_name") with "AdminUpdated"
     And I click on t("shf_applications.edit.submit_button_label")
     Then I should see t("shf_applications.update.success")
     And I should see status line with status t("shf_applications.waiting_for_applicant")
@@ -315,7 +312,7 @@ Feature: SHF Application status is changed
     Given I am on the "application" page for "lars_rejected@snarkybark.se"
     And I should see "rehab"
     When I click on t("shf_applications.edit_shf_application")
-    And I fill in t("shf_applications.show.last_name") with "BadBadLars"
+    And I fill in t("shf_applications.show.contact_email") with "newmail@mail.com"
     And I click on t("shf_applications.edit.submit_button_label")
     Then I should see t("shf_applications.update.success")
     And I should see status line with status t("shf_applications.rejected")

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -16,13 +16,18 @@ Feature: Applicant uploads a file for their application
       | user_email             | company_number | state                 |
       | applicant_1@random.com | 5562252998     | waiting_for_applicant |
 
+    And the following companies exist:
+      | name                 | company_number | email                  | region     |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.com | Stockholm  |
+
 
   Scenario: Upload a file during a new application
     Given I am logged in as "applicant_2@random.com"
     And I am on the "submit new membership application" page
     And I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 5560360793                          | 031-1234567                       | applicant_2@random.com             |
+      | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 031-1234567                       | applicant_2@random.com             |
+    And I select "5560360793" in select list "company_id"
     And I choose a file named "diploma.pdf" to upload
     When I click on t("shf_applications.new.submit_button_label")
     Then I should see t("shf_applications.create.success", email_address: applicant_2@random.com)

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -25,9 +25,8 @@ Feature: Applicant uploads a file for their application
     Given I am logged in as "applicant_2@random.com"
     And I am on the "submit new membership application" page
     And I fill in the translated form with data:
-      | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 031-1234567                       | applicant_2@random.com             |
-    And I select "5560360793" in select list "company_id"
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5560360793                          | 031-1234567                       | applicant_2@random.com             |
     And I choose a file named "diploma.pdf" to upload
     When I click on t("shf_applications.new.submit_button_label")
     Then I should see t("shf_applications.create.success", email_address: applicant_2@random.com)

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -21,8 +21,8 @@ Feature: Applicant uploads a file for their application
     Given I am logged in as "applicant_2@random.com"
     And I am on the "submit new membership application" page
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | Hans                            | Newfoundland                   | 5560360793                          | 031-1234567                       | applicant_2@random.com             |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5560360793                          | 031-1234567                       | applicant_2@random.com             |
     And I choose a file named "diploma.pdf" to upload
     When I click on t("shf_applications.new.submit_button_label")
     Then I should see t("shf_applications.create.success", email_address: applicant_2@random.com)

--- a/features/user-applies-approved-edits-co.feature
+++ b/features/user-applies-approved-edits-co.feature
@@ -21,17 +21,22 @@ Feature: Whole process of a new user creating a login, applying, being approved,
       | Groomer      |
       | Psychologist |
 
+    And the following companies exist:
+      | name                 | company_number | email                  | region     |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.com | Stockholm  |
+
 
   @admin, @user, @member
-  Scenario: User creates login, admin approves, user edits company, blank main address is displayed
+  Scenario: User creates application, admin approves, user edits company, blank main address is displayed
     Given I am in "new_user@example.com" browser
     And I am logged in as "new_user@example.com"
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 5562252998                          | 031-1234567                       | new_user@example.com               |
+      | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 031-1234567                       | new_user@example.com               |
     And I select "Groomer" Category
+    And I select "5560360793" in select list "company_id"
     And I click on t("shf_applications.new.submit_button_label")
     And I should see t("shf_applications.create.success", email_address: new_user@example.com)
 

--- a/features/user-applies-approved-edits-co.feature
+++ b/features/user-applies-approved-edits-co.feature
@@ -33,10 +33,9 @@ Feature: Whole process of a new user creating a login, applying, being approved,
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 031-1234567                       | new_user@example.com               |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5560360793                          | 031-1234567                       | new_user@example.com               |
     And I select "Groomer" Category
-    And I select "5560360793" in select list "company_id"
     And I click on t("shf_applications.new.submit_button_label")
     And I should see t("shf_applications.create.success", email_address: new_user@example.com)
 

--- a/features/user-applies-approved-edits-co.feature
+++ b/features/user-applies-approved-edits-co.feature
@@ -3,9 +3,9 @@ Feature: Whole process of a new user creating a login, applying, being approved,
 
   Background:
     Given the following users exists
-      | email                | admin |
-      | new_user@example.com |       |
-      | admin@shf.se         | true  |
+      | email                | admin | first_name | last_name |
+      | new_user@example.com |       | NewUser1   | Lastname  |
+      | admin@shf.se         | true  |            |           |
 
     Given the following regions exist:
       | name         |
@@ -29,8 +29,8 @@ Feature: Whole process of a new user creating a login, applying, being approved,
     And I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
-      | shf_applications.new.first_name | shf_applications.new.last_name | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | NewUser1                        | NewLastName                    | 5562252998                          | 031-1234567                       | new_user@example.com               |
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5562252998                          | 031-1234567                       | new_user@example.com               |
     And I select "Groomer" Category
     And I click on t("shf_applications.new.submit_button_label")
     And I should see t("shf_applications.create.success", email_address: new_user@example.com)

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -61,73 +61,100 @@ Feature: Visitor sees all companies
       | Company02    | Uppsala    | Aneby   |
 
     And the following users exists
-      | email        | admin | member |
-      | a@mutts.com  |       | true   |
-      | b@mutts.com  |       | false  |
-      | admin@shf.se | true  |        |
+      | email         | admin | member |
+      | u1@mutts.com  |       | true   |
+      | u2@mutts.com  |       | true   |
+      | u3@mutts.com  |       | true   |
+      | u4@mutts.com  |       | true   |
+      | u5@mutts.com  |       | true   |
+      | u6@mutts.com  |       | true   |
+      | u7@mutts.com  |       | true   |
+      | u8@mutts.com  |       | true   |
+      | u9@mutts.com  |       | true   |
+      | u10@mutts.com |       | true   |
+      | u11@mutts.com |       | true   |
+      | u12@mutts.com |       | true   |
+      | u13@mutts.com |       | true   |
+      | u14@mutts.com |       | true   |
+      | u15@mutts.com |       | true   |
+      | u16@mutts.com |       | true   |
+      | u17@mutts.com |       | true   |
+      | u18@mutts.com |       | true   |
+      | u19@mutts.com |       | true   |
+      | u20@mutts.com |       | true   |
+      | u21@mutts.com |       | true   |
+      | u22@mutts.com |       | true   |
+      | u23@mutts.com |       | true   |
+      | u24@mutts.com |       | true   |
+      | u25@mutts.com |       | true   |
+      | u26@mutts.com |       | true   |
+      | u27@mutts.com |       | true   |
+      | u29@mutts.com |       | true   |
+      | b@mutts.com   |       | false  |
+      | admin@shf.se  | true  |        |
 
     And the following payments exist
       | user_email  | start_date | expire_date | payment_type | status | hips_id | company_name |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company01    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company02    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company03    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company04    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company05    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company06    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company07    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company08    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company09    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company10    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company11    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company12    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company13    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company14    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company15    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company16    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company17    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company18    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company19    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company20    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company21    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company22    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company23    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company24    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company25    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company26    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company27    |
-      | a@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company28    |
+      | u1@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company01    |
+      | u2@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company02    |
+      | u3@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company03    |
+      | u4@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company04    |
+      | u5@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company05    |
+      | u6@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company06    |
+      | u7@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company07    |
+      | u8@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company08    |
+      | u9@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company09    |
+      | u10@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company10    |
+      | u11@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company11    |
+      | u12@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company12    |
+      | u13@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company13    |
+      | u14@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company14    |
+      | u15@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company15    |
+      | u16@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company16    |
+      | u17@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company17    |
+      | u18@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company18    |
+      | u19@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company19    |
+      | u20@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company20    |
+      | u21@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company21    |
+      | u22@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company22    |
+      | u23@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company23    |
+      | u24@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company24    |
+      | u25@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company25    |
+      | u26@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company26    |
+      | u27@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company27    |
+      | u29@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company28    |
 
     And the following applications exist:
-      | user_email  | company_name | state    | categories |
-      | a@mutts.com | Company01    | accepted | Groomer    |
-      | a@mutts.com | Company02    | accepted | Groomer    |
-      | a@mutts.com | Company03    | accepted | Groomer    |
-      | a@mutts.com | Company04    | accepted | Groomer    |
-      | a@mutts.com | Company05    | accepted | Groomer    |
-      | a@mutts.com | Company06    | accepted | Groomer    |
-      | a@mutts.com | Company07    | accepted | Groomer    |
-      | a@mutts.com | Company08    | accepted | Groomer    |
-      | a@mutts.com | Company09    | accepted | Groomer    |
-      | a@mutts.com | Company10    | accepted | Groomer    |
-      | a@mutts.com | Company11    | accepted | Groomer    |
-      | a@mutts.com | Company12    | accepted | Groomer    |
-      | a@mutts.com | Company13    | accepted | Groomer    |
-      | a@mutts.com | Company14    | accepted | Groomer    |
-      | a@mutts.com | Company15    | accepted | Groomer    |
-      | a@mutts.com | Company16    | accepted | Groomer    |
-      | a@mutts.com | Company17    | accepted | Groomer    |
-      | a@mutts.com | Company18    | accepted | Groomer    |
-      | a@mutts.com | Company19    | accepted | Groomer    |
-      | a@mutts.com | Company20    | accepted | Groomer    |
-      | a@mutts.com | Company21    | accepted | Groomer    |
-      | a@mutts.com | Company22    | accepted | Groomer    |
-      | a@mutts.com | Company23    | accepted | Groomer    |
-      | a@mutts.com | Company24    | accepted | Groomer    |
-      | a@mutts.com | Company25    | accepted | Groomer    |
-      | a@mutts.com | Company26    | accepted | Groomer    |
-      | a@mutts.com | Company27    | accepted | Groomer    |
-      | b@mutts.com | Company28    | accepted | Groomer    |
-      | a@mutts.com | Company29    | accepted | Groomer    |
+      | user_email    | company_name | state    | categories |
+      | u1@mutts.com  | Company01    | accepted | Groomer    |
+      | u2@mutts.com  | Company02    | accepted | Groomer    |
+      | u3@mutts.com  | Company03    | accepted | Groomer    |
+      | u4@mutts.com  | Company04    | accepted | Groomer    |
+      | u5@mutts.com  | Company05    | accepted | Groomer    |
+      | u6@mutts.com  | Company06    | accepted | Groomer    |
+      | u7@mutts.com  | Company07    | accepted | Groomer    |
+      | u8@mutts.com  | Company08    | accepted | Groomer    |
+      | u9@mutts.com  | Company09    | accepted | Groomer    |
+      | u10@mutts.com | Company10    | accepted | Groomer    |
+      | u11@mutts.com | Company11    | accepted | Groomer    |
+      | u12@mutts.com | Company12    | accepted | Groomer    |
+      | u13@mutts.com | Company13    | accepted | Groomer    |
+      | u14@mutts.com | Company14    | accepted | Groomer    |
+      | u15@mutts.com | Company15    | accepted | Groomer    |
+      | u16@mutts.com | Company16    | accepted | Groomer    |
+      | u17@mutts.com | Company17    | accepted | Groomer    |
+      | u18@mutts.com | Company18    | accepted | Groomer    |
+      | u19@mutts.com | Company19    | accepted | Groomer    |
+      | u20@mutts.com | Company20    | accepted | Groomer    |
+      | u21@mutts.com | Company21    | accepted | Groomer    |
+      | u22@mutts.com | Company22    | accepted | Groomer    |
+      | u23@mutts.com | Company23    | accepted | Groomer    |
+      | u24@mutts.com | Company24    | accepted | Groomer    |
+      | u25@mutts.com | Company25    | accepted | Groomer    |
+      | u26@mutts.com | Company26    | accepted | Groomer    |
+      | u27@mutts.com | Company27    | accepted | Groomer    |
+      | b@mutts.com   | Company28    | accepted | Groomer    |
+      | u29@mutts.com | Company29    | accepted | Groomer    |
 
   @selenium @time_adjust
   Scenario: Visitor sees all companies
@@ -161,7 +188,7 @@ Feature: Visitor sees all companies
   @time_adjust
   Scenario: User sees all the companies
     Given the date is set to "2017-10-01"
-    Given I am logged in as "a@mutts.com"
+    Given I am logged in as "u1@mutts.com"
     And I am on the "landing" page
     Then I should see t("companies.index.title")
     And I should see "Company02"

--- a/features/view_shf_applications.feature
+++ b/features/view_shf_applications.feature
@@ -6,43 +6,67 @@ Feature: Admin sees as many or few SHF Applications as they want (pagination)
 
   Background:
     Given the following users exists
-      | email             | admin | member    |
-      | emma@random.com   |       | false     |
-      | hans@random.com   |       | false     |
-      | nils@random.com   |       | true      |
-      | bob@barkybobs.com |       | true      |
-      | admin@shf.se      | true  | false     |
+      | email         | admin | member    |
+      | u1@mutts.com  |       | false     |
+      | u2@mutts.com  |       | false     |
+      | u3@mutts.com  |       | true      |
+      | u4@mutts.com  |       | true      |
+      | u5@mutts.com  |       | true      |
+      | u6@mutts.com  |       | true      |
+      | u7@mutts.com  |       | true      |
+      | u8@mutts.com  |       | true      |
+      | u9@mutts.com  |       | true      |
+      | u10@mutts.com |       | true      |
+      | u11@mutts.com |       | true      |
+      | u12@mutts.com |       | true      |
+      | u13@mutts.com |       | true      |
+      | u14@mutts.com |       | true      |
+      | u15@mutts.com |       | true      |
+      | u16@mutts.com |       | true      |
+      | u17@mutts.com |       | true      |
+      | u18@mutts.com |       | true      |
+      | u19@mutts.com |       | true      |
+      | u20@mutts.com |       | true      |
+      | u21@mutts.com |       | true      |
+      | u22@mutts.com |       | true      |
+      | u23@mutts.com |       | true      |
+      | u24@mutts.com |       | true      |
+      | u25@mutts.com |       | true      |
+      | u26@mutts.com |       | true      |
+      | u27@mutts.com |       | true      |
+      | u28@mutts.com |       | true      |
+      | admin@shf.se  | true  | false     |
 
     And the following applications exist:
-      | user_email        | company_number | state                 |
-      | hans@random.com   | 2120000142     | under_review          |
-      | emma@random.com   | 2965790286     | waiting_for_applicant |
-      | nils@random.com   | 2965790286     | under_review          |
-      | hans@random.com   | 3609340140     | under_review          |
-      | bob@barkybobs.com | 4268582063     | under_review          |
-      | emma@random.com   | 5560360793     | waiting_for_applicant |
-      | emma@random.com   | 6112107039     | waiting_for_applicant |
-      | bob@barkybobs.com | 6222279082     | under_review          |
-      | nils@random.com   | 6613265393     | under_review          |
-      | hans@random.com   | 6914762726     | under_review          |
-      | nils@random.com   | 7661057765     | under_review          |
-      | bob@barkybobs.com | 7736362901     | under_review          |
-      | emma@random.com   | 8025085252     | waiting_for_applicant |
-      | emma@random.com   | 8028973322     | waiting_for_applicant |
-      | hans@random.com   | 8356502446     | under_review          |
-      | nils@random.com   | 8394317054     | under_review          |
-      | bob@barkybobs.com | 8423893877     | under_review          |
-      | emma@random.com   | 8589182768     | waiting_for_applicant |
-      | hans@random.com   | 8616006592     | under_review          |
-      | bob@barkybobs.com | 8728875504     | under_review          |
-      | nils@random.com   | 8764985894     | under_review          |
-      | bob@barkybobs.com | 8822107739     | under_review          |
-      | hans@random.com   | 8909248752     | under_review          |
-      | nils@random.com   | 9074668568     | under_review          |
-      | bob@barkybobs.com | 9243957975     | under_review          |
-      | emma@random.com   | 9267816362     | waiting_for_applicant |
-      | hans@random.com   | 9360289459     | under_review          |
-      | nils@random.com   | 9475077674     | under_review          |
+      | user_email    | company_number | state                 |
+      | u1@mutts.com  | 2120000142     | under_review          |
+      | u2@mutts.com  | 2965790286     | waiting_for_applicant |
+      | u3@mutts.com  | 2965790286     | under_review          |
+      | u4@mutts.com  | 3609340140     | under_review          |
+      | u5@mutts.com  | 4268582063     | under_review          |
+      | u6@mutts.com  | 5560360793     | waiting_for_applicant |
+      | u7@mutts.com  | 6112107039     | waiting_for_applicant |
+      | u8@mutts.com  | 6222279082     | under_review          |
+      | u9@mutts.com  | 6613265393     | under_review          |
+      | u10@mutts.com | 6914762726     | under_review          |
+      | u11@mutts.com | 7661057765     | under_review          |
+      | u12@mutts.com | 7736362901     | under_review          |
+      | u13@mutts.com | 8025085252     | waiting_for_applicant |
+      | u14@mutts.com | 8028973322     | waiting_for_applicant |
+      | u15@mutts.com | 8356502446     | under_review          |
+      | u16@mutts.com | 8394317054     | under_review          |
+      | u17@mutts.com | 8423893877     | under_review          |
+      | u18@mutts.com | 8589182768     | waiting_for_applicant |
+      | u19@mutts.com | 8616006592     | under_review          |
+      | u20@mutts.com | 8728875504     | under_review          |
+      | u21@mutts.com | 8764985894     | under_review          |
+      | u22@mutts.com | 8822107739     | under_review          |
+      | u23@mutts.com | 8909248752     | under_review          |
+      | u24@mutts.com | 9074668568     | under_review          |
+      | u25@mutts.com | 9243957975     | under_review          |
+      | u26@mutts.com | 9267816362     | waiting_for_applicant |
+      | u27@mutts.com | 9360289459     | under_review          |
+      | u28@mutts.com | 9475077674     | under_review          |
 
 
 

--- a/features/view_shf_applications.feature
+++ b/features/view_shf_applications.feature
@@ -77,6 +77,7 @@ Feature: Admin sees as many or few SHF Applications as they want (pagination)
     And I hide the search form
     Then "items_count" should have "All" selected
     And I select "10" in select list "items_count"
+    And I wait 2 seconds
     And I reload the page
     Then "items_count" should have "10" selected
     # prevents getting the element not clickable at that position error in Chrome

--- a/features/view_shf_applications.feature
+++ b/features/view_shf_applications.feature
@@ -85,6 +85,7 @@ Feature: Admin sees as many or few SHF Applications as they want (pagination)
     When I click on t("shf_applications.index.org_nr")
     And I should see "6914762726"
     And I wait for all ajax requests to complete
+    And I reload the page
     And I should not see "7661057765"
     Then I click on t("will_paginate.next_label") link
     And I wait for all ajax requests to complete

--- a/features/view_shf_applications.feature
+++ b/features/view_shf_applications.feature
@@ -77,24 +77,18 @@ Feature: Admin sees as many or few SHF Applications as they want (pagination)
     And I hide the search form
     Then "items_count" should have "All" selected
     And I select "10" in select list "items_count"
-    And I wait for all ajax requests to complete
-    And I reload the page
     Then "items_count" should have "10" selected
     # prevents getting the element not clickable at that position error in Chrome
     And I scroll to the top
     When I click on t("shf_applications.index.org_nr")
     And I should see "6914762726"
-    And I wait for all ajax requests to complete
-    And I reload the page
     And I should not see "7661057765"
     Then I click on t("will_paginate.next_label") link
-    And I wait for all ajax requests to complete
     And I should see "7661057765"
     And I should see "8728875504"
     And I should not see "6914762726"
     And I should not see "8764985894"
     Then I click on t("will_paginate.next_label") link
-    And I wait for all ajax requests to complete
     And I should see "8764985894"
     And I should not see "8728875504"
 

--- a/features/view_shf_applications.feature
+++ b/features/view_shf_applications.feature
@@ -77,6 +77,7 @@ Feature: Admin sees as many or few SHF Applications as they want (pagination)
     And I hide the search form
     Then "items_count" should have "All" selected
     And I select "10" in select list "items_count"
+    And I reload the page
     Then "items_count" should have "10" selected
     # prevents getting the element not clickable at that position error in Chrome
     And I scroll to the top

--- a/features/view_shf_applications.feature
+++ b/features/view_shf_applications.feature
@@ -77,20 +77,23 @@ Feature: Admin sees as many or few SHF Applications as they want (pagination)
     And I hide the search form
     Then "items_count" should have "All" selected
     And I select "10" in select list "items_count"
-    And I wait 2 seconds
+    And I wait for all ajax requests to complete
     And I reload the page
     Then "items_count" should have "10" selected
     # prevents getting the element not clickable at that position error in Chrome
     And I scroll to the top
     When I click on t("shf_applications.index.org_nr")
     And I should see "6914762726"
+    And I wait for all ajax requests to complete
     And I should not see "7661057765"
     Then I click on t("will_paginate.next_label") link
+    And I wait for all ajax requests to complete
     And I should see "7661057765"
     And I should see "8728875504"
     And I should not see "6914762726"
     And I should not see "8764985894"
     Then I click on t("will_paginate.next_label") link
+    And I wait for all ajax requests to complete
     And I should see "8764985894"
     And I should not see "8728875504"
 

--- a/features/view_shf_applications.feature
+++ b/features/view_shf_applications.feature
@@ -81,8 +81,8 @@ Feature: Admin sees as many or few SHF Applications as they want (pagination)
     # prevents getting the element not clickable at that position error in Chrome
     And I scroll to the top
     When I click on t("shf_applications.index.org_nr")
-    And I should see "6914762726"
-    And I should not see "7661057765"
+    And I should see "6222279082" before "6613265393"
+    And I should see "6613265393" before "6914762726"
     Then I click on t("will_paginate.next_label") link
     And I should see "7661057765"
     And I should see "8728875504"

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -150,10 +150,9 @@ RSpec.describe AdminController, type: :controller do
         let(:c1) { FactoryGirl.create(:company) }
 
         let(:member1) { FactoryGirl.create :shf_application,
-                                                      contact_email:  "u1@example.com",
-                                                      state:          :accepted,
-                                                      company_number: c1.company_number,
-                                                      user:           u1
+                                           contact_email:  "u1@example.com",
+                                           state:          :accepted,
+                                           user:           u1
         }
 
 
@@ -211,10 +210,9 @@ RSpec.describe AdminController, type: :controller do
         let(:c1) { FactoryGirl.create(:company) }
 
         let(:member1) { FactoryGirl.create :shf_application,
-                                                contact_email:  "u1@example.com",
-                                                state:          :accepted,
-                                                company_number: c1.company_number,
-                                                user:           u1
+                                           contact_email:  "u1@example.com",
+                                           state:          :accepted,
+                                           user:           u1
                       }
 
         let(:csv_response) { post :export_ansokan_csv

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe AdminController, type: :controller do
 
         let(:c1) { FactoryBot.create(:company) }
 
-        let(:member1) { FactoryGirl.create :shf_application,
+        let(:member1) { FactoryBot.create :shf_application,
                                            contact_email:  "u1@example.com",
                                            state:          :accepted,
                                            user:           u1
@@ -209,7 +209,7 @@ RSpec.describe AdminController, type: :controller do
 
         let(:c1) { FactoryBot.create(:company) }
 
-        let(:member1) { FactoryGirl.create :shf_application,
+        let(:member1) { FactoryBot.create :shf_application,
                                            contact_email:  "u1@example.com",
                                            state:          :accepted,
                                            user:           u1

--- a/spec/db/seed_development_spec.rb
+++ b/spec/db/seed_development_spec.rb
@@ -5,11 +5,18 @@ RSpec.describe 'load business categories, regions, kommuns, users and applicatio
   # seed with a minimum of 4 users to cover: admin, no application, single application, double application
   seed_users = 4
 
+  env_shf_email = 'SHF_ADMIN_EMAIL'
+  env_shf_pwd = 'SHF_ADMIN_PWD'
+  admin_email = 'the-shfadmin@shf.org'
+  admin_pwd = 'insecure-password'
+
   before(:all) do
     DatabaseCleaner.start
     RSpec::Mocks.with_temporary_scope do
       allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('development'))
-      stub_const('ENV', {'SHF_SEED_USERS' => seed_users.to_s})
+      stub_const('ENV', { 'SHF_SEED_USERS' => seed_users.to_s,
+                          env_shf_email => admin_email,
+                          env_shf_pwd => admin_pwd })
       SHFProject::Application.load_tasks
       SHFProject::Application.load_seed
     end
@@ -38,11 +45,11 @@ RSpec.describe 'load business categories, regions, kommuns, users and applicatio
   end
 
   it "addresses are in the db" do
-    expect(Address.all.size).to eq(ShfApplication.where(state: :accepted).count)
+    expect(Address.count).to eq(ShfApplication.count)
   end
 
   it "companies are in the db" do
-    expect(Company.all.size).to eq(ShfApplication.where(state: :accepted).count)
+    expect(Company.count).to eq(ShfApplication.count)
   end
 
   it "memberships applications are in the db" do

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -1,7 +1,18 @@
 FactoryGirl.define do
   factory :company do
     name 'SomeCompany'
-    company_number '0000000000'
+    company_number do
+      org_number = nil
+
+      100.times do
+        org_number = OrgNummersGenerator.generate_one
+
+        # stop if number not already used
+        break if ! Company.find_by_company_number(org_number)
+      end
+
+      org_number
+    end
     phone_number '123123123'
     email 'thiscompany@example.com'
     website 'http://www.example.com'

--- a/spec/factories/companies_shf_applications.rb
+++ b/spec/factories/companies_shf_applications.rb
@@ -1,5 +1,0 @@
-FactoryGirl.define do
-  factory :companies_shf_application do
-    
-  end
-end

--- a/spec/factories/companies_shf_applications.rb
+++ b/spec/factories/companies_shf_applications.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :companies_shf_application do
+    
+  end
+end

--- a/spec/factories/company_applications.rb
+++ b/spec/factories/company_applications.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :company_application do
+    company nil
+    shf_application nil
+  end
+end

--- a/spec/factories/company_applications.rb
+++ b/spec/factories/company_applications.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :company_application do
     company
     shf_application

--- a/spec/factories/company_applications.rb
+++ b/spec/factories/company_applications.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :company_application do
-    company nil
-    shf_application nil
+    company
+    shf_application
   end
 end

--- a/spec/factories/shf_applications.rb
+++ b/spec/factories/shf_applications.rb
@@ -20,6 +20,7 @@ FactoryGirl.define do
     transient do
       num_categories 0
       category_name "Business Category"
+      company_number nil
     end
 
     after(:build) do |shf_app, evaluator|
@@ -33,8 +34,14 @@ FactoryGirl.define do
       end
 
       if (evaluator.state) && evaluator.state.to_sym != :rejected
-
-        company = FactoryGirl.create(:company)
+        if evaluator.company_number
+          company = Company.find_by(company_number: evaluator.company_number)
+          unless company
+            company = FactoryGirl.create(:company, company_number: evaluator.company_number)
+          end
+        else
+          company = FactoryGirl.create(:company)
+        end
         shf_app.companies << company
       end
     end

--- a/spec/factories/shf_applications.rb
+++ b/spec/factories/shf_applications.rb
@@ -33,19 +33,16 @@ FactoryGirl.define do
         end
       end
 
-      if (evaluator.state) && evaluator.state.to_sym != :rejected
-        if evaluator.company_number
-          company = Company.find_by(company_number: evaluator.company_number)
-          unless company
-            company = FactoryGirl.create(:company, company_number: evaluator.company_number)
-          end
-        else
-          company = FactoryGirl.create(:company)
+      if evaluator.company_number
+        company = Company.find_by(company_number: evaluator.company_number)
+        unless company
+          company = FactoryGirl.create(:company, company_number: evaluator.company_number)
         end
-        shf_app.companies << company
+      else
+        company = FactoryGirl.create(:company)
       end
+      shf_app.companies << company
     end
-
 
   end
 end

--- a/spec/factories/shf_applications.rb
+++ b/spec/factories/shf_applications.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
           company = FactoryBot.create(:company, company_number: evaluator.company_number)
         end
       else
-        company = FactoryGirl.create(:company)
+        company = FactoryBot.create(:company)
       end
       shf_app.companies << company
     end

--- a/spec/factories/shf_applications.rb
+++ b/spec/factories/shf_applications.rb
@@ -3,7 +3,6 @@ FactoryGirl.define do
   sequence(:cat_name_seq, "Business Category", 1) { |name, num| "#{name} #{num}" }
 
   factory :shf_application do
-    company_number '5562252998'
     phone_number 'MyString'
     contact_email 'MyString@email.com'
     state :new
@@ -33,13 +32,9 @@ FactoryGirl.define do
         end
       end
 
-      if (evaluator.state) && evaluator.state.to_sym == :accepted
-        shf_app.state = :accepted
+      if (evaluator.state) && evaluator.state.to_sym != :rejected
 
-        company = Company.find_by(company_number: evaluator.company_number)
-        unless company
-          company = FactoryGirl.create(:company, company_number: evaluator.company_number)
-        end
+        company = FactoryGirl.create(:company)
         shf_app.companies << company
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,10 +12,6 @@ FactoryGirl.define do
       File.new("#{Rails.root}/spec/fixtures/member_photos/photo_unavailable.png")
     end
 
-    transient do
-      company_number 5712213304
-    end
-
     factory :user_without_first_and_lastname do
 
       after(:create) do |user|
@@ -28,7 +24,7 @@ FactoryGirl.define do
     factory :user_with_membership_app do
 
       after(:create) do |user, evaluator|
-        create_list(:shf_application, 1, user: user, contact_email: evaluator.email, company_number: evaluator.company_number)
+        create_list(:shf_application, 1, user: user, contact_email: evaluator.email)
       end
     end
 
@@ -42,8 +38,7 @@ FactoryGirl.define do
 
       after(:create) do |user, evaluator|
         create_list(:shf_application, 1, :accepted, user: user,
-                    contact_email: evaluator.email,
-                    company_number:  evaluator.company_number)
+                    contact_email: evaluator.email)
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -247,9 +247,9 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     it 'adds a count of errors' do
-      expect(errors_html_sv).to match(/#{t('model_errors', count: 2)}/)
+      expect(errors_html_sv).to match(/#{t('model_errors', count: 3)}/)
 
-      expect(errors_html_en).to match(/#{t('model_errors', count: 3)}/)
+      expect(errors_html_en).to match(/#{t('model_errors', count: 4)}/)
     end
 
     it 'returns all model errors - swedish' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     let(:good_ma) { FactoryGirl.create(:shf_application) }
 
-    let(:user)    { FactoryGirl.create(:user) }
+    let(:user) { FactoryGirl.create(:user) }
 
     let(:errors_html_sv)  do
       I18n.locale = :sv
@@ -237,7 +237,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     let(:errors_html_en)  do
       I18n.locale = :en
-      ma = ShfApplication.new(user: user)
+      ma = ShfApplication.new(user: good_ma.user)
       ma.valid?
       model_errors_helper(ma)
     end
@@ -247,33 +247,23 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     it 'adds a count of errors' do
-      expect(errors_html_sv).to match(/#{t('model_errors', count: 4)}/)
+      expect(errors_html_sv).to match(/#{t('model_errors', count: 2)}/)
 
-      expect(errors_html_en).to match(/#{t('model_errors', count: 4)}/)
+      expect(errors_html_en).to match(/#{t('model_errors', count: 3)}/)
     end
 
     it 'returns all model errors - swedish' do
-      expect(errors_html_sv).to match(/Organisationsnummer måste anges/)
-
-      expect(errors_html_sv).
-        to match(/Organisationsnummer har fel längd \(ska vara 10 tecken\)/)
-
       expect(errors_html_sv).to match(/Kontakt e-post måste anges/)
 
       expect(errors_html_sv).to match(/Kontakt e-post har fel format/)
-
     end
 
     it 'returns all model errors - english' do
-      expect(errors_html_en).to match(/Company number cannot be blank/)
-
-      expect(errors_html_en).
-        to match(/Company number is the wrong length \(should be 10 characters\)/)
-
       expect(errors_html_en).to match(/Contact Email cannot be blank/)
 
       expect(errors_html_en).to match(/Contact Email is invalid/)
 
+      expect(errors_html_en).to match(/User has already been taken/)
     end
   end
 

--- a/spec/helpers/companies_helper_spec.rb
+++ b/spec/helpers/companies_helper_spec.rb
@@ -176,12 +176,12 @@ RSpec.describe CompaniesHelper, type: :helper do
   describe '#company_number_entry_field' do
     it 'returns number entry field for company_number' do
       expect(company_number_entry_field)
-        .to match(/input type="number" name="company_number" id="company_number"/)
+        .to match(/input type="number" name="company_number" id="shf_application_company_number"/)
     end
 
     it 'returns entry field with initial value when given an argument' do
       expect(company_number_entry_field('0000000000'))
-        .to match(/id="company_number" value="0000000000"/)
+        .to match(/id="shf_application_company_number" value="0000000000"/)
     end
   end
 end

--- a/spec/helpers/companies_helper_spec.rb
+++ b/spec/helpers/companies_helper_spec.rb
@@ -10,28 +10,25 @@ RSpec.describe CompaniesHelper, type: :helper do
     let(:employee3) { create(:user) }
 
     let!(:ma1) do
-      ma = create(:shf_application, :accepted,
-                  user: employee1,
-                  company_number: company.company_number)
+      ma = create(:shf_application, :accepted, user: employee1)
       ma.business_categories << create(:business_category, name: 'cat1')
       ma
     end
     let!(:ma2) do
-      ma = create(:shf_application, :accepted,
-                  user: employee2,
-                  company_number: company.company_number)
+      ma = create(:shf_application, :accepted, user: employee2)
       ma.business_categories << create(:business_category, name: 'cat2')
+      ma.companies = ma1.companies
       ma
     end
     let!(:ma3) do
-      ma = create(:shf_application, :accepted,
-                  user: employee3,
-                  company_number: company.company_number)
+      ma = create(:shf_application, :accepted, user: employee3)
       ma.business_categories << create(:business_category, name: 'cat3')
+      ma.companies = ma1.companies
       ma
     end
 
     it '#list_categories' do
+      company = ma1.companies.first
       expect(helper.list_categories(company)).to eq 'cat1 cat2 cat3'
       expect(helper.list_categories(company)).not_to include 'Träning'
     end

--- a/spec/helpers/companies_helper_spec.rb
+++ b/spec/helpers/companies_helper_spec.rb
@@ -172,4 +172,16 @@ RSpec.describe CompaniesHelper, type: :helper do
         .to match(/option selected="selected" value="#{cmpy_3.id}"/)
     end
   end
+
+  describe '#company_number_entry_field' do
+    it 'returns number entry field for company_number' do
+      expect(company_number_entry_field)
+        .to match(/input type="number" name="company_number" id="company_number"/)
+    end
+
+    it 'returns entry field with initial value when given an argument' do
+      expect(company_number_entry_field('0000000000'))
+        .to match(/id="company_number" value="0000000000"/)
+    end
+  end
 end

--- a/spec/helpers/companies_helper_spec.rb
+++ b/spec/helpers/companies_helper_spec.rb
@@ -163,13 +163,13 @@ RSpec.describe CompaniesHelper, type: :helper do
 
     it 'returns select field for company_number, value == company ID' do
       Company.all.each do |cmpy|
-        expect(company_number_selection_field).to match /option value="#{cmpy.id}"/
+        expect(company_number_selection_field).to match(/option value="#{cmpy.id}"/)
       end
     end
 
     it 'sets selected value when given an argument' do
       expect(company_number_selection_field(cmpy_3.id))
-        .to match /option selected="selected" value="#{cmpy_3.id}"/
+        .to match(/option selected="selected" value="#{cmpy_3.id}"/)
     end
   end
 end

--- a/spec/helpers/companies_helper_spec.rb
+++ b/spec/helpers/companies_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CompaniesHelper, type: :helper do
-  let!(:company) { create(:company) }
+  let(:company) { create(:company) }
   let(:user) { create(:user) }
 
   describe 'companies' do
@@ -153,6 +153,23 @@ RSpec.describe CompaniesHelper, type: :helper do
     it 'returns pay-fee link with company and user id' do
       expect(pay_branding_fee_link(company.id, user.id))
         .to match Regexp.new(Regexp.escape(expected_path))
+    end
+  end
+
+  describe '#company_number_selection_field' do
+    4.times do |n|
+      let!("cmpy_#{n+1}".to_sym) { create(:company) }
+    end
+
+    it 'returns select field for company_number, value == company ID' do
+      Company.all.each do |cmpy|
+        expect(company_number_selection_field).to match /option value="#{cmpy.id}"/
+      end
+    end
+
+    it 'sets selected value when given an argument' do
+      expect(company_number_selection_field(cmpy_3.id))
+        .to match /option selected="selected" value="#{cmpy_3.id}"/
     end
   end
 end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe AdminMailer, type: :mailer do
 
     it 'has the company number' do
       expect(email_sent).to have_body_text(I18n.t('activerecord.attributes.company.company_number'))
-      expect(email_sent).to have_body_text(new_app.company_number)
+      expect(email_sent).to have_body_text(new_app.companies.first.company_number)
     end
 
   end

--- a/spec/mailers/shf_application_mailer_spec.rb
+++ b/spec/mailers/shf_application_mailer_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe ShfApplicationMailer, type: :mailer do
 
 
       let(:accepted_app_branding_paid) {
-        create(:shf_application, :accepted, user: user1, company_number: co_branding_paid.company_number)
+        create(:shf_application, :accepted, user: user1)
       }
 
       let(:email_sent_branding_paid) { ShfApplicationMailer.app_approved(accepted_app_branding_paid) }

--- a/spec/models/companies_shf_application_spec.rb
+++ b/spec/models/companies_shf_application_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CompaniesShfApplication, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/companies_shf_application_spec.rb
+++ b/spec/models/companies_shf_application_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe CompaniesShfApplication, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/company_application_spec.rb
+++ b/spec/models/company_application_spec.rb
@@ -1,5 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe CompanyApplication, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Factory' do
+    it 'has a valid factory' do
+      expect(create(:company_application)).to be_valid
+    end
+  end
+
+  describe 'DB Table' do
+    it { is_expected.to have_db_column :id }
+    it { is_expected.to have_db_column :company_id }
+    it { is_expected.to have_db_column :shf_application_id }
+  end
+
+  describe 'Associations' do
+    it { is_expected.to belong_to :company }
+    it { is_expected.to belong_to :shf_application }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:company) }
+    it { is_expected.to validate_presence_of(:shf_application) }
+    it 'validates uniqueness of company<>shf_application association' do
+      subject { FactoryGirl.build(:company_application)
+      is_expected.to validate_uniqueness_of(:company_id).scoped_to(:shf_application) }
+    end
+  end
 end

--- a/spec/models/company_application_spec.rb
+++ b/spec/models/company_application_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CompanyApplication, type: :model do
     it { is_expected.to validate_presence_of(:company) }
     it { is_expected.to validate_presence_of(:shf_application) }
     it 'validates uniqueness of company<>shf_application association' do
-      subject { FactoryGirl.build(:company_application)
+      subject { FactoryBot.build(:company_application)
       is_expected.to validate_uniqueness_of(:company_id).scoped_to(:shf_application) }
     end
   end

--- a/spec/models/company_application_spec.rb
+++ b/spec/models/company_application_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CompanyApplication, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/shf_application_spec.rb
+++ b/spec/models/shf_application_spec.rb
@@ -62,8 +62,6 @@ RSpec.describe ShfApplication, type: :model do
                           .allow_destroy(true) }
     it { is_expected.to accept_nested_attributes_for(:user)
                           .update_only(true).allow_destroy(false) }
-
-    it { is_expected.to accept_nested_attributes_for(:companies).allow_destroy(false) }
   end
 
   describe 'Validations' do

--- a/spec/models/shf_application_spec.rb
+++ b/spec/models/shf_application_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe ShfApplication, type: :model do
     it { is_expected.not_to allow_value('userexample.com').for(:contact_email) }
 
     describe 'uniqueness of user across all applications' do
-      subject { FactoryGirl.build(:shf_application) }
+      subject { FactoryBot.build(:shf_application) }
       it { is_expected.to validate_uniqueness_of(:user_id) }
     end
   end

--- a/spec/models/shf_application_spec.rb
+++ b/spec/models/shf_application_spec.rb
@@ -41,19 +41,18 @@ RSpec.describe ShfApplication, type: :model do
 
   describe 'DB Table' do
     it { is_expected.to have_db_column :id }
-    it { is_expected.to have_db_column :company_number }
     it { is_expected.to have_db_column :phone_number }
     it { is_expected.to have_db_column :contact_email }
     it { is_expected.to have_db_column :state }
     it { is_expected.to have_db_column :custom_reason_text }
     it { is_expected.to have_db_column :user_id }
-    it { is_expected.to have_db_column :company_id }
     it { is_expected.to have_db_column :member_app_waiting_reasons_id }
   end
 
   describe 'Associations' do
     it { is_expected.to belong_to :user }
-    it { is_expected.to have_and_belong_to_many :companies }
+    it { is_expected.to have_many(:company_applications) }
+    it { is_expected.to have_many(:companies).through(:company_applications) }
     it { is_expected.to have_and_belong_to_many :business_categories }
     it { is_expected.to have_many :uploaded_files }
     it { is_expected.to belong_to(:waiting_reason)
@@ -63,29 +62,20 @@ RSpec.describe ShfApplication, type: :model do
                           .allow_destroy(true) }
     it { is_expected.to accept_nested_attributes_for(:user)
                           .update_only(true).allow_destroy(false) }
+
+    it { is_expected.to accept_nested_attributes_for(:companies).allow_destroy(false) }
   end
 
   describe 'Validations' do
     it { is_expected.to validate_presence_of :contact_email }
-    it { is_expected.to validate_presence_of :company_number }
     it { is_expected.to validate_presence_of :state }
 
     it { is_expected.to allow_value('user@example.com').for(:contact_email) }
     it { is_expected.not_to allow_value('userexample.com').for(:contact_email) }
 
-    it { is_expected.to validate_length_of(:company_number).is_equal_to(10) }
-
-    describe 'uniqueness of user scoped within company_number' do
+    describe 'uniqueness of user across all applications' do
       subject { FactoryGirl.build(:shf_application) }
-      it { is_expected.to validate_uniqueness_of(:user_id)
-                                .scoped_to(:company_number) }
-    end
-
-    describe 'swedish org number' do
-      it { is_expected.to allow_values('5560360793', '2120000142')
-                            .for(:company_number) }
-      it { is_expected.not_to allow_values('0123456789', '212000')
-                            .for(:company_number) }
+      it { is_expected.to validate_uniqueness_of(:user_id) }
     end
   end
 
@@ -149,6 +139,7 @@ RSpec.describe ShfApplication, type: :model do
 
   end
 
+
   describe 'destroy callbacks' do
     let(:user1) { create(:user) }
     let(:user2) { create(:user) }
@@ -163,8 +154,7 @@ RSpec.describe ShfApplication, type: :model do
     let(:application2) do
       create(:shf_application, user: user2,
              uploaded_files: [uploaded_file], state: :new,
-             companies: [application.companies.last],
-             company_number: application.company_number)
+             companies: [application.companies.last])
     end
 
     it 'invokes method to destroy uploaded files' do
@@ -176,6 +166,22 @@ RSpec.describe ShfApplication, type: :model do
       application2
       expect(application.companies.last).not_to receive(:destroy)
       application.destroy
+    end
+
+    it 'destroys CompanyApplication record' do
+      application
+      expect { application.destroy }.to change(CompanyApplication, :count).by(-1)
+    end
+
+    it 'destroys associated companies' do
+      application
+      expect { application.destroy }.to change(Company, :count).by(-1)
+    end
+
+    it 'does not destroy company if other app(s) exist' do
+      application
+      application2
+      expect { application.destroy }.not_to change(Company, :count)
     end
   end
 
@@ -327,18 +333,39 @@ RSpec.describe ShfApplication, type: :model do
     end
 
     context 'actions taken on state transition' do
+      let(:uploaded_files) { create(:uploaded_file,
+                                    actual_file: (File.new(File.join(FIXTURE_DIR,
+                                                  'image.jpg')))) }
       describe 'application accepted' do
         before(:each) do
+          application.uploaded_files = [uploaded_files]
           application.start_review!
           application.accept!
         end
+
         it "assigns app's latest-added-company email to application contact_email" do
           expect(application.companies.last.email).to eq application.contact_email
         end
       end
 
       describe 'application rejected' do
-        xit 'need tests here' do
+        before(:each) do
+          application.uploaded_files = [uploaded_files]
+          application.user.membership_number = 10
+          application.start_review!
+          application.reject!
+        end
+
+        it 'assigns user membership_number to nil' do
+          expect(application.user.membership_number).to be_nil
+        end
+
+        it 'destroys uploaded files' do
+          expect(application.uploaded_files.count).to be 0
+        end
+
+        it 'destroys associated company(s)' do
+          expect(application.companies.count).to be 0
         end
       end
     end

--- a/spec/models/shf_application_spec.rb
+++ b/spec/models/shf_application_spec.rb
@@ -376,7 +376,11 @@ RSpec.describe ShfApplication, type: :model do
   describe '#se_mailing_csv_str (comma sep string) of the address for the swedish postal service' do
 
     let(:accepted_app) { create(:shf_application, :accepted) }
-    let(:rejected_app) { create(:shf_application, :rejected)}  # no company for this
+    let(:app_no_company) do
+      app = create(:shf_application)
+      app.companies = []
+      app
+    end
 
     it "uses the app's latest-added-company main address" do
 
@@ -389,7 +393,7 @@ RSpec.describe ShfApplication, type: :model do
 
     it 'blanks (just commas with no data between them) if there is no company' do
 
-      expect(rejected_app.se_mailing_csv_str).to eq AddressExporter.se_mailing_csv_str(nil)
+      expect(app_no_company.se_mailing_csv_str).to eq AddressExporter.se_mailing_csv_str(nil)
 
     end
 

--- a/spec/models/shf_application_spec.rb
+++ b/spec/models/shf_application_spec.rb
@@ -365,7 +365,7 @@ RSpec.describe ShfApplication, type: :model do
         end
 
         it 'destroys associated company(s)' do
-          expect(application.companies.count).to be 0
+          expect(application.companies.count).to be 1
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -149,9 +149,9 @@ RSpec.describe User, type: :model do
   describe '#has_company?' do
 
     after(:each) {
-      Company.delete_all
-      ShfApplication.delete_all
-      User.delete_all
+      Company.destroy_all
+      ShfApplication.destroy_all
+      User.destroy_all
     }
 
     describe 'user: no application' do
@@ -161,7 +161,7 @@ RSpec.describe User, type: :model do
 
     describe 'user: 1 saved application' do
       subject { create(:user_with_membership_app) }
-      it { expect(subject.has_company?).to be_falsey }
+      it { expect(subject.has_company?).to be_truthy }
     end
 
     describe 'member with 1 app' do
@@ -208,32 +208,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#company' do
-    describe 'user: no application' do
-      subject { create(:user) }
-      it { expect(subject.company).to be_nil }
-    end
-
-    describe 'user: 1 saved application' do
-      subject { create(:user_with_membership_app) }
-      it { expect(subject.company).to be_nil }
-    end
-
-    describe 'member with 1 app' do
-      let(:member) { create(:member_with_membership_app) }
-      it { expect(member.company).not_to be_nil }
-    end
-
-    describe 'member with 0 apps (should not happen)' do
-      let(:member) { create(:user) }
-      it { expect(member.company).to be_nil }
-    end
-
-    describe 'admin' do
-      subject { create(:user, admin: true) }
-      it { expect(subject.company).to be_nil }
-    end
-  end
 
   describe '#member_or_admin?' do
 
@@ -280,15 +254,16 @@ RSpec.describe User, type: :model do
     end
 
     describe 'is a member, so is in companies' do
+      let(:co_number) { member.shf_application&.companies&.first&.company_number }
 
       describe 'member with 1 app' do
         let(:member) { create(:member_with_membership_app) }
-        it { expect(member.in_company_numbered?(default_co_number)).to be_truthy }
+        it { expect(member.in_company_numbered?(co_number)).to be_truthy }
       end
 
       describe 'member with 0 apps (should not happen)' do
         let(:member) { create(:user) }
-        it { expect(member.in_company_numbered?(default_co_number)).to be_falsey }
+        it { expect(member.in_company_numbered?(co_number)).to be_falsey }
       end
 
     end
@@ -303,14 +278,9 @@ RSpec.describe User, type: :model do
   describe '#companies' do
     describe 'not yet a member, so not in any full companies' do
 
-      describe 'user: no applications, so not in any companies' do
-        subject { create(:user) }
-        it { expect(subject.companies.size).to eq(0) }
-      end
-
       describe 'user: 1 saved application' do
         subject { create(:user_with_membership_app) }
-        it { expect(subject.companies.size).to eq(0) }
+        it { expect(subject.companies.size).to eq(1) }
       end
     end
 

--- a/spec/policies/address_policy_spec.rb
+++ b/spec/policies/address_policy_spec.rb
@@ -4,10 +4,11 @@ include PoliciesHelper
 RSpec.describe AddressPolicy do
 
   let(:user_1) { create(:user, email: 'user_1@random.com') }
-  let(:member) { create(:member_with_membership_app, email: 'member@random.com', company_number: '5562728336')}
+  let(:member) { create(:member_with_membership_app, email: 'member@random.com') }
+  let(:member_wo_cmpy) { create(:user, member: true) }
   let(:admin)  { create(:user, email: 'admin@sfh.com', admin: true) }
   let(:visitor) { build(:visitor) }
-  let(:company) { create(:company, company_number: '5712213304')}
+  let(:company) { create(:company) }
 
   describe 'For admin' do
     subject { described_class.new(admin, company.addresses.first) }
@@ -20,7 +21,10 @@ RSpec.describe AddressPolicy do
   end
 
   describe 'For a member that is a part of a company' do
-    let(:members_company) { Company.find_by_company_number('5562728336') }
+    let(:members_company) do
+      co_number = member.shf_application.companies.first.company_number
+      Company.find_by_company_number(co_number)
+    end
     subject { described_class.new(member, members_company.addresses.first) }
 
     it { is_expected.to permit_action :edit }
@@ -31,7 +35,7 @@ RSpec.describe AddressPolicy do
   end
 
   describe 'For a member that is not part of a company' do
-    subject { described_class.new(member, company.addresses.first) }
+    subject { described_class.new(member_wo_cmpy, company.addresses.first) }
 
     it { is_expected.to forbid_action :edit }
     it { is_expected.to forbid_action :update }

--- a/spec/policies/company_policy_spec.rb
+++ b/spec/policies/company_policy_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe CompanyPolicy do
     it { is_expected.to permit_action :show }
     it { is_expected.to permit_action :edit }
     it { is_expected.to permit_action :update }
-    it { is_expected.to forbid_action :new }
-    it { is_expected.to forbid_action :create }
+    it { is_expected.to permit_action :new }
+    it { is_expected.to permit_action :create }
     it { is_expected.to forbid_action :edit_payment }
   end
 
@@ -44,8 +44,8 @@ RSpec.describe CompanyPolicy do
     it { is_expected.to permit_action :show }
     it { is_expected.to forbid_action :edit }
     it { is_expected.to forbid_action :update }
-    it { is_expected.to forbid_action :new }
-    it { is_expected.to forbid_action :create }
+    it { is_expected.to permit_action :new }
+    it { is_expected.to permit_action :create }
     it { is_expected.to forbid_action :edit_payment }
   end
 
@@ -56,8 +56,8 @@ RSpec.describe CompanyPolicy do
     it { is_expected.to permit_action :show }
     it { is_expected.to forbid_action :edit }
     it { is_expected.to forbid_action :update }
-    it { is_expected.to forbid_action :new }
-    it { is_expected.to forbid_action :create }
+    it { is_expected.to permit_action :new }
+    it { is_expected.to permit_action :create }
     it { is_expected.to forbid_action :edit_payment }
   end
 

--- a/spec/policies/company_policy_spec.rb
+++ b/spec/policies/company_policy_spec.rb
@@ -4,7 +4,7 @@ include PoliciesHelper
 RSpec.describe CompanyPolicy do
 
   let(:user_1) { create(:user, email: 'user_1@random.com') }
-  let(:member) { create(:member_with_membership_app, email: 'member@random.com', company_number: '5562728336')}
+  let(:member) { create(:member_with_membership_app, email: 'member@random.com')}
   let(:admin)  { create(:user, email: 'admin@sfh.com', admin: true) }
   let(:visitor) { build(:visitor) }
   let(:company) { create(:company, company_number: '5712213304')}
@@ -22,7 +22,10 @@ RSpec.describe CompanyPolicy do
   end
 
   describe 'For a member that is a part of a company' do
-    let(:members_company) { Company.find_by_company_number('5562728336')}
+    let(:members_company) do
+      co_number = member.shf_application.companies.first.company_number
+      Company.find_by_company_number(co_number)
+    end
     subject { described_class.new(member, members_company) }
 
     it { is_expected.to permit_action :index }

--- a/spec/policies/company_policy_spec.rb
+++ b/spec/policies/company_policy_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CompanyPolicy do
     it { is_expected.to permit_action :show }
     it { is_expected.to permit_action :edit }
     it { is_expected.to permit_action :update }
-    it { is_expected.to permit_action :new }
+    it { is_expected.to forbid_action :new }
     it { is_expected.to permit_action :create }
     it { is_expected.to forbid_action :edit_payment }
   end
@@ -44,7 +44,7 @@ RSpec.describe CompanyPolicy do
     it { is_expected.to permit_action :show }
     it { is_expected.to forbid_action :edit }
     it { is_expected.to forbid_action :update }
-    it { is_expected.to permit_action :new }
+    it { is_expected.to forbid_action :new }
     it { is_expected.to permit_action :create }
     it { is_expected.to forbid_action :edit_payment }
   end
@@ -56,7 +56,7 @@ RSpec.describe CompanyPolicy do
     it { is_expected.to permit_action :show }
     it { is_expected.to forbid_action :edit }
     it { is_expected.to forbid_action :update }
-    it { is_expected.to permit_action :new }
+    it { is_expected.to forbid_action :new }
     it { is_expected.to permit_action :create }
     it { is_expected.to forbid_action :edit_payment }
   end

--- a/spec/policies/shf_application_policy_spec.rb
+++ b/spec/policies/shf_application_policy_spec.rb
@@ -19,7 +19,7 @@ describe ShfApplicationPolicy do
 
   let(:user_not_owner) { create(:user, email: 'user_not_owner@random.com') }
   let(:user_applicant) { create(:user_with_membership_app, email: 'user_owner@random.com') }
-  # let(:application) { create(:shf_application, user: user_applicant, state: :new) }
+  let(:user_2) { create(:user) }
   let(:application) { create(:shf_application, state: :new) }
 
   let(:visitor) { build(:visitor) }
@@ -140,44 +140,80 @@ describe ShfApplicationPolicy do
 
     describe 'Member or User not the owner can only create a new one and view information' do
 
-      { 'Member': :member_not_owner,
-        'User': :user_not_owner }.each do |user_class, current_user|
+      describe "For User (without an application)" do
 
-        describe "For #{user_class} (not the owner of the application)" do
+        let(:current_user) { :user_not_owner }
 
-          it 'permits new for a new application (not already instantiated)' do
-            expect(described_class.new(self.send(current_user), ShfApplication)).to permit_action :new
-          end
-
-          it 'forbids new for an existing application (already instantiated)' do
-            expect(described_class.new(self.send(current_user), application)).to forbid_action :new
-          end
-
-          it 'permits create for a new application (not already instantiated)' do
-            expect(described_class.new(self.send(current_user), ShfApplication)).to permit_action :create
-          end
-
-          it 'forbids create for an existing application (already instantiated)' do
-            expect(described_class.new(self.send(current_user), application)).to forbid_action :create
-          end
-
-          it 'forbids all other CRUD actions (that are not :new or :create)' do
-            expect(described_class.new(self.send(current_user), application)).to forbid_actions(CRUD_ACTIONS - [:new, :create])
-          end
-
-          it 'permits :information' do
-            expect(described_class.new(self.send(current_user), application)).to permit_action :information
-          end
-
-          it 'forbids :index' do
-            expect(described_class.new(self.send(current_user), application)).to forbid_action :index
-          end
-
-          it 'forbids all application state change actions' do
-            expect(described_class.new(self.send(current_user), application)).to forbid_actions APP_STATE_CHANGE_ACTIONS
-          end
-
+        it 'permits new for a new application (not already instantiated)' do
+          expect(described_class.new(self.send(current_user), ShfApplication)).to permit_action :new
         end
+
+        it 'forbids new for an existing application (already instantiated)' do
+          expect(described_class.new(self.send(current_user), application)).to forbid_action :new
+        end
+
+        it 'permits create for a new application (not already instantiated)' do
+          expect(described_class.new(self.send(current_user), ShfApplication)).to permit_action :create
+        end
+
+        it 'forbids create for an existing application (already instantiated)' do
+          expect(described_class.new(self.send(current_user), application)).to forbid_action :create
+        end
+
+        it 'forbids all other CRUD actions (that are not :new or :create)' do
+          expect(described_class.new(self.send(current_user), application)).to forbid_actions(CRUD_ACTIONS - [:new, :create])
+        end
+
+        it 'permits :information' do
+          expect(described_class.new(self.send(current_user), application)).to permit_action :information
+        end
+
+        it 'forbids :index' do
+          expect(described_class.new(self.send(current_user), application)).to forbid_action :index
+        end
+
+        it 'forbids all application state change actions' do
+          expect(described_class.new(self.send(current_user), application)).to forbid_actions APP_STATE_CHANGE_ACTIONS
+        end
+
+      end
+
+      describe "For Member (who already has application)" do
+
+        let(:current_user) { :member_not_owner }
+
+        it 'forbids new for a new application (not already instantiated)' do
+          expect(described_class.new(self.send(current_user), ShfApplication)).to forbid_action :new
+        end
+
+        it 'forbids new for an existing application (already instantiated)' do
+          expect(described_class.new(self.send(current_user), application)).to forbid_action :new
+        end
+
+        it 'forbids create for a new application (not already instantiated)' do
+          expect(described_class.new(self.send(current_user), ShfApplication)).to forbid_action :create
+        end
+
+        it 'forbids create for an existing application (already instantiated)' do
+          expect(described_class.new(self.send(current_user), application)).to forbid_action :create
+        end
+
+        it 'forbids all other CRUD actions (that are not :new or :create)' do
+          expect(described_class.new(self.send(current_user), application)).to forbid_actions(CRUD_ACTIONS - [:new, :create])
+        end
+
+        it 'permits :information' do
+          expect(described_class.new(self.send(current_user), application)).to permit_action :information
+        end
+
+        it 'forbids :index' do
+          expect(described_class.new(self.send(current_user), application)).to forbid_action :index
+        end
+
+        it 'forbids all application state change actions' do
+          expect(described_class.new(self.send(current_user), application)).to forbid_actions APP_STATE_CHANGE_ACTIONS
+        end
+
       end
 
     end
@@ -192,8 +228,8 @@ describe ShfApplicationPolicy do
 
           let(:app_being_checked) { self.send(current_user).shf_application }
 
-          it 'permits new for a new application (not already instantiated)' do
-            expect(described_class.new(self.send(current_user), ShfApplication)).to permit_action :new
+          it 'forbids new for a new application (not already instantiated)' do
+            expect(described_class.new(self.send(current_user), ShfApplication)).to forbid_action :new
           end
 
           describe 'For other users of ShfApplication' do
@@ -202,8 +238,8 @@ describe ShfApplicationPolicy do
               expect(described_class.new(self.send(current_user), app_being_checked)).to forbid_action :new
             end
 
-            it 'permits create for a new application (not already instantiated)' do
-              expect(described_class.new(self.send(current_user), described_class)).to permit_action :create
+            it 'forbids create for a new application (not already instantiated)' do
+              expect(described_class.new(self.send(current_user), described_class)).to forbid_action :create
             end
 
             it 'permits create for an existing application (already instantiated)' do
@@ -284,16 +320,16 @@ describe ShfApplicationPolicy do
 
       subject { described_class.new(member_applicant, application) }
 
-      it 'permits new for a new application (not already instantiated)' do
-        expect(described_class.new(member_applicant, ShfApplication)).to permit_action :new
+      it 'forbids new for a new application (not already instantiated)' do
+        expect(described_class.new(member_applicant, ShfApplication)).to forbid_action :new
       end
 
       it 'forbids new for an existing application (already instantiated)' do
         is_expected.to forbid_action :new
       end
 
-      it 'permits create for a new application (not already instantiated)' do
-        expect(described_class.new(member_applicant, ShfApplication)).to permit_action :create
+      it 'forbids create for a new application (not already instantiated)' do
+        expect(described_class.new(member_applicant, ShfApplication)).to forbid_action :create
       end
 
       it 'permits create for an existing application (already instantiated)' do

--- a/spec/policies/shf_application_policy_spec.rb
+++ b/spec/policies/shf_application_policy_spec.rb
@@ -19,9 +19,8 @@ describe ShfApplicationPolicy do
 
   let(:user_not_owner) { create(:user, email: 'user_not_owner@random.com') }
   let(:user_applicant) { create(:user_with_membership_app, email: 'user_owner@random.com') }
-  let(:application) { create(:shf_application,
-                             user: user_applicant,
-                             state: :new) }
+  # let(:application) { create(:shf_application, user: user_applicant, state: :new) }
+  let(:application) { create(:shf_application, state: :new) }
 
   let(:visitor) { build(:visitor) }
 


### PR DESCRIPTION
**Update, Mar 14** I took a snapshot of production data and loaded into development in order to confirm the data migration logic.  After discovering a couple of situations in the prod data, the logic was changed to accommodate those (see comment in story: https://www.pivotaltracker.com/story/show/151611254).  At this point I think this PR is ready for final review and merging.

**Update, Mar 12** Reconfigured the app-edit form (create and update) to use a single data-entry field (for company_number) instead of a selection list showing all existing company_numbers.  This is because we cannot expose company_numbers to the public that are personal numbers (as opposed to actual _organization_ numbers).  The use still has the option of creating a new company if the company does not yet exist.

**Update, Mar 7** I changed the membership application create/update process to allow a user to either 1) select from an existing list of company numbers, or, if their company does not yet exist, create a new company to associated with the application.  Screenshots shown below.

**Update, Feb 28** I am rethinking certain aspects of this effort so please hold off on reviewing this PR at this time.

PT Story: https://www.pivotaltracker.com/story/show/151611254

The title of this story is misleading as it actually consists of restructuring the association between an application and companies.  This PR is a follow-on effort to previous efforts, and positions the app for actually implementing, in the UI, the ability to associated a member (via their membership association) with a second, third, etc. company.

Changes proposed in this pull request:
1.  Drop the attribute `company_number` from ShfApplication.  This was used to keep track of the (single) company associated with an application.  We now use the many<>many association between applications and companies for that.
2. Changed the association between applications and companies from `has_and_belongs_to_many` (HABTM) to `has many ..., through: company_applications` (HMT).  Generally, HMT is preferred over HABTM), since the former involves a real model as the joining association (not just a join table), and as such one can add attribute to that model if needed (this is not needed for this PR, but may be in the future).
3. When an application is created, we now create a corresponding company (or associate the application with an existing company), using the company_number attribute of a company (accessed in the application form via `accepts_nested_attributes_for`).  (this is a departure from prior practice, where we created a company _only_ when the application was accepted).
4. A migration that converts production data from the prior mechanism to this new approach.  The migration is reversible.
5. Added application state `being_destroyed`.  This allows us to destroy all associated companies when an application is destroyed.

So, how should one review this sprawling mess of a PR?  I suggest focusing on models and their associations.  Also, take a look at the migration and see if there are any vulnerabilities there.

Also, it would be really good if the reviewer would stand up this branch in their local environment, and run the migration and confirm that the data has been correctly migrated.  Then, rollback and confirm the prior data and data structure was restored.

**Screenshots**

## User creating application - enter company number or choose to create new company

<img width="614" alt="screen shot 2018-03-12 at 9 07 27 am" src="https://user-images.githubusercontent.com/9968213/37285465-7099e2ce-25d5-11e8-84a7-cd13c25a0f6b.png">

## User creating application - create new company - model errors shown

<img width="747" alt="screen shot 2018-03-12 at 9 10 39 am" src="https://user-images.githubusercontent.com/9968213/37285489-7d931298-25d5-11e8-8b4a-2dc48b9554a3.png">


## User has created new company - new company_number auto-entered into form field

<img width="573" alt="screen shot 2018-03-12 at 9 10 59 am" src="https://user-images.githubusercontent.com/9968213/37285500-8679c910-25d5-11e8-88af-0671fe752ebd.png">


Ready for review:
@AgileVentures/shf-project-team 