### PR TITLE
fixed bug in app-create when file-upload fails

### DIFF
--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -66,7 +66,9 @@ class ShfApplicationsController < ApplicationController
         helpers.flash_message(:notice, t('.success', email_address: @shf_application.contact_email))
         redirect_to information_path
       else
-        create_error(t('.error'))
+        helpers.flash_message(:notice, t('.success_with_file_problem'))
+        load_update_objects
+        render :edit
       end
 
     else

--- a/app/views/shf_applications/edit.html.haml
+++ b/app/views/shf_applications/edit.html.haml
@@ -10,7 +10,7 @@
 
       = render partial: 'membership_number', locals: { user: @shf_application.user }
 
-      = form_for @shf_application, html: {multipart: true}, url: shf_application_path do |f|
+      = form_for @shf_application do |f|
 
         != model_errors_helper(@shf_application)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -314,6 +314,7 @@ en:
     create:
       success: "Thank You. Your membership application has been submitted. You should receive an email shortly at %{email_address} with information about what to expect next."
       error: The was a problem creating and submitting your application.
+      success_with_file_problem: YOUR APPLICATION WAS CREATED, BUT PLEASE NOTE PROBLEM(S) ABOVE
 
     edit:
       title: Edit Membership Application

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -315,6 +315,7 @@ sv:
     create:
       success: "Tack, din ansökan har skickats. Du borde få en bekräftelse inom kort till %{email_address}."
       error: Ett eller flera problem hindrade din ansökan från att skickas.
+      success_with_file_problem: DIN ANSÖKAN SKAPAS, MEN OBSERVERA PROBLEM (ER) OVANFÖR
 
     edit:
       title: Redigera ansökan om medlemskap
@@ -667,7 +668,7 @@ sv:
       membership_expire_date_tooltip: Efter detta datum går perioden för ditt medlemskap ut.
       proof_of_membership: Behörighetsbevis
       proof_of_membership_describe: Detta är ditt behörighetsbevis.
-      proof_of_membership_photo_needed: 'Om du ser "Photo Unavailable" ladda 
+      proof_of_membership_photo_needed: 'Om du ser "Photo Unavailable" ladda
                                          sedan upp ett foto av dig själv här: '
       proof_of_membership_image: Du kan ladda ner den här bilden och använda den
                                  som du vill, inklusive på din webbplats, eller

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -315,7 +315,7 @@ sv:
     create:
       success: "Tack, din ansökan har skickats. Du borde få en bekräftelse inom kort till %{email_address}."
       error: Ett eller flera problem hindrade din ansökan från att skickas.
-      success_with_file_problem: DIN ANSÖKAN SKAPAS, MEN OBSERVERA PROBLEM (ER) OVANFÖR
+      success_with_file_problem: DIN ANSÖKAN HAR SKAPATS, MEN OBSERVERA FELMEDDELANDE(N) OVAN
 
     edit:
       title: Redigera ansökan om medlemskap

--- a/features/size_validation.feature
+++ b/features/size_validation.feature
@@ -30,6 +30,22 @@ Feature: Applicant uploads too large a file for their application
     Then I should see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large")
     And I should not see t("shf_applications.create.success")
 
+  Scenario: New application - Uploads a file that is too large then uploads ok file
+    Given I am logged in as "hans@new_applicant.se"
+    And I am on the "submit new membership application" page
+    When I fill in the form with data:
+      | shf_application_company_number | shf_application_phone_number | shf_application_contact_email |
+      | 5560360793                     | 031-1234567                  | applicant_2@random.com        |
+    And I choose a file named "diploma_huge.pdf" to upload
+    When I click on t("shf_applications.new.submit_button_label")
+    Then I should see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large")
+    And I should see t("shf_applications.create.success_with_file_problem")
+
+    Then I choose a file named "diploma.pdf" to upload
+    When I click on t("shf_applications.edit.submit_button_label")
+
+    And I should see t("shf_applications.update.success")
+
 
   Scenario: New application - Uploads a file just under the size limit
     Given I am logged in as "hans@new_applicant.se"
@@ -50,6 +66,19 @@ Feature: Applicant uploads too large a file for their application
     When I click on t("shf_applications.edit.submit_button_label")
     Then I should see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large")
     And I should not see t("shf_applications.update.success")
+
+  Scenario: Existing application - Uploads a file that is too large then uploads ok file
+    Given I am logged in as "emma@happymutts.se"
+    And I am on the "edit my application" page
+    And I choose a file named "diploma_huge.pdf" to upload
+    When I click on t("shf_applications.edit.submit_button_label")
+    Then I should see t("activerecord.errors.models.uploaded_file.attributes.actual_file_file_size.file_too_large")
+    And I should not see t("shf_applications.update.success")
+
+    Then I choose a file named "diploma.pdf" to upload
+    When I click on t("shf_applications.edit.submit_button_label")
+
+    And I should see t("shf_applications.update.success")
 
 
   Scenario: Existing application - Uploads a file just under the size limit


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/155908873


Changes proposed in this pull request:

1. The application (app) is created, and then the user-specified file is uploaded.  However, the file upload can fail due to model validations (e.g. file is larger than allowed).  The user is then put back into the `new` view.  If the user then specifies another file and clicks "submit", the `create` action fails (due to routing error) and a second application for the user has been created (the first now being an "orphan", with no connection to a user). 

To fix this, in `create`, if there is a problem with the file upload (after the app has been created), we:

1. Add flash message telling the user that the application was created, but that there was a problem with a file upload,
2. Render the `edit` view (which will route the form submit to the `update` action, of course).

The user sees two sets of flash messages as shown in screenshots.

Screenshots (Optional):
---

<img width="873" alt="screen shot 2018-03-25 at 1 49 15 pm" src="https://user-images.githubusercontent.com/9968213/37878498-4131eeb0-3038-11e8-93c9-1a7fb74f9db6.png">

---
<img width="929" alt="screen shot 2018-03-25 at 1 51 57 pm" src="https://user-images.githubusercontent.com/9968213/37878500-44f2040e-3038-11e8-81fb-0adb21828789.png">
---


Ready for review:
@AgileVentures/shf-project-team 