### PR TITLE
Removed deprecated cucumber tags

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,7 +1,7 @@
 <%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags ~@wip"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags 'not @wip'"
 %>
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -12,7 +12,7 @@ Before('@selenium_browser') do
  Capybara.current_driver = :selenium_browser
 end
 
-After('@selenium, @selenium_browser') do
+After('@selenium or @selenium_browser') do
   ajax_active = !page.evaluate_script('window.jQuery ? jQuery.active : 0').zero?
   Capybara.reset_sessions!
   Capybara.current_driver = :rack_test


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/156039684


Changes proposed in this pull request:
1. Changed tags in our code base.

**NOTE** The remaining warnings are coming from included gem(s), e.g. `cucumber-rails`.  These should go away when the specific gem(s) are updated.

See: https://github.com/cucumber/cucumber-rails/issues/346

The remaining warnings are:

Deprecated: Found tagged hook with '~@javascript'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead.
Deprecated: Found tagged hook with '~@no-database-cleaner'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead.
Deprecated: Found tagged hook with '~@no-database-cleaner'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead.
Deprecated: Found tagged hook with '~@no-js-emulation'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead.



Ready for review:
@AgileVentures/shf-project-team 