### PR TITLE
Move js to js erb to remove additional logic and partial rendering from controller

### DIFF
--- a/app/assets/javascripts/companies.js
+++ b/app/assets/javascripts/companies.js
@@ -1,12 +1,6 @@
 $(function() {
   'use strict';
 
-  $('body').on('ajax:success', '.companies_pagination', function (e, data) {
-    $('#companies_list').html(data);
-    // In case there is tooltip(s) in rendered element:
-    $('[data-toggle="tooltip"]').tooltip();
-  });
-
   $('#brandingStatusForm').on('ajax:success', function (e, data) {
     $('#company-branding-status').html(data);
     $('[data-toggle="tooltip"]').tooltip();

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -37,8 +37,7 @@ class CompaniesController < ApplicationController
     @all_visible_companies.each { |co| geocode_if_needed co }
 
     @companies = @all_companies.page(params[:page]).per_page(items_per_page)
-
-    render partial: 'companies_list' if request.xhr?
+    respond_to :js, :html
   end
 
   def show

--- a/app/views/companies/_companies_list.html.haml
+++ b/app/views/companies/_companies_list.html.haml
@@ -26,7 +26,7 @@
           %th
 
     %tbody
-      - @companies.each do |company|
+      - companies.each do |company|
         %tr.company
           %td{ style: 'white-space: nowrap;' }
             = safe_join(company.categories_names, tag.br)
@@ -41,7 +41,7 @@
               %td= link_to "#{t('delete')}", company, method: :delete,
                               data: { :confirm => "#{t('confirm_are_you_sure')}" }
 
-  = render 'application/paginate_footer', entities: @companies,
+  = render 'application/paginate_footer', entities: companies,
                                           paginate_class: 'companies_pagination',
                                           items_count: @items_count,
                                           url: companies_path

--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -5,6 +5,7 @@
     %h1.entry-title= t('.admin_title')
 
 .entry-content
+
   .row
     = render 'map_companies',
              markers: location_and_markers_for(@all_visible_companies)
@@ -32,4 +33,4 @@
     %strong
       #{t('.no_search_results')}
   - else
-    = render 'companies_list'
+    = render 'companies_list', companies: @companies

--- a/app/views/companies/index.js.erb
+++ b/app/views/companies/index.js.erb
@@ -1,0 +1,3 @@
+$('#companies_list').html("<%= j(render 'companies_list', companies: @companies) %>");
+// In case there is tooltip(s) in rendered element:
+$('[data-toggle="tooltip"]').tooltip();


### PR DESCRIPTION
when I was changing another things in views I realised that there is additional logic in controllers that is not necessary because we can move it to js erb and because of that remove using instance variables in partial
