### PR TITLE
Hide non-searchable companies from search list, also hide these in category "show" view

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,7 +31,7 @@ Lint/AssignmentInCondition:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition'
   Enabled: true
 
-Lint/BlockAlignment:
+Layout/BlockAlignment:
   Description: 'Align block ends correctly.'
   Enabled: true
 
@@ -39,7 +39,7 @@ Lint/CircularArgumentReference:
   Description: "Don't refer to the keyword argument in the default value."
   Enabled: true
 
-Lint/ConditionPosition:
+Layout/ConditionPosition:
   Description: >-
                  Checks for condition placed in a confusing position relative to
                  the keyword.
@@ -50,7 +50,7 @@ Lint/Debugger:
   Description: 'Check for debugger calls.'
   Enabled: true
 
-Lint/DefEndAlignment:
+Layout/DefEndAlignment:
   Description: 'Align ends corresponding to defs correctly.'
   Enabled: true
 
@@ -78,7 +78,7 @@ Lint/EmptyInterpolation:
   Description: 'Checks for empty string interpolation.'
   Enabled: true
 
-Lint/EndAlignment:
+Layout/EndAlignment:
   Description: 'Align ends correctly.'
   Enabled: true
 
@@ -157,7 +157,7 @@ Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: true
 
-Lint/UnneededDisable:
+Lint/UnneededCopDisableDirective:
   Description: >-
                  Checks for rubocop:disable comments that can be removed.
                  Note: this cop is not disabled when disabling all cops.

--- a/app/controllers/business_categories_controller.rb
+++ b/app/controllers/business_categories_controller.rb
@@ -11,7 +11,9 @@ class BusinessCategoriesController < ApplicationController
 
   def show
 
-    @companies = @business_category.companies.includes(:addresses).complete.order(:name)
+    @companies = @business_category.companies.includes(:addresses).order(:name)
+
+    @companies = @companies.searchable unless current_user.admin?
 
   end
 

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -25,12 +25,7 @@ class CompaniesController < ApplicationController
     # allowing sorting on an associated table column ("region" in this case)
     # https://github.com/activerecord-hackery/ransack#problem-with-distinct-selects
 
-    unless current_user.admin?
-      @all_companies = @all_companies
-                           .branding_licensed
-                           .with_members
-                           .complete
-    end
+    @all_companies = @all_companies.searchable unless current_user.admin?
 
     @all_visible_companies = @all_companies.address_visible
 

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -111,6 +111,11 @@ class Company < ApplicationRecord
       .joins(:users).where('users.member = ?', true).distinct
   end
 
+  def self.searchable
+    # Criteria limiting visibility of companies to non-admin users
+    complete.with_members.branding_licensed
+  end
+
   def destroy_checks
 
     error_if_has_applications?

--- a/app/views/companies/_search_form.html.haml
+++ b/app/views/companies/_search_form.html.haml
@@ -42,7 +42,7 @@
                 class: 'control-label',
                 style: 'text-align: left; font-size: 12px;'
       = f.collection_select :name_in,
-                      Company.complete.order(:name),
+                      Company.searchable.order(:name),
                       :name, :name, { include_blank: false },
                       { multiple: true, size: 5, style: 'width: 100%;',
                         class: 'form-control search_field',

--- a/features/admin_creates_company.feature
+++ b/features/admin_creates_company.feature
@@ -26,12 +26,13 @@ Feature: As an admin
 
     Given the following kommuns exist:
       | name      |
+      | Stockholm |
       | Bromölla  |
 
     And the following companies exist:
-      | name                 | company_number | email                  | region     |
-      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.com | Stockholm  |
-      | Bowsers              | 2120000142     | bowwow@bowsersy.com    | Norrbotten |
+      | name                 | company_number | email                  | region     | kommun    |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.com | Stockholm  | Stockholm |
+      | Bowsers              | 2120000142     | bowwow@bowsersy.com    | Norrbotten | Bromölla  |
 
     Given the following payments exist
       | user_email                 | start_date | expire_date | payment_type | status | hips_id | company_number |

--- a/features/approve-member.feature
+++ b/features/approve-member.feature
@@ -35,6 +35,7 @@ Feature: As an admin
       | hans@happymutts.se    | 5562252998     | dog grooming | under_review |
       | anna@nosnarkybarky.se | 5560360793     | rehab        | under_review |
 
+
   Scenario: Admin approves, no company exists so one is created
     Given I am logged in as "admin@shf.com"
     And I am on the "application" page for "emma@happymutts.se"
@@ -59,9 +60,6 @@ Feature: As an admin
     And I am on the "all companies" page
     And I should see "No More Snarky Barky"
     And I am Logged out
-    And I am on the "landing" page
-    And I should see "No More Snarky Barky"
-    And I should see "rehab"
 
     Then I am in "anna@nosnarkybarky.se" browser
     And I am logged in as "anna@nosnarkybarky.se"
@@ -73,6 +71,13 @@ Feature: As an admin
     And I am on the "show my application" page for "anna@nosnarkybarky.se"
     Then I should see t("shf_applications.show.membership_number")
     And I should not see "902"
+
+    Then I am the page for company number "5560360793"
+    Then I complete the branding payment for "No More Snarky Barky"
+
+    Then I am on the "landing" page
+    And I should see "No More Snarky Barky"
+    And I should see "rehab"
 
     Then I am in "admin@shf.com" browser
     And I am logged in as "admin@shf.com"

--- a/features/list_companies_of_category.feature
+++ b/features/list_companies_of_category.feature
@@ -5,11 +5,11 @@ Feature: As any type of visitor
 
   Background:
     Given the following users exists
-      | email               | admin |
-      | emma@happymutts.com |       |
-      | ernt@mutts.com      |       |
-      | anna@sadmutts.com   |       |
-      | admin@shf.se        | true  |
+      | email               | admin | member |
+      | emma@happymutts.com |       | true   |
+      | ernt@mutts.com      |       | true   |
+      | anna@sadmutts.com   |       | true   |
+      | admin@shf.se        | true  |        |
 
     Given the following regions exist:
       | name         |
@@ -42,6 +42,16 @@ Feature: As any type of visitor
       | ernt@mutts.com      | 5569467466     | Awesome    | accepted |
       | anna@sadmutts.com   | 2120000142     | Sadness    | accepted |
 
+    And the following payments exist
+      | user_email           | start_date | expire_date | payment_type | status | hips_id | company_number |
+      | emma@happymutts.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 5562252998     |
+      | ernt@mutts.com       | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 5569467466     |
+      | anna@sadmutts.com    | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 2120000142     |
+      | anna@sadmutts.com    | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |                |
+
+    Given the date is set to "2017-10-01"
+
+  @time_adjust
   Scenario: Categories list multiple businesses
     Given I am Logged out
     And I am on the business category "Awesome"
@@ -51,6 +61,7 @@ Feature: As any type of visitor
     And I should see "Västerbotten"
     And I should not see "Sad Sad Snarky Barky"
 
+  @time_adjust
   Scenario: Categories list businesses
     Given I am Logged out
     And I am on the business category "Sadness"

--- a/features/mapping_and_geocoding/companies_are_geocoded_when_viewing_all.feature
+++ b/features/mapping_and_geocoding/companies_are_geocoded_when_viewing_all.feature
@@ -25,6 +25,7 @@ Feature: All companies are geocoded before being shown on the view all companies
       | email               | admin | member |
       | emma@happymutts.com |       | true   |
       | a@happymutts.com    |       | true   |
+      | me@notvisible.com   |       | true   |
       | admin@shf.se        | true  |        |
 
     And the following business categories exist
@@ -36,11 +37,13 @@ Feature: All companies are geocoded before being shown on the view all companies
       | user_email          | company_number | categories | state    |
       | emma@happymutts.com | 5560360793     | Groomer    | accepted |
       | a@happymutts.com    | 2120000142     | Trainer    | accepted |
+      | me@notvisible.com   | 5569467466     | Trainer    | accepted |
 
     And the following payments exist
       | user_email          | start_date | expire_date | payment_type | status | hips_id | company_number |
       | emma@happymutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 5560360793     |
       | a@happymutts.com    | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 2120000142     |
+      | me@notvisible.com   | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 5569467466     |
 
 
   @time_adjust

--- a/features/search_companies.feature
+++ b/features/search_companies.feature
@@ -11,6 +11,7 @@ Background:
     | john@happymutts.com  |       | true   |
     | anna@dogsrus.com     |       | true   |
     | emma@weluvdogs.com   |       | true   |
+    | lars@nopayment.se    |       | true   |
 
   And the following business categories exist
     | name         |
@@ -39,6 +40,8 @@ Background:
     | HappyMutts  | 2120000142     | woof@happymutts.com  | Västerbotten | Bromölla  |
     | Dogs R Us   | 5562252998     | chief@dogsrus.com    | Norrbotten   | Östersund |
     | We Luv Dogs | 5569467466     | alpha@weluvdogs.com  | Sweden       | Laxå      |
+    | NoPayment   | 8028973322     | hello@nopayment.se   | Stockholm    | Alingsås  |
+    | NoMember    | 9697222900     | hello@nomember.se    | Stockholm    | Alingsås  |
 
   And the following payments exist
     | user_email          | start_date | expire_date | payment_type | status | hips_id | company_number |
@@ -53,18 +56,21 @@ Background:
     | john@happymutts.com | 2120000142     | accepted | Psychologist    |
     | anna@dogsrus.com    | 5562252998     | accepted | Trainer         |
     | emma@weluvdogs.com  | 5569467466     | accepted | Groomer, Walker |
+    | lars@nopayment.se   | 8028973322     | accepted | Groomer, Trainer|
 
   Given the date is set to "2017-10-01"
 
 
 @selenium @time_adjust
-Scenario: View all companies, sort by columns
+Scenario: View all searchable companies, sort by columns
   Given I am Logged out
   And I am on the "landing" page
   And I should see "Barky Boys"
   And I should see "HappyMutts"
   And I should see "Dogs R Us"
   And I should see "We Luv Dogs"
+  And I should not see "NoPayment"
+  And I should not see "NoMember"
   And I click on t("activerecord.attributes.company.region") link
   And I should see "Norrbotten" before "Stockholm"
   And I should see "Stockholm" before "Sweden"
@@ -110,9 +116,11 @@ Scenario: Search by region
   And I should not see "We Luv Dogs"
 
 @selenium @time_adjust
-Scenario: Search by company
+Scenario: Search by company (and confirm cannot search with non-searchable company name)
   Given I am Logged out
   And I am on the "landing" page
+  And I cannot select "NoPayment" in select list t("activerecord.models.company.one")
+  And I cannot select "NoMember" in select list t("activerecord.models.company.one")
   Then I select "We Luv Dogs" in select list t("activerecord.models.company.one")
   And I click on t("search")
   Then I click on t("toggle.company_search_form.hide")

--- a/features/show_only_searchable_companies.feature
+++ b/features/show_only_searchable_companies.feature
@@ -74,21 +74,24 @@ Feature: So that I do not get frustrated by trying to find out more
     And I should not see "NoPayment"
     And I should not see "NoMember"
 
-  @visitor
-  Scenario: Visitor on Kategori - only complete companies are shown
+  @visitor @time_adjust
+  Scenario: Visitor on Kategori - only searchable companies are shown
     Given I am Logged out
     When I am on the business category "Groomer"
-    And show me the page
     Then I should not see "5906055081"
     And I should not see "NoRegion"
     And I should not see "Bowsers"
     And I should not see "2120000142"
+    And I should not see "NoPayment"
+    And I should not see "NoMember"
     And I should see "Happy Mutts"
     When I am on the business category "Trainer"
     Then I should not see "5906055081"
     And I should not see "NoRegion"
     And I should not see "Happy Mutts"
     And I should not see "5560360793"
+    And I should not see "NoPayment"
+    And I should not see "NoMember"
     And I should see "Bowsers"
 
   @member @time_adjust
@@ -102,20 +105,24 @@ Feature: So that I do not get frustrated by trying to find out more
     And I should not see "NoPayment"
     And I should not see "NoMember"
 
-  @member
-  Scenario: Member on Kategori - only complete companies are shown
+  @member @time_adjust
+  Scenario: Member on Kategori - only searchable companies are shown
     Given I am logged in as "emmagroomer@happymutts.com"
     When I am on the business category "Groomer"
     Then I should not see "5906055081"
     And I should not see "NoRegion"
     And I should not see "Bowsers"
     And I should not see "2120000142"
+    And I should not see "NoPayment"
+    And I should not see "NoMember"
     And I should see "Happy Mutts"
     When I am on the business category "Trainer"
     Then I should not see "5906055081"
     And I should not see "NoRegion"
     And I should not see "Happy Mutts"
     And I should not see "5560360793"
+    And I should not see "NoPayment"
+    And I should not see "NoMember"
     And I should see "Bowsers"
 
   @admin @time_adjust
@@ -132,19 +139,14 @@ Feature: So that I do not get frustrated by trying to find out more
     And I should see "NoPayment"
     And I should see "NoMember"
 
-
-  @admin
+  @admin @time_adjust
   Scenario: admin Kategori list - all companies are shown
     Given I am logged in as "admin@shf.se"
     When I am on the business category "Groomer"
-    Then I should not see "5906055081"
-    And I should not see "NoRegion"
-    And I should not see "Bowsers"
-    And I should not see "2120000142"
+    And I should see "NoRegion"
     And I should see "Happy Mutts"
+    And I should see "NoPayment"
     When I am on the business category "Trainer"
-    Then I should not see "5906055081"
-    And I should not see "NoRegion"
-    And I should not see "Happy Mutts"
-    And I should not see "5560360793"
+    And I should see "NoRegion"
     And I should see "Bowsers"
+    And I should see "NoPayment"

--- a/features/show_only_searchable_companies.feature
+++ b/features/show_only_searchable_companies.feature
@@ -27,45 +27,58 @@ Feature: So that I do not get frustrated by trying to find out more
       | Bowsers      | 2120000142     | bowwow@bowsersy.com    | Västerbotten          | Bromölla |
       | NoRegion     | 8028973322     | hello@NoRegion.se      | ThisNameWillBeDeleted | Laxå     |
       |              | 5906055081     | hello@noName.se        | Stockholm             | Alingsås |
+      | NoPayment    | 5562252998     | hello@nopayment.se     | Stockholm             | Alingsås |
+      | NoMember     | 9697222900     | hello@nomember.se      | Stockholm             | Alingsås |
 
     And the following users exists
-      | email                        | admin |
-      | emmagroomer@happymutts.com   |       |
-      | annaTrainer@bowsers.com      |       |
-      | ole@noOldRegion.se           |       |
-      | maja@onlyNoRegion.se         |       |
-      | kikki@noName.se              |       |
-      | larsGroomer@noRegionOrOld.se |       |
-      | larsTrainer@noRegionOrOld.se |       |
-      | admin@shf.se                 | true  |
-
+      | email                        | admin | member |
+      | emmagroomer@happymutts.com   |       | true   |
+      | annatrainer@bowsers.com      |       | true   |
+      | ole@noOldRegion.se           |       | true   |
+      | maja@onlyNoRegion.se         |       | true   |
+      | kikki@noName.se              |       | true   |
+      | lars@nopayment.se            |       | true   |
+      | larsTrainer@noRegionOrOld.se |       | true   |
+      | admin@shf.se                 | true  | false  |
 
     And the following applications exist:
       | user_email                 | company_number | categories       | state    |
-      | emmaGroomer@happymutts.com | 5560360793     | Groomer          | accepted |
-      | annaTrainer@bowsers.com    | 2120000142     | Trainer          | accepted |
+      | emmagroomer@happymutts.com | 5560360793     | Groomer          | accepted |
+      | annatrainer@bowsers.com    | 2120000142     | Trainer          | accepted |
       | ole@noOldRegion.se         | 5569467466     | Groomer, Trainer | accepted |
       | maja@onlyNoRegion.se       | 8028973322     | Groomer, Trainer | accepted |
       | kikki@noName.se            | 5906055081     | Groomer, Trainer | accepted |
+      | lars@nopayment.se          | 5562252998     | Groomer, Trainer | accepted |
 
+    And the following payments exist
+      | user_email                  | start_date | expire_date | payment_type | status | hips_id | company_number |
+      | emmagroomer@happymutts.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 5560360793     |
+      | emmagroomer@happymutts.com  | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |                |
+      | annatrainer@bowsers.com     | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 2120000142     |
+      | annatrainer@bowsers.com     | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |                |
+      | admin@shf.se                | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 9697222900     |
+
+    Given the date is set to "2017-10-01"
     And the region for company named "NoRegion" is set to nil
 
 
-  @visitor
-  Scenario: Visitor on landing page - only complete companies are shown
+  @visitor @time_adjust
+  Scenario: Visitor on landing page - only searchable companies are shown
     Given I am Logged out
-    And the region for company named "NoRegion" is set to nil
     And I am on the "landing" page
     When I click on t("search") button
     Then I should see "Happy Mutts"
     And I should see "Bowsers"
     And I should not see "NoRegion"
     And I should not see "5906055081"
+    And I should not see "NoPayment"
+    And I should not see "NoMember"
 
   @visitor
   Scenario: Visitor on Kategori - only complete companies are shown
     Given I am Logged out
     When I am on the business category "Groomer"
+    And show me the page
     Then I should not see "5906055081"
     And I should not see "NoRegion"
     And I should not see "Bowsers"
@@ -78,14 +91,16 @@ Feature: So that I do not get frustrated by trying to find out more
     And I should not see "5560360793"
     And I should see "Bowsers"
 
-  @member
-  Scenario: Member on landing page - only complete companies are shown
+  @member @time_adjust
+  Scenario: Member on landing page - only searchable companies are shown
     Given I am logged in as "emmagroomer@happymutts.com"
     When I am on the "landing" page
     Then I should see "Happy Mutts"
     And I should see "Bowsers"
     And I should not see "NoRegion"
     And I should not see "5906055081"
+    And I should not see "NoPayment"
+    And I should not see "NoMember"
 
   @member
   Scenario: Member on Kategori - only complete companies are shown
@@ -103,7 +118,7 @@ Feature: So that I do not get frustrated by trying to find out more
     And I should not see "5560360793"
     And I should see "Bowsers"
 
-  @admin
+  @admin @time_adjust
   Scenario: admin is on companies list - all companies are shown
     Given I am logged in as "admin@shf.se"
     When I am on the "all companies" page
@@ -114,6 +129,8 @@ Feature: So that I do not get frustrated by trying to find out more
     And I should see "Bowsers"
     And I should see "2120000142"
     And I should see "5569467466"
+    And I should see "NoPayment"
+    And I should see "NoMember"
 
 
   @admin

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -305,3 +305,7 @@ Then(/^I should get a downloaded image with the filename "([^\"]*)"$/) do |filen
   expect(page.driver.response_headers['Content-Type'])
     .to eq 'image/jpg'
 end
+
+When "I cannot select {capture_string} in select list {capture_string}" do |option, list|
+  expect(find_field(list).text.match(option)).to be_nil
+end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -71,10 +71,6 @@ When "I select {capture_string} in select list {capture_string}" do |option, lis
   select option, from: list
 end
 
-When "I cannot select {capture_string} in select list {capture_string}" do |option, list|
-  expect(find_field(list).text.match(option)).to be_nil
-end
-
 When "I select radio button {capture_string}" do |label_text|
   find(:xpath, "//label[contains(.,'#{label_text}')]/input[@type='radio']").click
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -71,6 +71,10 @@ When "I select {capture_string} in select list {capture_string}" do |option, lis
   select option, from: list
 end
 
+When "I cannot select {capture_string} in select list {capture_string}" do |option, list|
+  expect(find_field(list).text.match(option)).to be_nil
+end
+
 When "I select radio button {capture_string}" do |label_text|
   find(:xpath, "//label[contains(.,'#{label_text}')]/input[@type='radio']").click
 end

--- a/features/step_definitions/company_steps.rb
+++ b/features/step_definitions/company_steps.rb
@@ -6,8 +6,8 @@ And(/^the following companies exist:$/) do |table|
 
     cmpy = FactoryBot.create(:company, company)
 
-    cmpy.addresses.first.update(region: Region.find_by_name(region),
-                                kommun: Kommun.find_by_name(kommun),
+    cmpy.addresses.first.update(region: Region.find_or_create_by(name: region),
+                                kommun: Kommun.find_or_create_by(name: kommun),
                                 visibility: visibility)
 
   end

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -94,16 +94,17 @@ Feature: Visitor sees all companies
       | admin@shf.se  | true  |        |
 
     And the following payments exist
-      | user_email  | start_date | expire_date | payment_type | status | hips_id | company_name |
-      | u1@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company01    |
-      | u2@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company02    |
-      | u3@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company03    |
-      | u4@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company04    |
-      | u5@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company05    |
-      | u6@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company06    |
-      | u7@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company07    |
-      | u8@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company08    |
-      | u9@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company09    |
+      | user_email    | start_date | expire_date | payment_type | status | hips_id | company_name |
+      | u1@mutts.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company01    |
+      | u1@mutts.com  | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |              |
+      | u2@mutts.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company02    |
+      | u3@mutts.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company03    |
+      | u4@mutts.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company04    |
+      | u5@mutts.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company05    |
+      | u6@mutts.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company06    |
+      | u7@mutts.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company07    |
+      | u8@mutts.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company08    |
+      | u9@mutts.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company09    |
       | u10@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company10    |
       | u11@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company11    |
       | u12@mutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company12    |


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/156415087


Changes proposed in this pull request:
1. Introduce Company scope `searchable`, which limits companies collection to those companies that:
  - are "complete" (address fields defined)
  - have paid branding fee (unexpired)
  - have member(s)
2. Added this filter to companies associated with a specific service category (`business_categories_controller#show`)
3. Added / Adjusted tests as appropriate

Screenshots (Optional):


Ready for review:
@AgileVentures/shf-project-team 