### PR TITLE
Show needed company payments on member's landing page

### DIFF
--- a/app/models/shf_application.rb
+++ b/app/models/shf_application.rb
@@ -48,12 +48,6 @@ class ShfApplication < ApplicationRecord
   delegate :full_name, to: :user, prefix: true
   delegate :membership_number, :membership_number=, to: :user, prefix: false
 
-  def company
-    # Method used during restructuring to allow an application to have_many
-    # companies.  Remove when restructuring complete.
-    companies.last
-  end
-
   include AASM
 
   aasm :column => 'state' do

--- a/app/views/shf_applications/_check_payment_status.html.haml
+++ b/app/views/shf_applications/_check_payment_status.html.haml
@@ -28,7 +28,7 @@
 
 - if current_user.companies.any?
 
-  - current_user.companies.each do |company|
+  - current_user.companies.order(:id).each do |company|
 
     - if ! company.most_recent_branding_payment
       -# User has never paid

--- a/app/views/shf_applications/_check_payment_status.html.haml
+++ b/app/views/shf_applications/_check_payment_status.html.haml
@@ -26,31 +26,35 @@
 
   - need_to_pay = false
 
+- if current_user.companies.any?
 
-- if (company = current_user.companies.first)
+  - current_user.companies.each do |company|
 
-  - if ! company.most_recent_branding_payment
-    -# User has never paid
+    - if ! company.most_recent_branding_payment
+      -# User has never paid
 
-    - need_to_pay = true
+      - need_to_pay = true
 
-    %h4= t('shf_applications.information.check_payment_status.pay_h_here')
-
-
-  - elsif ! company.branding_license?
-    -# User has paid but payment has expired
-
-    - need_to_pay = true
-
-    %h4
-      = t('shf_applications.information.check_payment_status.h_expires')
-      %strong= company.branding_expire_date
+      %h4
+        = t('shf_applications.information.check_payment_status.pay_h_here_html',
+             company: company.name)
 
 
-- if need_to_pay
+    - elsif ! company.branding_license?
+      -# User has paid but payment has expired
+
+      - need_to_pay = true
+
+      %h4
+        = t('shf_applications.information.check_payment_status.h_expires_html',
+            company: company.name)
+
+        %strong= company.branding_expire_date
 
 
+    - if need_to_pay
 
-  = link_to(t('menus.nav.company.pay_branding_fee'), company_path(company), class: 'btn btn-info')
-  %br
-  %br
+      = link_to(t('menus.nav.company.pay_branding_fee'),
+                company_path(company), class: 'btn btn-info')
+      %br
+      %br

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -395,8 +395,8 @@ en:
         pay_m_here: 'Pay your membership on this page:'
         approved_since_before: You are approved since earlier but have one or more unpaid fees.
         m_expires: 'Your membership-payment expired:'
-        h_expires: 'Your H-branding fee-payment expired:'
-        pay_h_here: 'Your H-branding fee needs to be paid:'
+        h_expires_html: 'Your H-branding fee-payment for company <b>%{company}</b> expired:'
+        pay_h_here_html: 'Your H-branding fee for company <b>%{company}</b>BrandingNotPaid needs to be paid:'
 
     start_review:
       success: The review has been started.

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -383,8 +383,8 @@ sv:
         pay_m_here: 'Ditt medlemskap betalas på denna sida:'
         approved_since_before: Du är godkänd sedan innan men du har just nu en eller flera avgifter som inte är betalda.
         m_expires: 'Ditt medlemskap är betalt till:'
-        h_expires: 'Din H-märkningspremie är betald till:'
-        pay_h_here: 'Din H-märkningspremie behöver betalas:'
+        h_expires_html: 'Din H-branding avgift-betalning för företaget <b>%{company}</b> utgått:'
+        pay_h_here_html: 'Din H-branding avgift för företaget <b>%{company}</b> måste betalas:'
 
       user:
         title: Hej, kul att du är intresserad

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -85,6 +85,7 @@ Feature: Create a new membership application
     And I fill in t("companies.show.company_number") with "2286411992"
     And I fill in t("companies.show.email") with "info@craft.se"
     And I click on t("companies.create.create_submit")
+    And I wait 2 seconds
     And I wait for all ajax requests to complete
     And I click on t("shf_applications.new.submit_button_label")
 
@@ -118,6 +119,7 @@ Feature: Create a new membership application
     And I fill in t("companies.show.company_number") with "5562252998"
     And I fill in t("companies.show.email") with "info@craft.se"
     And I click on t("companies.create.create_submit")
+    And I wait 2 seconds
     And I wait for all ajax requests to complete
     And I click on t("shf_applications.new.submit_button_label")
 

--- a/features/landing_page.feature
+++ b/features/landing_page.feature
@@ -12,19 +12,24 @@ Feature: As a Member
       | admin@shf.se    | true  | false  |                   |
 
     Given the following companies exist:
-      | name       | company_number | email                 | region    |
-      | HappyMutts | 2120000142     | woof@happymutts.com   | Stockholm |
-      | HappyMuffs | 6222279082     | woof@happymuffs.com   | Stockholm |
+      | name            | company_number | email                | region    |
+      | HappyMutts      | 2120000142     | woof@happymutts.com  | Stockholm |
+      | HappyMuffs      | 6222279082     | woof@happymuffs.com  | Stockholm |
+      | BrandingNotPaid | 5560360793     | nobranding@mail.com  | Stockholm |
+      | BrandingExpired | 7661057765     | exbranding@mail.com  | Stockholm |
 
     Given the following applications exist:
       | user_email      | company_number | category_name | state         |
       | emma@mutts.com  | 2120000142     | rehab         | accepted      |
+      | emma@mutts.com  | 5560360793     | rehab         | accepted      |
+      | emma@mutts.com  | 7661057765     | rehab         | accepted      |
       | anna@muffs.com  | 6222279082     | other         | under_review  |
-      | fanny@mutts.com | 6222279082     | other         | accepted  |
+      | fanny@mutts.com | 6222279082     | other         | accepted      |
 
     Given the following payments exist
       | user_email     | start_date | expire_date | payment_type | status | hips_id | company_number |
       | emma@mutts.com | 2017-10-1  | 2018-01-31  | branding_fee | betald | none    | 2120000142     |
+      | emma@mutts.com | 2017-10-1  | 2018-01-31  | branding_fee | betald | none    | 7661057765     |
       | emma@mutts.com | 2017-10-1  | 2018-02-27  | member_fee   | betald | none    |                |
 
   Scenario: After login, Admin still sees new memberships on their landing page
@@ -72,11 +77,19 @@ Feature: As a Member
     Given the date is set to "2018-02-01"
     And I am logged in as "emma@mutts.com"
     When I am on the "user instructions" page
-    Then I should see t("shf_applications.information.check_payment_status.h_expires")
+    Then I should see t("shf_applications.information.check_payment_status.h_expires_html", company: 'HappyMutts')
+    And I should see t("shf_applications.information.check_payment_status.h_expires_html", company: 'BrandingExpired')
+    And I should see t("shf_applications.information.check_payment_status.pay_h_here_html", company: 'BrandingNotPaid')
     And I should not see t("shf_applications.information.check_payment_status.m_expires")
     And I should not see t("shf_applications.information.waiting_for_approval.in_process")
-    When I click on t("menus.nav.company.pay_branding_fee")
-    Then I should be on the "my company" page for "emma@mutts.com"
+    When I click on first t("menus.nav.company.pay_branding_fee") link
+    Then I should be on the "my first company" page for "emma@mutts.com"
+    Then I am on the "user instructions" page
+    And I click on second t("menus.nav.company.pay_branding_fee") link
+    Then I should be on the "my second company" page for "emma@mutts.com"
+    Then I am on the "user instructions" page
+    And I click on third t("menus.nav.company.pay_branding_fee") link
+    Then I should be on the "my third company" page for "emma@mutts.com"
 
   Scenario: After login, user with accepted app but with no membership payment sees instructions to pay
     And I am logged in as "fanny@mutts.com"
@@ -90,11 +103,11 @@ Feature: As a Member
   Scenario: After login, Member without previously paid H-branding sees correct instructions about H branding
     And I am logged in as "fanny@mutts.com"
     When I am on the "user instructions" page
-    Then I should see t("shf_applications.information.check_payment_status.pay_h_here")
-    And I should not see t("shf_applications.information.check_payment_status.h_expires")
+    Then I should see t("shf_applications.information.check_payment_status.pay_h_here_html", company: 'HappyMuffs')
+    And I should not see t("shf_applications.information.check_payment_status.h_expires, company: 'HappyMuffs'")
     And I should not see t("shf_applications.information.waiting_for_approval.in_process")
     When I click on t("menus.nav.company.pay_branding_fee")
-    Then I should be on the "my company" page for "fanny@mutts.com"
+    Then I should be on the "my first company" page for "fanny@mutts.com"
 
   Scenario: After login, user with accepted app sees info about their app being handled
     Given I am logged in as "anna@muffs.com"

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -51,7 +51,7 @@ module PathHelpers
       when 'my third company'
         path = company_path(user.shf_application.companies.third)
       when 'edit my company'
-        path = edit_company_path(user.shf_application.company)
+        path = edit_company_path(user.shf_application.companies.first)
       when 'all users'
         path = users_path
       when 'all shf documents'

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -44,8 +44,12 @@ module PathHelpers
         path = new_company_path
       when 'submit new membership application'
         path = new_shf_application_path
-      when 'my company'
-        path = company_path(user.shf_application.company)
+      when 'my first company'
+        path = company_path(user.shf_application.companies.first)
+      when 'my second company'
+        path = company_path(user.shf_application.companies.second)
+      when 'my third company'
+        path = company_path(user.shf_application.companies.third)
       when 'edit my company'
         path = edit_company_path(user.shf_application.company)
       when 'all users'

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -1,39 +1,43 @@
 And(/^the following applications exist:$/) do |table|
- table.hashes.each do |hash|   
+ table.hashes.each do |hash|
    attributes = hash.except('user_email', 'categories', 'company_name')
    user = User.find_by(email: hash[:user_email].downcase)
 
-   if hash['state'] == 'accepted' || hash['state'] == 'rejected'
 
-     if hash['company_name']
-       company = Company.find_by(name: hash['company_name'])
-     else
-       company = Company.find_by(company_number: hash['company_number'])
-       unless company
-         company = FactoryBot.create(:company, company_number: hash['company_number'])
-       end
-     end
-   end
-   contact_email = hash['contact_email'] && ! hash['contact_email'].empty? ?
-                   hash['contact_email'] : hash[:user_email]
+    if hash['company_name']
+      company = Company.find_by(name: hash['company_name'])
+    else
+      company = Company.find_by(company_number: hash['company_number'])
+      unless company
+        company = FactoryBot.create(:company, company_number: hash['company_number'])
+      end
+    end
 
-   if company.nil?
-     company_number = hash['company_number']
-   else
-     company_number = company.company_number
-   end
+    contact_email = hash['contact_email'] && ! hash['contact_email'].empty? ?
+                    hash['contact_email'] : hash[:user_email]
 
-   ma = FactoryBot.create(:shf_application,
-                            attributes.merge(user: user,
-                            company_number: company_number,
-                            contact_email: contact_email))
+    company_number = company.company_number
 
-   if hash['categories']
-     categories = []
-     for category_name in hash['categories'].split(/\s*,\s*/)
-       categories << BusinessCategory.find_by_name(category_name)
-     end
-     ma.business_categories = categories
-   end
- end
+    if (ma = user.shf_application)
+
+      user.shf_application.companies << company
+
+    else
+
+      ma = FactoryBot.create(:shf_application,
+                              attributes.merge(user: user,
+                              company_number: company_number,
+                              contact_email: contact_email))
+    end
+
+    if hash['categories']
+      categories = []
+      for category_name in hash['categories'].split(/\s*,\s*/)
+        categories << BusinessCategory.find_by_name(category_name) unless
+          ma.business_categories.where(name: category_name).exists?
+      end
+      ma.business_categories = categories
+    end
+
+  end
 end

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -1,7 +1,7 @@
 And(/^the following applications exist:$/) do |table|
- table.hashes.each do |hash|
-   attributes = hash.except('user_email', 'categories', 'company_name')
-   user = User.find_by(email: hash[:user_email].downcase)
+  table.hashes.each do |hash|
+    attributes = hash.except('user_email', 'categories', 'company_name')
+    user = User.find_by(email: hash[:user_email].downcase)
 
 
     if hash['company_name']
@@ -38,6 +38,5 @@ And(/^the following applications exist:$/) do |table|
       end
       ma.business_categories = categories
     end
-
   end
 end

--- a/features/support/parameter_types.rb
+++ b/features/support/parameter_types.rb
@@ -12,7 +12,9 @@ ParameterType(
     else
       cleaned_content = content.delete("\"'")[2..-2]
       key, parameters = parse_i18n_string(cleaned_content)
-      i18n_content(key, parameters)
+      Rails::Html::FullSanitizer.new.sanitize(i18n_content(key, parameters))
+      # ^ strip html styling tags in i18n string (otherwise comparison of the
+      #   string to the rendered version will fail)
     end
   end
 )

--- a/spec/support/data_creation_helper.rb
+++ b/spec/support/data_creation_helper.rb
@@ -86,7 +86,7 @@ module DataCreationHelper
     u = create(:member_with_membership_app, company_number: company_number)
     u.shf_application.update(created_at: payment_create_date, updated_at: payment_create_date)
 
-    co = u.shf_application.company
+    co = u.shf_application.companies.first
 
     create(:payment,
            user: u,


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/156693457


Changes proposed in this pull request:
1. Changes to landing page to show all user's companies that require payment of the H-Branding fee.
2. Cleaned up last vestiges (I hope) of the prior association between a membership application and a company (was one-to-one, now is many-to-many)
3. Changes to cucumber support methods to a) allow for non-string i18N translation parameters, and b) allow for HTML styling within translation strings (the latter has to be stripped out in order to compare the intended string to the actual rendered string).

**NOTE** - this PR is based upon PR #508 (which is why there are many files involved).   That PR should be merged before this one.

Screenshots (Optional):
### Member with 3 companies ... 2 companies have never had the h-branding fee paid, the 3rd company branding fee payment has expired:

<img width="817" alt="screen shot 2018-04-13 at 7 54 40 am" src="https://user-images.githubusercontent.com/9968213/38755872-63e1ab92-3f35-11e8-8d10-deb0f7914d92.png">

---

<img width="701" alt="screen shot 2018-04-13 at 7 54 51 am" src="https://user-images.githubusercontent.com/9968213/38755881-694ec65a-3f35-11e8-81b9-9eb7fd5f635b.png">



Ready for review:
@AgileVentures/shf-project-team 