### PR TITLE
Changed to new method names for User validation (avoid deprecation warnings)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,18 @@ class User < ApplicationRecord
                                     content_type:  /\Aimage\/.*(jpg|jpeg|png)\z/
   validates_attachment_file_name :member_photo, matches: [/png\z/, /jpe?g\z/, /PNG\z/,/JPE?G\z/]
 
-  validates_presence_of :first_name, :last_name, unless: Proc.new {!new_record? && !(first_name_changed? || last_name_changed?)}
+  validates_presence_of :first_name, :last_name, unless: :updating_without_name_changes
+
+  def updating_without_name_changes
+    # Not a new record and not saving changes to either first or last name
+
+    # https://github.com/rails/rails/pull/25337#issuecomment-225166796
+    # ^^ Useful background
+
+    !new_record? && !(will_save_change_to_attribute?('first_name') ||
+                      will_save_change_to_attribute?('last_name'))
+  end
+
   validates_uniqueness_of :membership_number, allow_blank: true
 
   scope :admins, -> { where(admin: true) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
                                     content_type:  /\Aimage\/.*(jpg|jpeg|png)\z/
   validates_attachment_file_name :member_photo, matches: [/png\z/, /jpe?g\z/, /PNG\z/,/JPE?G\z/]
 
-  validates_presence_of :first_name, :last_name, unless: :updating_without_name_changes
+  validates :first_name, :last_name, presence: true, unless: :updating_without_name_changes
 
   def updating_without_name_changes
     # Not a new record and not saving changes to either first or last name
@@ -34,7 +34,7 @@ class User < ApplicationRecord
                       will_save_change_to_attribute?('last_name'))
   end
 
-  validates_uniqueness_of :membership_number, allow_blank: true
+  validates :membership_number, uniqueness: true, allow_blank: true
 
   scope :admins, -> { where(admin: true) }
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/156023834


Changes proposed in this pull request:

1. Changed User model validation to use new method names in place to to-be-deprecated methods in next version of rails.  (see deprecation message in PT story).


Ready for review:
@AgileVentures/shf-project-team 