### PR TITLE
Provide for multiple member companies in member menu structure

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User < ApplicationRecord
 
   has_one :shf_application
 
+  has_many :companies, through: :shf_application
+
   has_many :payments
   accepts_nested_attributes_for :payments
 
@@ -83,20 +85,6 @@ class User < ApplicationRecord
     if member? && ! membership_current?
       update(member: false)
     end
-  end
-
-
-  def has_company?
-    shf_application&.companies&.any?
-  end
-
-
-  def companies
-    return Company.all if admin?
-
-    return [] unless has_company?
-
-    shf_application.companies
   end
 
 

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -20,10 +20,6 @@ class Visitor
     nil
   end
 
-  def has_company?
-    false
-  end
-
   def in_company_numbered?(_company_number_)
     false
   end

--- a/app/views/application/_navigation.html.haml
+++ b/app/views/application/_navigation.html.haml
@@ -43,18 +43,25 @@
 
                   = render 'navigation_member_pages'
 
-                  - if current_user.has_company?
-                    - member_company = current_user.shf_application&.company
+                  - if (company_count = current_user.companies.count) > 0
+
                     %li.menu-item.menu-item-has-children
-                      = link_to t('menus.nav.members.manage_company.submenu_title'),
-                                company_path(member_company)
+                      %a.link-no-styling{ href: '#' }
+                        = t('my_company', count: company_count)
+
                       %ul.sub-menu
-                        %li.menu-item
-                          = link_to t('menus.nav.members.manage_company.view_company'),
-                                    company_path(member_company)
-                        %li.menu-item
-                          = link_to t('menus.nav.members.manage_company.edit_company'),
-                                    edit_company_path(member_company)
+
+                        - current_user.companies.each do |company|
+
+                          %li.menu-item.menu-item-has-children
+                            %a.link-no-styling{ href: '#' }= company.name
+                            %ul.sub-menu
+                              %li.menu-item
+                                = link_to t('menus.nav.members.manage_company.view_company'),
+                                          company_path(company)
+                              %li.menu-item
+                                = link_to t('menus.nav.members.manage_company.edit_company'),
+                                          edit_company_path(company)
 
                   = render 'navigation_edit_my_application', shf_app: current_user.shf_application
 

--- a/app/views/shf_applications/_check_payment_status.html.haml
+++ b/app/views/shf_applications/_check_payment_status.html.haml
@@ -27,8 +27,7 @@
   - need_to_pay = false
 
 
-- if current_user.has_company?
-  - company = current_user.companies.first
+- if (company = current_user.companies.first)
 
   - if ! company.most_recent_branding_payment
     -# User has never paid

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,6 +101,10 @@ en:
     spoofed_media_type: &spoofed_media file name (type) does not match the file
                         content.  Please use another photo file.
 
+  my_company:
+    one: My Company
+    other: My Companies
+
  # Automatic and manual lookup for ActiveRecords:
   activerecord:
     models:
@@ -1046,7 +1050,6 @@ en:
         member_pages: *member_pages
         shf_meeting_minutes: *member_pages_board_meetings
         manage_company:
-          submenu_title: My company
           view_company: View Company
           edit_company: Edit My Company
         my_application: *my_application

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -101,6 +101,10 @@ sv:
     spoofed_media_type: &spoofed_media filnamn (typ) matchar inte filinnehållet.
                         Vänligen använd en annan bildfil.
 
+  my_company:
+    one: Mitt företag
+    other: Mina företag
+
   # Automatisk och manuell sökning för Active Records
   activerecord:
     models:
@@ -1049,7 +1053,6 @@ sv:
         member_pages: *member_pages
         shf_meeting_minutes: *member_pages_board_meetings
         manage_company:
-          submenu_title: Mitt företag
           view_company: Visa företagssida
           edit_company: Redigera företag
         my_application: *my_application

--- a/features/approve-member.feature
+++ b/features/approve-member.feature
@@ -67,7 +67,7 @@ Feature: As an admin
     Then I click on t("menus.nav.members.pay_membership")
     And I complete the payment
     And I should see t("payments.success.success")
-    Then I should see t("menus.nav.members.manage_company.submenu_title")
+    Then I should see t("my_company", count: "1.to_i")
     And I am on the "show my application" page for "anna@nosnarkybarky.se"
     Then I should see t("shf_applications.show.membership_number")
     And I should not see "902"

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -73,7 +73,7 @@ Feature: Create a new membership application
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: info@craft.se)
 
-  @selenium
+  @selenium_browser
   Scenario: A user can submit a new Membership Application with no categories
     Given I am on the "new application" page
     And I fill in the translated form with data:
@@ -85,7 +85,6 @@ Feature: Create a new membership application
     And I fill in t("companies.show.company_number") with "2286411992"
     And I fill in t("companies.show.email") with "info@craft.se"
     And I click on t("companies.create.create_submit")
-    And I wait 2 seconds
     And I wait for all ajax requests to complete
     And I click on t("shf_applications.new.submit_button_label")
 
@@ -107,7 +106,7 @@ Feature: Create a new membership application
     And the field t("shf_applications.new.phone_number") should not have a required field indicator
     And I should see t("is_required_field")
 
-  @selenium
+  @selenium_browser
   Scenario: Two users can submit a new Membership Application (with empty membershipnumbers)
     And I am on the "new application" page
     And I fill in the translated form with data:
@@ -119,7 +118,6 @@ Feature: Create a new membership application
     And I fill in t("companies.show.company_number") with "5562252998"
     And I fill in t("companies.show.email") with "info@craft.se"
     And I click on t("companies.create.create_submit")
-    And I wait 2 seconds
     And I wait for all ajax requests to complete
     And I click on t("shf_applications.new.submit_button_label")
 
@@ -137,7 +135,6 @@ Feature: Create a new membership application
     And I fill in t("companies.show.email") with "info@craft.se"
     And I click on t("companies.create.create_submit")
     And I wait for all ajax requests to complete
-    And I wait 2 seconds
     And I click on t("shf_applications.new.submit_button_label")
 
     Then I should see t("shf_applications.create.success", email_address: applicant_2@random.com)

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -85,8 +85,8 @@ Feature: Create a new membership application
     And I fill in t("companies.show.company_number") with "2286411992"
     And I fill in t("companies.show.email") with "info@craft.se"
     And I click on t("companies.create.create_submit")
-    And I wait for all ajax requests to complete
     And I wait 2 seconds
+    And I wait for all ajax requests to complete
     And I click on t("shf_applications.new.submit_button_label")
 
     Then I should be on the "user instructions" page
@@ -119,8 +119,8 @@ Feature: Create a new membership application
     And I fill in t("companies.show.company_number") with "5562252998"
     And I fill in t("companies.show.email") with "info@craft.se"
     And I click on t("companies.create.create_submit")
-    And I wait for all ajax requests to complete
     And I wait 2 seconds
+    And I wait for all ajax requests to complete
     And I click on t("shf_applications.new.submit_button_label")
 
     Then I should see t("shf_applications.create.success", email_address: applicant_1@random.com)

--- a/features/show_only_searchable_companies.feature
+++ b/features/show_only_searchable_companies.feature
@@ -119,7 +119,7 @@ Feature: So that I do not get frustrated by trying to find out more
     When I am on the business category "Trainer"
     Then I should not see "5906055081"
     And I should not see "NoRegion"
-    And I should not see "Happy Mutts"
+    And I should not see "Happy Mutts" in the business categories table
     And I should not see "5560360793"
     And I should not see "NoPayment"
     And I should not see "NoMember"

--- a/features/step_definitions/business_category_steps.rb
+++ b/features/step_definitions/business_category_steps.rb
@@ -18,3 +18,7 @@ Given(/^I am on the business category "([^"]*)"$/) do |name|
   business_category = BusinessCategory.find_by(name: name)
   visit path_with_locale(business_category_path(business_category))
 end
+
+And(/I should( not)? see "([^"]*)" in the business categories table$/) do | negate, cmpy |
+  step %{I should#{negate} see xpath "tr[td//text()[contains(., '#{cmpy}')]]"}
+end

--- a/features/support/parameter_types.rb
+++ b/features/support/parameter_types.rb
@@ -63,6 +63,13 @@ def parse_i18n_string(i18n_string)
       keyvalue = e.sub(' :', ' ').split(':')
       key = keyvalue[0].strip.to_sym
       value = keyvalue[1].strip
+
+      # Parameters other than strings can be handled by specifying a
+      # string transformation method in the cucumber step, e.g.:
+      #  Then I should see t("my_company", count: '1.to_i')
+      if (idx = value.index('.to_'))
+        value = value[0..idx-1].send(value[idx+1..-1])
+      end
       parameters[key] = value
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -123,11 +123,6 @@ RSpec.describe User, type: :model do
       it { expect(subject.has_shf_application?).to be_truthy }
     end
 
-    describe 'user: 1 not yet saved application' do
-      let(:user_with_app) { build(:user_with_membership_app) }
-      it { expect(subject.has_company?).to be_falsey }
-    end
-
     describe 'member with 1 app' do
       let(:member) { create(:member_with_membership_app) }
       let(:member_app) { create(:shf_application, user: user_with_app) }
@@ -144,40 +139,6 @@ RSpec.describe User, type: :model do
       it { expect(subject.has_shf_application?).to be_falsey }
     end
 
-  end
-
-  describe '#has_company?' do
-
-    after(:each) {
-      Company.destroy_all
-      ShfApplication.destroy_all
-      User.destroy_all
-    }
-
-    describe 'user: no application' do
-      subject { create(:user) }
-      it { expect(subject.has_company?).to be_falsey }
-    end
-
-    describe 'user: 1 saved application' do
-      subject { create(:user_with_membership_app) }
-      it { expect(subject.has_company?).to be_truthy }
-    end
-
-    describe 'member with 1 app' do
-      let(:member) { create(:member_with_membership_app) }
-      it { expect(member.has_company?).to be_truthy }
-    end
-
-    describe 'member with 0 apps (should not happen)' do
-      let(:member) { create(:user) }
-      it { expect(member.has_company?).to be_falsey }
-    end
-
-    describe 'admin' do
-      subject { create(:user, admin: true) }
-      it { expect(subject.has_company?).to be_falsey }
-    end
   end
 
   describe '#shf_application' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -275,41 +275,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#companies' do
-    describe 'not yet a member, so not in any full companies' do
-
-      describe 'user: 1 saved application' do
-        subject { create(:user_with_membership_app) }
-        it { expect(subject.companies.size).to eq(1) }
-      end
-    end
-
-    describe 'is a member, so is in companies' do
-
-      describe 'member with 1 app' do
-        let(:member) { create(:member_with_membership_app) }
-        it { expect(member.companies.size).to eq(1) }
-      end
-
-      describe 'member with 0 apps (should not happen)' do
-        let(:member) { create(:user) }
-        it { expect(member.companies.size).to eq(0) }
-      end
-
-    end
-
-    describe 'admin will get all Companies' do
-      subject { create(:user, admin: true) }
-      it do
-        create(:company, company_number: '0000000000')
-        create(:company, company_number: '5560360793')
-        create(:company, company_number: '2120000142')
-        num_companies = Company.all.size
-        expect(subject.companies.size).to eq(num_companies)
-      end
-    end
-  end
-
   describe '#admin?' do
     describe 'user: no application' do
       subject { create(:user) }

--- a/spec/models/visitor_spec.rb
+++ b/spec/models/visitor_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe Visitor, type: :model do
     it { should respond_to(:member?) }
     it { should respond_to(:member_or_admin?) }
     it { should respond_to(:has_shf_application?) }
-    it { should respond_to(:has_company?) }
+    it { should respond_to(:shf_application) }
     it { should respond_to(:in_company_numbered?) }
+    it { should respond_to(:id) }
   end
 
   describe Visitor do

--- a/spec/views/application/_navigation.html.haml_spec.rb
+++ b/spec/views/application/_navigation.html.haml_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe 'companies/index' do
 
   let(:user)    { FactoryBot.create(:user_with_membership_app) }
 
-  let(:cmpy_id) { member.shf_application.company.id }
-  let(:cmpy_id) { member.shf_application.company.id }
+  let(:cmpy_id) { member.shf_application.companies.first.id }
+
+  let(:cmpy2)   { FactoryBot.create(:company, name: 'Second Company') }
 
   let(:app_id)  { member.shf_application.id }
 
@@ -69,23 +70,77 @@ RSpec.describe 'companies/index' do
       end
     end
 
-    context 'manage my company menu' do
+    context 'manage my company(s) menu' do
 
-      it 'renders default menu link == view-my-company' do
-        text = t('menus.nav.members.manage_company.submenu_title')
-        expect(rendered).to match %r{<a href=\"\/hundforetag\/#{cmpy_id}\">#{text}}
+      context 'single company for member' do
+
+        it 'renders menu title == "My Company"' do
+          expect(rendered).to match t('my_company', count: 1)
+        end
+
+        it 'renders sub-menu title with company name' do
+          text = %r{href=\'\#\'>#{member.companies.first.name}}
+          expect(rendered).to match text
+        end
+
+        it 'renders view-my-company link' do
+          text = t('menus.nav.members.manage_company.view_company')
+          expect(rendered)
+            .to match %r{<a href=\"\/hundforetag\/#{cmpy_id}\">#{text}}
+        end
+
+        it 'renders edit-my-company link' do
+          text = t('menus.nav.members.manage_company.edit_company')
+          expect(rendered)
+            .to match %r{<a href=\"\/hundforetag\/#{cmpy_id}\/redigera\">#{text}}
+        end
       end
 
-      it 'renders view-my-company link' do
-        text = t('menus.nav.members.manage_company.view_company')
-        expect(rendered)
-          .to match %r{<a href=\"\/hundforetag\/#{cmpy_id}\">#{text}}
-      end
+      context 'two companies for member' do
 
-      it 'renders edit-my-company link' do
-        text = t('menus.nav.members.manage_company.edit_company')
-        expect(rendered)
-          .to match %r{<a href=\"\/hundforetag\/#{cmpy_id}\/redigera\">#{text}}
+        before(:each) do
+          member.shf_application.companies << cmpy2
+          member.reload
+          render 'application/navigation'
+        end
+
+        it 'renders menu title == "My Companies"' do
+          expect(rendered).to match t('my_company', count: 2)
+        end
+
+        it 'renders sub-menu title with first company name' do
+          text = %r{href=\'\#\'>#{member.companies.first.name}}
+          expect(rendered).to match text
+        end
+
+        it 'renders view-my-company link - first company' do
+          text = t('menus.nav.members.manage_company.view_company')
+          expect(rendered)
+            .to match %r{<a href=\"\/hundforetag\/#{cmpy_id}\">#{text}}
+        end
+
+        it 'renders edit-my-company link - first company' do
+          text = t('menus.nav.members.manage_company.edit_company')
+          expect(rendered)
+            .to match %r{<a href=\"\/hundforetag\/#{cmpy_id}\/redigera\">#{text}}
+        end
+
+        it 'renders sub-menu title with second company name' do
+          text = %r{href=\'\#\'>#{member.companies.second.name}}
+          expect(rendered).to match text
+        end
+
+        it 'renders view-my-company link - second company' do
+          text = t('menus.nav.members.manage_company.view_company')
+          expect(rendered)
+            .to match %r{<a href=\"\/hundforetag\/#{cmpy2.id}\">#{text}}
+        end
+
+        it 'renders edit-my-company link - second company' do
+          text = t('menus.nav.members.manage_company.edit_company')
+          expect(rendered)
+            .to match %r{<a href=\"\/hundforetag\/#{cmpy2.id}\/redigera\">#{text}}
+        end
       end
     end
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/156248030


Changes proposed in this pull request:
1. Adjusted menu logic as needed
2. Removed some methods associated with prior application<>company association that are no longer needed

Screenshots (Optional): (member with 3 associated companies)

<img width="721" alt="screen shot 2018-04-11 at 10 08 49 am" src="https://user-images.githubusercontent.com/9968213/38622347-fca01600-3d70-11e8-8adc-5022ee803179.png">

---

<img width="718" alt="screen shot 2018-04-11 at 10 08 16 am" src="https://user-images.githubusercontent.com/9968213/38622351-00aadce4-3d71-11e8-978b-b023057f9b8c.png">


Ready for review:
@AgileVentures/shf-project-team 