### PR TITLE
Remove certain deprecation warnings for spec tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.4.2'
+ruby '2.4.3'
 gem 'dotenv-rails'
 gem 'rails', '5.1'
 gem 'pg', '~> 0.18'
@@ -89,7 +89,7 @@ group :development, :test do
   gem 'better_errors'
   gem 'binding_of_caller'  # needed to make better_errors work well
 
-  gem 'i18n-tasks'
+  gem 'i18n-tasks', '~> 0.9.21'
 
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: git://github.com/galetahub/ckeditor.git
-  revision: 32bc0c6702388549cb4b3f00f82afbc3798d6891
+  revision: 115a50628baceeac5cc37363db082e3f5ba03c76
   specs:
     ckeditor (4.2.4)
-      cocaine
       orm_adapter (~> 0.5.0)
+      terrapin
 
 GEM
   remote: https://rubygems.org/
@@ -55,7 +55,7 @@ GEM
       io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (7.2.6)
+    autoprefixer-rails (8.1.0.1)
       execjs
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -76,7 +76,7 @@ GEM
     bootstrap-will_paginate (1.0.0)
       will_paginate
     builder (3.2.3)
-    bullet (5.7.2)
+    bullet (5.7.5)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11.0)
     byebug (10.0.0)
@@ -101,14 +101,14 @@ GEM
       sshkit (~> 1.3)
     capistrano-ssh-doctor (1.0.0)
       capistrano (>= 3.1)
-    capybara (2.17.0)
+    capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
-    childprocess (0.8.0)
+    childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (1.2.0)
       archive-zip (~> 0.10)
@@ -169,10 +169,10 @@ GEM
     debug_inspector (0.0.3)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (4.4.1)
+    devise (4.4.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 5.2)
+      railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
@@ -193,7 +193,7 @@ GEM
     equalizer (0.0.11)
     erb2haml (0.1.5)
       html2haml
-    erubi (1.7.0)
+    erubi (1.7.1)
     erubis (2.7.0)
     exception_notification (4.2.2)
       actionmailer (>= 4.0, < 6)
@@ -205,21 +205,21 @@ GEM
       factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     ffaker (2.8.1)
-    ffi (1.9.21)
+    ffi (1.9.23)
     flay (2.10.0)
       erubis (~> 2.7.0)
       path_expander (~> 1.0)
       ruby_parser (~> 3.0)
       sexp_processor (~> 4.0)
-    flog (4.6.1)
+    flog (4.6.2)
       path_expander (~> 1.0)
       ruby_parser (~> 3.1, > 3.1.0)
       sexp_processor (~> 4.8)
     font-awesome-rails (4.7.0.3)
       railties (>= 3.2, < 5.2)
-    font-awesome-sass (5.0.6.1)
+    font-awesome-sass (5.0.6.2)
       sass (>= 3.2)
-    geocoder (1.4.5)
+    geocoder (1.4.7)
     gherkin (5.0.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -243,13 +243,13 @@ GEM
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    httparty (0.15.7)
+    httparty (0.16.1)
       multi_xml (>= 0.5.2)
-    i18n (0.9.4)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    i18n-js (3.0.4)
-      i18n (~> 0.6, >= 0.6.6)
-    i18n-tasks (0.9.20)
+    i18n-js (3.0.5)
+      i18n (>= 0.6.6, < 2)
+    i18n-tasks (0.9.21)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       easy_translate (>= 0.5.1)
@@ -257,7 +257,7 @@ GEM
       highline (>= 1.7.3)
       i18n
       parser (>= 2.2.3.0)
-      rainbow (~> 2.2)
+      rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
     ice_nine (0.11.2)
     imgkit (1.6.1)
@@ -277,7 +277,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.1.1)
+    loofah (2.2.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -299,7 +299,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
     netrc (0.11.0)
-    nio4r (2.2.0)
+    nio4r (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     nokogumbo (1.5.0)
@@ -315,7 +315,7 @@ GEM
     parallel (1.12.1)
     parser (2.4.0.2)
       ast (~> 2.3)
-    path_expander (1.0.2)
+    path_expander (1.0.3)
     pg (0.21.0)
     poltergeist (1.17.0)
       capybara (~> 2.1)
@@ -328,7 +328,7 @@ GEM
       addressable
       css_parser (>= 1.6.0)
       htmlentities (>= 4.0.0)
-    premailer-rails (1.10.1)
+    premailer-rails (1.10.2)
       actionmailer (>= 3, < 6)
       premailer (~> 1.7, >= 1.7.9)
     pry (0.11.3)
@@ -337,8 +337,8 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
-    public_suffix (3.0.1)
-    puma (3.11.2)
+    public_suffix (3.0.2)
+    puma (3.11.3)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     pundit-matchers (1.4.1)
@@ -374,13 +374,13 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.3.0)
-    ransack (1.8.7)
+    ransack (1.8.8)
       actionpack (>= 3.0)
       activerecord (>= 3.0)
       activesupport (>= 3.0)
       i18n
       polyamorous (~> 1.3.2)
-    rb-fsevent (0.10.2)
+    rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rb-readline (0.5.5)
@@ -424,7 +424,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
-    ruby_parser (3.10.1)
+    ruby_parser (3.11.0)
       sexp_processor (~> 4.9)
     rubycritic (3.3.0)
       flay (~> 2.8)
@@ -438,7 +438,7 @@ GEM
       virtus (~> 1.0)
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
-    sanitize (4.6.0)
+    sanitize (4.6.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
       nokogumbo (~> 1.4)
@@ -453,10 +453,10 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    selenium-webdriver (3.9.0)
+    selenium-webdriver (3.11.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
-    sexp_processor (4.10.0)
+    sexp_processor (4.10.1)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     simplecov (0.14.1)
@@ -486,6 +486,8 @@ GEM
       tins (~> 1.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    terrapin (0.6.0)
+      climate_control (>= 0.0.3, < 1.0)
     thor (0.19.4)
     thread (0.2.2)
     thread_safe (0.3.6)
@@ -498,7 +500,7 @@ GEM
     turbolinks-source (5.1.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (4.1.6)
+    uglifier (4.1.8)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
@@ -570,7 +572,7 @@ DEPENDENCIES
   high_voltage (~> 3.0.0)
   httparty
   i18n-js (>= 3.0.0.rc11)
-  i18n-tasks
+  i18n-tasks (~> 0.9.21)
   imgkit
   jbuilder (~> 2.5)
   jquery-rails
@@ -617,7 +619,7 @@ DEPENDENCIES
   wkhtmltoimage-binary
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 2.4.3p205
 
 BUNDLED WITH
    1.16.1

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3,6 +3,7 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
@@ -21,8 +22,6 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
-SET search_path = public, pg_catalog;
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -31,7 +30,7 @@ SET default_with_oids = false;
 -- Name: addresses; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE addresses (
+CREATE TABLE public.addresses (
     id bigint NOT NULL,
     street_address character varying,
     post_code character varying,
@@ -52,7 +51,7 @@ CREATE TABLE addresses (
 -- Name: addresses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE addresses_id_seq
+CREATE SEQUENCE public.addresses_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -64,14 +63,14 @@ CREATE SEQUENCE addresses_id_seq
 -- Name: addresses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE addresses_id_seq OWNED BY addresses.id;
+ALTER SEQUENCE public.addresses_id_seq OWNED BY public.addresses.id;
 
 
 --
 -- Name: app_configurations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE app_configurations (
+CREATE TABLE public.app_configurations (
     id bigint NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
@@ -90,7 +89,7 @@ CREATE TABLE app_configurations (
 -- Name: app_configurations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE app_configurations_id_seq
+CREATE SEQUENCE public.app_configurations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -102,14 +101,14 @@ CREATE SEQUENCE app_configurations_id_seq
 -- Name: app_configurations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE app_configurations_id_seq OWNED BY app_configurations.id;
+ALTER SEQUENCE public.app_configurations_id_seq OWNED BY public.app_configurations.id;
 
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ar_internal_metadata (
+CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
     created_at timestamp without time zone NOT NULL,
@@ -121,7 +120,7 @@ CREATE TABLE ar_internal_metadata (
 -- Name: business_categories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE business_categories (
+CREATE TABLE public.business_categories (
     id bigint NOT NULL,
     name character varying,
     description character varying,
@@ -134,7 +133,7 @@ CREATE TABLE business_categories (
 -- Name: business_categories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE business_categories_id_seq
+CREATE SEQUENCE public.business_categories_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -146,14 +145,14 @@ CREATE SEQUENCE business_categories_id_seq
 -- Name: business_categories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE business_categories_id_seq OWNED BY business_categories.id;
+ALTER SEQUENCE public.business_categories_id_seq OWNED BY public.business_categories.id;
 
 
 --
 -- Name: business_categories_shf_applications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE business_categories_shf_applications (
+CREATE TABLE public.business_categories_shf_applications (
     id bigint NOT NULL,
     shf_application_id bigint,
     business_category_id bigint
@@ -164,7 +163,7 @@ CREATE TABLE business_categories_shf_applications (
 -- Name: business_categories_shf_applications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE business_categories_shf_applications_id_seq
+CREATE SEQUENCE public.business_categories_shf_applications_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -176,14 +175,14 @@ CREATE SEQUENCE business_categories_shf_applications_id_seq
 -- Name: business_categories_shf_applications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE business_categories_shf_applications_id_seq OWNED BY business_categories_shf_applications.id;
+ALTER SEQUENCE public.business_categories_shf_applications_id_seq OWNED BY public.business_categories_shf_applications.id;
 
 
 --
 -- Name: ckeditor_assets; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ckeditor_assets (
+CREATE TABLE public.ckeditor_assets (
     id bigint NOT NULL,
     data_file_name character varying NOT NULL,
     data_content_type character varying,
@@ -202,7 +201,7 @@ CREATE TABLE ckeditor_assets (
 -- Name: ckeditor_assets_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE ckeditor_assets_id_seq
+CREATE SEQUENCE public.ckeditor_assets_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -214,14 +213,14 @@ CREATE SEQUENCE ckeditor_assets_id_seq
 -- Name: ckeditor_assets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE ckeditor_assets_id_seq OWNED BY ckeditor_assets.id;
+ALTER SEQUENCE public.ckeditor_assets_id_seq OWNED BY public.ckeditor_assets.id;
 
 
 --
 -- Name: companies; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE companies (
+CREATE TABLE public.companies (
     id bigint NOT NULL,
     name character varying,
     company_number character varying,
@@ -238,7 +237,7 @@ CREATE TABLE companies (
 -- Name: companies_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE companies_id_seq
+CREATE SEQUENCE public.companies_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -250,14 +249,14 @@ CREATE SEQUENCE companies_id_seq
 -- Name: companies_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE companies_id_seq OWNED BY companies.id;
+ALTER SEQUENCE public.companies_id_seq OWNED BY public.companies.id;
 
 
 --
 -- Name: companies_shf_applications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE companies_shf_applications (
+CREATE TABLE public.companies_shf_applications (
     shf_application_id bigint NOT NULL,
     company_id bigint NOT NULL
 );
@@ -267,7 +266,7 @@ CREATE TABLE companies_shf_applications (
 -- Name: kommuns; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE kommuns (
+CREATE TABLE public.kommuns (
     id bigint NOT NULL,
     name character varying,
     created_at timestamp without time zone NOT NULL,
@@ -279,7 +278,7 @@ CREATE TABLE kommuns (
 -- Name: kommuns_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE kommuns_id_seq
+CREATE SEQUENCE public.kommuns_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -291,14 +290,14 @@ CREATE SEQUENCE kommuns_id_seq
 -- Name: kommuns_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE kommuns_id_seq OWNED BY kommuns.id;
+ALTER SEQUENCE public.kommuns_id_seq OWNED BY public.kommuns.id;
 
 
 --
 -- Name: member_app_waiting_reasons; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE member_app_waiting_reasons (
+CREATE TABLE public.member_app_waiting_reasons (
     id bigint NOT NULL,
     name_sv character varying,
     description_sv character varying,
@@ -314,49 +313,49 @@ CREATE TABLE member_app_waiting_reasons (
 -- Name: TABLE member_app_waiting_reasons; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON TABLE member_app_waiting_reasons IS 'reasons why SHF is waiting for more info from applicant. Add more columns when more locales needed.';
+COMMENT ON TABLE public.member_app_waiting_reasons IS 'reasons why SHF is waiting for more info from applicant. Add more columns when more locales needed.';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.name_sv; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN member_app_waiting_reasons.name_sv IS 'name of the reason in svenska/Swedish';
+COMMENT ON COLUMN public.member_app_waiting_reasons.name_sv IS 'name of the reason in svenska/Swedish';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.description_sv; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN member_app_waiting_reasons.description_sv IS 'description for the reason in svenska/Swedish';
+COMMENT ON COLUMN public.member_app_waiting_reasons.description_sv IS 'description for the reason in svenska/Swedish';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.name_en; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN member_app_waiting_reasons.name_en IS 'name of the reason in engelsk/English';
+COMMENT ON COLUMN public.member_app_waiting_reasons.name_en IS 'name of the reason in engelsk/English';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.description_en; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN member_app_waiting_reasons.description_en IS 'description for the reason in engelsk/English';
+COMMENT ON COLUMN public.member_app_waiting_reasons.description_en IS 'description for the reason in engelsk/English';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.is_custom; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN member_app_waiting_reasons.is_custom IS 'was this entered as a new ''custom'' reason?';
+COMMENT ON COLUMN public.member_app_waiting_reasons.is_custom IS 'was this entered as a new ''custom'' reason?';
 
 
 --
 -- Name: member_app_waiting_reasons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE member_app_waiting_reasons_id_seq
+CREATE SEQUENCE public.member_app_waiting_reasons_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -368,14 +367,14 @@ CREATE SEQUENCE member_app_waiting_reasons_id_seq
 -- Name: member_app_waiting_reasons_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE member_app_waiting_reasons_id_seq OWNED BY member_app_waiting_reasons.id;
+ALTER SEQUENCE public.member_app_waiting_reasons_id_seq OWNED BY public.member_app_waiting_reasons.id;
 
 
 --
 -- Name: member_pages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE member_pages (
+CREATE TABLE public.member_pages (
     id bigint NOT NULL,
     filename character varying NOT NULL,
     title character varying,
@@ -388,7 +387,7 @@ CREATE TABLE member_pages (
 -- Name: member_pages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE member_pages_id_seq
+CREATE SEQUENCE public.member_pages_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -400,14 +399,14 @@ CREATE SEQUENCE member_pages_id_seq
 -- Name: member_pages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE member_pages_id_seq OWNED BY member_pages.id;
+ALTER SEQUENCE public.member_pages_id_seq OWNED BY public.member_pages.id;
 
 
 --
 -- Name: membership_number_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE membership_number_seq
+CREATE SEQUENCE public.membership_number_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -419,7 +418,7 @@ CREATE SEQUENCE membership_number_seq
 -- Name: payments; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE payments (
+CREATE TABLE public.payments (
     id bigint NOT NULL,
     user_id bigint,
     company_id bigint,
@@ -438,7 +437,7 @@ CREATE TABLE payments (
 -- Name: payments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE payments_id_seq
+CREATE SEQUENCE public.payments_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -450,14 +449,14 @@ CREATE SEQUENCE payments_id_seq
 -- Name: payments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE payments_id_seq OWNED BY payments.id;
+ALTER SEQUENCE public.payments_id_seq OWNED BY public.payments.id;
 
 
 --
 -- Name: regions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE regions (
+CREATE TABLE public.regions (
     id bigint NOT NULL,
     name character varying,
     code character varying,
@@ -470,7 +469,7 @@ CREATE TABLE regions (
 -- Name: regions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE regions_id_seq
+CREATE SEQUENCE public.regions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -482,14 +481,14 @@ CREATE SEQUENCE regions_id_seq
 -- Name: regions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE regions_id_seq OWNED BY regions.id;
+ALTER SEQUENCE public.regions_id_seq OWNED BY public.regions.id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schema_migrations (
+CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
 
@@ -498,7 +497,7 @@ CREATE TABLE schema_migrations (
 -- Name: shf_applications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE shf_applications (
+CREATE TABLE public.shf_applications (
     id bigint NOT NULL,
     company_number character varying,
     phone_number character varying,
@@ -517,7 +516,7 @@ CREATE TABLE shf_applications (
 -- Name: shf_applications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE shf_applications_id_seq
+CREATE SEQUENCE public.shf_applications_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -529,14 +528,14 @@ CREATE SEQUENCE shf_applications_id_seq
 -- Name: shf_applications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE shf_applications_id_seq OWNED BY shf_applications.id;
+ALTER SEQUENCE public.shf_applications_id_seq OWNED BY public.shf_applications.id;
 
 
 --
 -- Name: shf_documents; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE shf_documents (
+CREATE TABLE public.shf_documents (
     id bigint NOT NULL,
     uploader_id bigint NOT NULL,
     title character varying,
@@ -554,7 +553,7 @@ CREATE TABLE shf_documents (
 -- Name: shf_documents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE shf_documents_id_seq
+CREATE SEQUENCE public.shf_documents_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -566,14 +565,14 @@ CREATE SEQUENCE shf_documents_id_seq
 -- Name: shf_documents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE shf_documents_id_seq OWNED BY shf_documents.id;
+ALTER SEQUENCE public.shf_documents_id_seq OWNED BY public.shf_documents.id;
 
 
 --
 -- Name: uploaded_files; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE uploaded_files (
+CREATE TABLE public.uploaded_files (
     id bigint NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
@@ -589,7 +588,7 @@ CREATE TABLE uploaded_files (
 -- Name: uploaded_files_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE uploaded_files_id_seq
+CREATE SEQUENCE public.uploaded_files_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -601,14 +600,14 @@ CREATE SEQUENCE uploaded_files_id_seq
 -- Name: uploaded_files_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE uploaded_files_id_seq OWNED BY uploaded_files.id;
+ALTER SEQUENCE public.uploaded_files_id_seq OWNED BY public.uploaded_files.id;
 
 
 --
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE users (
+CREATE TABLE public.users (
     id bigint NOT NULL,
     email character varying DEFAULT ''::character varying NOT NULL,
     encrypted_password character varying DEFAULT ''::character varying NOT NULL,
@@ -638,7 +637,7 @@ CREATE TABLE users (
 -- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE users_id_seq
+CREATE SEQUENCE public.users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -650,119 +649,119 @@ CREATE SEQUENCE users_id_seq
 -- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE users_id_seq OWNED BY users.id;
+ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
 -- Name: addresses id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY addresses ALTER COLUMN id SET DEFAULT nextval('addresses_id_seq'::regclass);
+ALTER TABLE ONLY public.addresses ALTER COLUMN id SET DEFAULT nextval('public.addresses_id_seq'::regclass);
 
 
 --
 -- Name: app_configurations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY app_configurations ALTER COLUMN id SET DEFAULT nextval('app_configurations_id_seq'::regclass);
+ALTER TABLE ONLY public.app_configurations ALTER COLUMN id SET DEFAULT nextval('public.app_configurations_id_seq'::regclass);
 
 
 --
 -- Name: business_categories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY business_categories ALTER COLUMN id SET DEFAULT nextval('business_categories_id_seq'::regclass);
+ALTER TABLE ONLY public.business_categories ALTER COLUMN id SET DEFAULT nextval('public.business_categories_id_seq'::regclass);
 
 
 --
 -- Name: business_categories_shf_applications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY business_categories_shf_applications ALTER COLUMN id SET DEFAULT nextval('business_categories_shf_applications_id_seq'::regclass);
+ALTER TABLE ONLY public.business_categories_shf_applications ALTER COLUMN id SET DEFAULT nextval('public.business_categories_shf_applications_id_seq'::regclass);
 
 
 --
 -- Name: ckeditor_assets id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ckeditor_assets ALTER COLUMN id SET DEFAULT nextval('ckeditor_assets_id_seq'::regclass);
+ALTER TABLE ONLY public.ckeditor_assets ALTER COLUMN id SET DEFAULT nextval('public.ckeditor_assets_id_seq'::regclass);
 
 
 --
 -- Name: companies id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY companies ALTER COLUMN id SET DEFAULT nextval('companies_id_seq'::regclass);
+ALTER TABLE ONLY public.companies ALTER COLUMN id SET DEFAULT nextval('public.companies_id_seq'::regclass);
 
 
 --
 -- Name: kommuns id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY kommuns ALTER COLUMN id SET DEFAULT nextval('kommuns_id_seq'::regclass);
+ALTER TABLE ONLY public.kommuns ALTER COLUMN id SET DEFAULT nextval('public.kommuns_id_seq'::regclass);
 
 
 --
 -- Name: member_app_waiting_reasons id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY member_app_waiting_reasons ALTER COLUMN id SET DEFAULT nextval('member_app_waiting_reasons_id_seq'::regclass);
+ALTER TABLE ONLY public.member_app_waiting_reasons ALTER COLUMN id SET DEFAULT nextval('public.member_app_waiting_reasons_id_seq'::regclass);
 
 
 --
 -- Name: member_pages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY member_pages ALTER COLUMN id SET DEFAULT nextval('member_pages_id_seq'::regclass);
+ALTER TABLE ONLY public.member_pages ALTER COLUMN id SET DEFAULT nextval('public.member_pages_id_seq'::regclass);
 
 
 --
 -- Name: payments id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY payments ALTER COLUMN id SET DEFAULT nextval('payments_id_seq'::regclass);
+ALTER TABLE ONLY public.payments ALTER COLUMN id SET DEFAULT nextval('public.payments_id_seq'::regclass);
 
 
 --
 -- Name: regions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY regions ALTER COLUMN id SET DEFAULT nextval('regions_id_seq'::regclass);
+ALTER TABLE ONLY public.regions ALTER COLUMN id SET DEFAULT nextval('public.regions_id_seq'::regclass);
 
 
 --
 -- Name: shf_applications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY shf_applications ALTER COLUMN id SET DEFAULT nextval('shf_applications_id_seq'::regclass);
+ALTER TABLE ONLY public.shf_applications ALTER COLUMN id SET DEFAULT nextval('public.shf_applications_id_seq'::regclass);
 
 
 --
 -- Name: shf_documents id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY shf_documents ALTER COLUMN id SET DEFAULT nextval('shf_documents_id_seq'::regclass);
+ALTER TABLE ONLY public.shf_documents ALTER COLUMN id SET DEFAULT nextval('public.shf_documents_id_seq'::regclass);
 
 
 --
 -- Name: uploaded_files id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY uploaded_files ALTER COLUMN id SET DEFAULT nextval('uploaded_files_id_seq'::regclass);
+ALTER TABLE ONLY public.uploaded_files ALTER COLUMN id SET DEFAULT nextval('public.uploaded_files_id_seq'::regclass);
 
 
 --
 -- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
 
 
 --
 -- Name: addresses addresses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY addresses
+ALTER TABLE ONLY public.addresses
     ADD CONSTRAINT addresses_pkey PRIMARY KEY (id);
 
 
@@ -770,7 +769,7 @@ ALTER TABLE ONLY addresses
 -- Name: app_configurations app_configurations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY app_configurations
+ALTER TABLE ONLY public.app_configurations
     ADD CONSTRAINT app_configurations_pkey PRIMARY KEY (id);
 
 
@@ -778,7 +777,7 @@ ALTER TABLE ONLY app_configurations
 -- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ar_internal_metadata
+ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
@@ -786,7 +785,7 @@ ALTER TABLE ONLY ar_internal_metadata
 -- Name: business_categories business_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY business_categories
+ALTER TABLE ONLY public.business_categories
     ADD CONSTRAINT business_categories_pkey PRIMARY KEY (id);
 
 
@@ -794,7 +793,7 @@ ALTER TABLE ONLY business_categories
 -- Name: business_categories_shf_applications business_categories_shf_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY business_categories_shf_applications
+ALTER TABLE ONLY public.business_categories_shf_applications
     ADD CONSTRAINT business_categories_shf_applications_pkey PRIMARY KEY (id);
 
 
@@ -802,7 +801,7 @@ ALTER TABLE ONLY business_categories_shf_applications
 -- Name: ckeditor_assets ckeditor_assets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ckeditor_assets
+ALTER TABLE ONLY public.ckeditor_assets
     ADD CONSTRAINT ckeditor_assets_pkey PRIMARY KEY (id);
 
 
@@ -810,7 +809,7 @@ ALTER TABLE ONLY ckeditor_assets
 -- Name: companies companies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY companies
+ALTER TABLE ONLY public.companies
     ADD CONSTRAINT companies_pkey PRIMARY KEY (id);
 
 
@@ -818,7 +817,7 @@ ALTER TABLE ONLY companies
 -- Name: kommuns kommuns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY kommuns
+ALTER TABLE ONLY public.kommuns
     ADD CONSTRAINT kommuns_pkey PRIMARY KEY (id);
 
 
@@ -826,7 +825,7 @@ ALTER TABLE ONLY kommuns
 -- Name: member_app_waiting_reasons member_app_waiting_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY member_app_waiting_reasons
+ALTER TABLE ONLY public.member_app_waiting_reasons
     ADD CONSTRAINT member_app_waiting_reasons_pkey PRIMARY KEY (id);
 
 
@@ -834,7 +833,7 @@ ALTER TABLE ONLY member_app_waiting_reasons
 -- Name: member_pages member_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY member_pages
+ALTER TABLE ONLY public.member_pages
     ADD CONSTRAINT member_pages_pkey PRIMARY KEY (id);
 
 
@@ -842,7 +841,7 @@ ALTER TABLE ONLY member_pages
 -- Name: payments payments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY payments
+ALTER TABLE ONLY public.payments
     ADD CONSTRAINT payments_pkey PRIMARY KEY (id);
 
 
@@ -850,7 +849,7 @@ ALTER TABLE ONLY payments
 -- Name: regions regions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY regions
+ALTER TABLE ONLY public.regions
     ADD CONSTRAINT regions_pkey PRIMARY KEY (id);
 
 
@@ -858,7 +857,7 @@ ALTER TABLE ONLY regions
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schema_migrations
+ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
@@ -866,7 +865,7 @@ ALTER TABLE ONLY schema_migrations
 -- Name: shf_applications shf_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY shf_applications
+ALTER TABLE ONLY public.shf_applications
     ADD CONSTRAINT shf_applications_pkey PRIMARY KEY (id);
 
 
@@ -874,7 +873,7 @@ ALTER TABLE ONLY shf_applications
 -- Name: shf_documents shf_documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY shf_documents
+ALTER TABLE ONLY public.shf_documents
     ADD CONSTRAINT shf_documents_pkey PRIMARY KEY (id);
 
 
@@ -882,7 +881,7 @@ ALTER TABLE ONLY shf_documents
 -- Name: uploaded_files uploaded_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY uploaded_files
+ALTER TABLE ONLY public.uploaded_files
     ADD CONSTRAINT uploaded_files_pkey PRIMARY KEY (id);
 
 
@@ -890,7 +889,7 @@ ALTER TABLE ONLY uploaded_files
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users
+ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
@@ -898,219 +897,219 @@ ALTER TABLE ONLY users
 -- Name: index_addresses_on_addressable_type_and_addressable_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_addresses_on_addressable_type_and_addressable_id ON addresses USING btree (addressable_type, addressable_id);
+CREATE INDEX index_addresses_on_addressable_type_and_addressable_id ON public.addresses USING btree (addressable_type, addressable_id);
 
 
 --
 -- Name: index_addresses_on_kommun_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_addresses_on_kommun_id ON addresses USING btree (kommun_id);
+CREATE INDEX index_addresses_on_kommun_id ON public.addresses USING btree (kommun_id);
 
 
 --
 -- Name: index_addresses_on_latitude_and_longitude; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_addresses_on_latitude_and_longitude ON addresses USING btree (latitude, longitude);
+CREATE INDEX index_addresses_on_latitude_and_longitude ON public.addresses USING btree (latitude, longitude);
 
 
 --
 -- Name: index_addresses_on_region_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_addresses_on_region_id ON addresses USING btree (region_id);
+CREATE INDEX index_addresses_on_region_id ON public.addresses USING btree (region_id);
 
 
 --
 -- Name: index_application_company; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_application_company ON companies_shf_applications USING btree (shf_application_id, company_id);
+CREATE INDEX index_application_company ON public.companies_shf_applications USING btree (shf_application_id, company_id);
 
 
 --
 -- Name: index_ckeditor_assets_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ckeditor_assets_on_company_id ON ckeditor_assets USING btree (company_id);
+CREATE INDEX index_ckeditor_assets_on_company_id ON public.ckeditor_assets USING btree (company_id);
 
 
 --
 -- Name: index_ckeditor_assets_on_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ckeditor_assets_on_type ON ckeditor_assets USING btree (type);
+CREATE INDEX index_ckeditor_assets_on_type ON public.ckeditor_assets USING btree (type);
 
 
 --
 -- Name: index_companies_on_company_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_companies_on_company_number ON companies USING btree (company_number);
+CREATE UNIQUE INDEX index_companies_on_company_number ON public.companies USING btree (company_number);
 
 
 --
 -- Name: index_company_application; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_company_application ON companies_shf_applications USING btree (company_id, shf_application_id);
+CREATE INDEX index_company_application ON public.companies_shf_applications USING btree (company_id, shf_application_id);
 
 
 --
 -- Name: index_on_applications; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_on_applications ON business_categories_shf_applications USING btree (shf_application_id);
+CREATE INDEX index_on_applications ON public.business_categories_shf_applications USING btree (shf_application_id);
 
 
 --
 -- Name: index_on_categories; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_on_categories ON business_categories_shf_applications USING btree (business_category_id);
+CREATE INDEX index_on_categories ON public.business_categories_shf_applications USING btree (business_category_id);
 
 
 --
 -- Name: index_payments_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_payments_on_company_id ON payments USING btree (company_id);
+CREATE INDEX index_payments_on_company_id ON public.payments USING btree (company_id);
 
 
 --
 -- Name: index_payments_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_payments_on_user_id ON payments USING btree (user_id);
+CREATE INDEX index_payments_on_user_id ON public.payments USING btree (user_id);
 
 
 --
 -- Name: index_shf_applications_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_shf_applications_on_company_id ON shf_applications USING btree (company_id);
+CREATE INDEX index_shf_applications_on_company_id ON public.shf_applications USING btree (company_id);
 
 
 --
 -- Name: index_shf_applications_on_member_app_waiting_reasons_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_shf_applications_on_member_app_waiting_reasons_id ON shf_applications USING btree (member_app_waiting_reasons_id);
+CREATE INDEX index_shf_applications_on_member_app_waiting_reasons_id ON public.shf_applications USING btree (member_app_waiting_reasons_id);
 
 
 --
 -- Name: index_shf_applications_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_shf_applications_on_user_id ON shf_applications USING btree (user_id);
+CREATE INDEX index_shf_applications_on_user_id ON public.shf_applications USING btree (user_id);
 
 
 --
 -- Name: index_shf_documents_on_uploader_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_shf_documents_on_uploader_id ON shf_documents USING btree (uploader_id);
+CREATE INDEX index_shf_documents_on_uploader_id ON public.shf_documents USING btree (uploader_id);
 
 
 --
 -- Name: index_uploaded_files_on_shf_application_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_uploaded_files_on_shf_application_id ON uploaded_files USING btree (shf_application_id);
+CREATE INDEX index_uploaded_files_on_shf_application_id ON public.uploaded_files USING btree (shf_application_id);
 
 
 --
 -- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_email ON users USING btree (email);
+CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
 
 
 --
 -- Name: index_users_on_membership_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_membership_number ON users USING btree (membership_number);
+CREATE UNIQUE INDEX index_users_on_membership_number ON public.users USING btree (membership_number);
 
 
 --
 -- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_reset_password_token ON users USING btree (reset_password_token);
+CREATE UNIQUE INDEX index_users_on_reset_password_token ON public.users USING btree (reset_password_token);
 
 
 --
 -- Name: payments fk_rails_081dc04a02; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY payments
-    ADD CONSTRAINT fk_rails_081dc04a02 FOREIGN KEY (user_id) REFERENCES users(id);
+ALTER TABLE ONLY public.payments
+    ADD CONSTRAINT fk_rails_081dc04a02 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
 -- Name: payments fk_rails_0fc68a9316; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY payments
-    ADD CONSTRAINT fk_rails_0fc68a9316 FOREIGN KEY (company_id) REFERENCES companies(id);
+ALTER TABLE ONLY public.payments
+    ADD CONSTRAINT fk_rails_0fc68a9316 FOREIGN KEY (company_id) REFERENCES public.companies(id);
 
 
 --
 -- Name: ckeditor_assets fk_rails_1b8d2a3863; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ckeditor_assets
-    ADD CONSTRAINT fk_rails_1b8d2a3863 FOREIGN KEY (company_id) REFERENCES companies(id);
+ALTER TABLE ONLY public.ckeditor_assets
+    ADD CONSTRAINT fk_rails_1b8d2a3863 FOREIGN KEY (company_id) REFERENCES public.companies(id);
 
 
 --
 -- Name: uploaded_files fk_rails_2224289299; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY uploaded_files
-    ADD CONSTRAINT fk_rails_2224289299 FOREIGN KEY (shf_application_id) REFERENCES shf_applications(id);
+ALTER TABLE ONLY public.uploaded_files
+    ADD CONSTRAINT fk_rails_2224289299 FOREIGN KEY (shf_application_id) REFERENCES public.shf_applications(id);
 
 
 --
 -- Name: shf_applications fk_rails_3ee395b045; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY shf_applications
-    ADD CONSTRAINT fk_rails_3ee395b045 FOREIGN KEY (member_app_waiting_reasons_id) REFERENCES member_app_waiting_reasons(id);
+ALTER TABLE ONLY public.shf_applications
+    ADD CONSTRAINT fk_rails_3ee395b045 FOREIGN KEY (member_app_waiting_reasons_id) REFERENCES public.member_app_waiting_reasons(id);
 
 
 --
 -- Name: addresses fk_rails_76a66052a5; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY addresses
-    ADD CONSTRAINT fk_rails_76a66052a5 FOREIGN KEY (kommun_id) REFERENCES kommuns(id);
+ALTER TABLE ONLY public.addresses
+    ADD CONSTRAINT fk_rails_76a66052a5 FOREIGN KEY (kommun_id) REFERENCES public.kommuns(id);
 
 
 --
 -- Name: shf_documents fk_rails_bb6df17516; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY shf_documents
-    ADD CONSTRAINT fk_rails_bb6df17516 FOREIGN KEY (uploader_id) REFERENCES users(id);
+ALTER TABLE ONLY public.shf_documents
+    ADD CONSTRAINT fk_rails_bb6df17516 FOREIGN KEY (uploader_id) REFERENCES public.users(id);
 
 
 --
 -- Name: shf_applications fk_rails_be394644c4; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY shf_applications
-    ADD CONSTRAINT fk_rails_be394644c4 FOREIGN KEY (user_id) REFERENCES users(id);
+ALTER TABLE ONLY public.shf_applications
+    ADD CONSTRAINT fk_rails_be394644c4 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
 -- Name: addresses fk_rails_f7aa0f06a9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY addresses
-    ADD CONSTRAINT fk_rails_f7aa0f06a9 FOREIGN KEY (region_id) REFERENCES regions(id);
+ALTER TABLE ONLY public.addresses
+    ADD CONSTRAINT fk_rails_f7aa0f06a9 FOREIGN KEY (region_id) REFERENCES public.regions(id);
 
 
 --

--- a/spec/mailers/shared_email_tests.rb
+++ b/spec/mailers/shared_email_tests.rb
@@ -19,8 +19,10 @@ end
 #   Does *not* include any text about 'email us with questions...'
 RSpec.shared_examples 'a successfully created email' do |subject, recipient, greeting_name, signoff, signature|
 
-  DEFAULT_SIGNOFF =   I18n.t('mailers.application_mailer.signoff')
-  DEFAULT_SIGNATURE = I18n.t('mailers.application_mailer.signature')
+  DEFAULT_SIGNOFF =   I18n.t('mailers.application_mailer.signoff') unless
+                        defined?(DEFAULT_SIGNOFF)
+  DEFAULT_SIGNATURE = I18n.t('mailers.application_mailer.signature') unless
+                        defined?(DEFAULT_SIGNATURE)
 
   it 'subject is correct' do
     expect(email_created).to have_subject(subject)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/156008599


Changes proposed in this pull request:
1. Upgraded to Ruby 2.4.3 in order to remove deprecation warnings for spec tests
2. Adjusted a couple of constant declaration statement to remove another set of warning messages when reassigning the same constants during tests.

The first warning arose from the ruby parser gem.  This is currently set to _not_ issue warnings for the latest minor version of 2.4 (that is, 2.4.3).  (I am not sure whether the warning would reappear when we got to Ruby 2.5, but we'll have to watch for that.)


Ready for review:
@AgileVentures/shf-project-team 