### PR TITLE
Refactor shf application update action and add update_reason_waiting action

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -39,17 +39,6 @@ $(function() {
 
     $('#toggle_admin_set_password_form').click(Utility.toggle);
 
-
-    // Paginate link sends AJAX request to controller, which renders new page
-    // in JS response.  These callbacks execute at that point and replaces
-    // the prior pagination page (DOM element) with the new page.
-
-    $('body').on('ajax:success', '.applications_pagination', function (e, data) {
-      $('#shf_applications_list').html(data);
-      // In case there is tooltip(s) in rendered element:
-      $('[data-toggle="tooltip"]').tooltip();
-    });
-
     // Enable all Bootstrap tooltips
     $('[data-toggle="tooltip"]').tooltip();
 

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -98,24 +98,24 @@ class ShfApplicationsController < ApplicationController
 
   def update_reason_waiting
 
-    # One or the other of the params keys will be present - but not both
+    @show_other_reason = true
+
     if (reason_id = params[:member_app_waiting_reasons])
 
-      if reason_id == "#{@other_waiting_reason_value}"
-        render plain: "#{reason_id}" and return
+      unless reason_id == @other_waiting_reason_value
+        @show_other_reason = false
+
+        @shf_application.update(member_app_waiting_reasons_id: reason_id,
+                                custom_reason_text: nil)
       end
 
-      @shf_application
-          .update(member_app_waiting_reasons_id: reason_id,
-                  custom_reason_text: nil)
     else
 
       @shf_application.update(custom_reason_text: params[:custom_reason_text],
                               member_app_waiting_reasons_id: nil)
     end
 
-    head :ok
-
+    respond_to :js
   end
 
 

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -98,24 +98,23 @@ class ShfApplicationsController < ApplicationController
 
   def update_reason_waiting
 
-    @show_other_reason = true
-
     if (reason_id = params[:member_app_waiting_reasons])
 
-      unless reason_id == @other_waiting_reason_value
-        @show_other_reason = false
-
-        @shf_application.update(member_app_waiting_reasons_id: reason_id,
-                                custom_reason_text: nil)
+      if reason_id == @other_waiting_reason_value
+        render plain: 'true' and return
       end
 
+      @shf_application
+          .update(member_app_waiting_reasons_id: reason_id,
+                  custom_reason_text: nil)
     else
 
       @shf_application.update(custom_reason_text: params[:custom_reason_text],
                               member_app_waiting_reasons_id: nil)
     end
 
-    respond_to :js
+    head :ok
+
   end
 
 

--- a/app/policies/shf_application_policy.rb
+++ b/app/policies/shf_application_policy.rb
@@ -67,6 +67,10 @@ class ShfApplicationPolicy < ApplicationPolicy
     user == record.user && EDITABLE_STATES_FOR_APPLICATION.include?(record.state.to_sym)
   end
 
+  def update_reason_waiting?
+    update?
+  end
+
 
   def information?
     not_a_visitor

--- a/app/views/shf_applications/_reason_waiting.html.haml
+++ b/app/views/shf_applications/_reason_waiting.html.haml
@@ -40,6 +40,14 @@
 
   $(document).ready(function () {
 
+    $('#member_app_waiting_reasons').on('ajax:success', function (e, show_other_reason) {
+      if (show_other_reason == 'true') {
+        $('#other-text-field').show();
+      } else {
+        $('#other-text-field').hide();
+      }
+    });
+
     $('#custom_reason_text').on('input', ChangeStatus.received_input);
 
     $('#custom_reason_text').on('change', function (e) {

--- a/app/views/shf_applications/_reason_waiting.html.haml
+++ b/app/views/shf_applications/_reason_waiting.html.haml
@@ -15,7 +15,7 @@
                          { include_blank: t('shf_applications.need_info.select_a_reason'),
                            class: 'reason-waiting-list',
                            data: { remote: true,
-                                   url: shf_application_path(@shf_application),
+                                   url: reason_waiting_shf_application_path(@shf_application),
                                    method: 'put' } })
 
   .row
@@ -24,7 +24,7 @@
         = label_tag :custom_reason_text, t('shf_applications.need_info.other_reason_label')
         = text_field_tag :custom_reason_text, @shf_application.custom_reason_text,
                     { data: { remote: true,
-                              url: shf_application_path(@shf_application),
+                              url: reason_waiting_shf_application_path(@shf_application),
                               method: 'put' } }
 
 

--- a/app/views/shf_applications/_reason_waiting.html.haml
+++ b/app/views/shf_applications/_reason_waiting.html.haml
@@ -40,14 +40,6 @@
 
   $(document).ready(function () {
 
-    $('#member_app_waiting_reasons').on('ajax:success', function (e, data) {
-      if (data === "#{@other_waiting_reason_value}") {
-        $('#other-text-field').show();
-      } else {
-        $('#other-text-field').hide();
-      }
-    });
-
     $('#custom_reason_text').on('input', ChangeStatus.received_input);
 
     $('#custom_reason_text').on('change', function (e) {

--- a/app/views/shf_applications/index.js.erb
+++ b/app/views/shf_applications/index.js.erb
@@ -1,0 +1,3 @@
+$('#shf_applications_list').html("<%= j(render 'shf_applications_list') %>");
+// In case there is tooltip(s) in rendered element:
+$('[data-toggle="tooltip"]').tooltip();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,9 @@ Rails.application.routes.draw do
 
     resources :shf_applications, path: 'ansokan' do
       member do
+        put 'update-reason-waiting', to: 'shf_applications#update_reason_waiting',
+            as: 'reason_waiting'
+
         get 'start-review', to: 'shf_applications#show'
         post 'start-review', to: 'shf_applications#start_review'
 

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -66,6 +66,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     Given I am on the "application" page for "anna_waiting_for_info@nosnarkybarky.se"
     When I select t("admin_only.member_app_waiting_reasons.other_custom_reason") in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
+    And I wait 2 seconds
     When I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
     And I am on the "membership applications" page
@@ -81,6 +82,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     Given I am on the "application" page for "anna_waiting_for_info@nosnarkybarky.se"
     When I select t("admin_only.member_app_waiting_reasons.other_custom_reason") in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
+    And I wait 2 seconds
     And I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
     And I wait for all ajax requests to complete
@@ -100,6 +102,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     And I press enter in "custom_reason_text"
     And I select "need doc" in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
+    And I wait 2 seconds
     # change back so the custom reason field shows. it should be blank
     And I select t("admin_only.member_app_waiting_reasons.other_custom_reason") in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
@@ -119,6 +122,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     Then I am on the "application" page for "anna_waiting_for_info@nosnarkybarky.se"
     When I select t("admin_only.member_app_waiting_reasons.other_custom_reason") in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
+    And I wait 2 seconds
     And I fill in "custom_reason_text" with "This is my reason"
     Then I click the browser back button and "dismiss" the prompt
     And the t("shf_applications.need_info.other_reason_label") field should be set to "This is my reason"

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -66,7 +66,6 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     Given I am on the "application" page for "anna_waiting_for_info@nosnarkybarky.se"
     When I select t("admin_only.member_app_waiting_reasons.other_custom_reason") in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
-    And I wait 2 seconds
     When I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
     And I am on the "membership applications" page
@@ -82,7 +81,6 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     Given I am on the "application" page for "anna_waiting_for_info@nosnarkybarky.se"
     When I select t("admin_only.member_app_waiting_reasons.other_custom_reason") in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
-    And I wait 2 seconds
     And I fill in "custom_reason_text" with "This is my reason"
     And I press enter in "custom_reason_text"
     And I wait for all ajax requests to complete
@@ -102,7 +100,6 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     And I press enter in "custom_reason_text"
     And I select "need doc" in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
-    And I wait 2 seconds
     # change back so the custom reason field shows. it should be blank
     And I select t("admin_only.member_app_waiting_reasons.other_custom_reason") in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
@@ -122,7 +119,6 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     Then I am on the "application" page for "anna_waiting_for_info@nosnarkybarky.se"
     When I select t("admin_only.member_app_waiting_reasons.other_custom_reason") in select list "member_app_waiting_reasons"
     And I wait for all ajax requests to complete
-    And I wait 2 seconds
     And I fill in "custom_reason_text" with "This is my reason"
     Then I click the browser back button and "dismiss" the prompt
     And the t("shf_applications.need_info.other_reason_label") field should be set to "This is my reason"


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/156324575


Changes proposed in this pull request:
1. Refactored `update` action to only handle updates to the membership (SHF) application attributes,
2. Pulled out logic from `update` that had to do with the application review process (which is "meta-data" about the application itself) and put it in a separate action,
3. Added route for the added action.


Ready for review:
@AgileVentures/shf-project-team 