### PR TITLE
Persist flash messages, provide dismiss button for user to close message

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -111,5 +111,3 @@ $(function() {
         }
     });
 });
-//Set timeout for flashes
-setTimeout("$('.flashes').fadeOut('slow');", 5000);

--- a/app/views/application/_flash.html.haml
+++ b/app/views/application/_flash.html.haml
@@ -1,5 +1,8 @@
 #flashes.flashes
   - flash.each do |key, value|
-    %div{class: "alert alert-#{flash_class(key)} center"}= render_flash_message(value)
+    %div{class: "alert alert-dismissable alert-#{flash_class(key)} center", role: 'alert'}
+      %button{type: 'button', class: 'close', 'data-dismiss' => 'alert'}
+        %span &times;
+      = render_flash_message(value)
 
   - flash.clear

--- a/app/views/application/_flash.html.haml
+++ b/app/views/application/_flash.html.haml
@@ -1,6 +1,6 @@
 #flashes.flashes
   - flash.each do |key, value|
-    %div.alert.alert-dismissable.center{ class: "alert-#{flash_class(key)}", role: 'alert' }
+    .alert.alert-dismissable.center{ class: "alert-#{flash_class(key)}", role: 'alert' }
       %button.close{ type: 'button', 'data-dismiss' => 'alert' }
         %span &times;
       = render_flash_message(value)

--- a/app/views/application/_flash.html.haml
+++ b/app/views/application/_flash.html.haml
@@ -1,7 +1,7 @@
 #flashes.flashes
   - flash.each do |key, value|
-    %div{class: "alert alert-dismissable alert-#{flash_class(key)} center", role: 'alert'}
-      %button{type: 'button', class: 'close', 'data-dismiss' => 'alert'}
+    %div.alert.alert-dismissable.center{ class: "alert-#{flash_class(key)}", role: 'alert' }
+      %button.close{ type: 'button', 'data-dismiss' => 'alert' }
         %span &times;
       = render_flash_message(value)
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -46,10 +46,10 @@
       I18n.locale = "#{I18n.locale}";
 
     = render 'top'
-    = render 'flash'
     #wrap
       #content.site-content.container
         .page-gutter.col-xs-12
+          = render 'flash'
           %section#primary.content-area
             %main#main.site-main{role: 'main'}
               %article

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -109,6 +109,7 @@ Feature: Create a new membership application
     And I fill in t("companies.show.company_number") with "2286411992"
     And I fill in t("companies.show.email") with "info@craft.se"
     And I click on t("companies.create.create_submit")
+    And I wait 4 seconds
     And I wait for all ajax requests to complete
 
     And I click on t("shf_applications.new.submit_button_label")
@@ -179,6 +180,7 @@ Feature: Create a new membership application
     And I fill in t("companies.show.company_number") with "5562252998"
     And I fill in t("companies.show.email") with "info@craft.se"
     And I click on t("companies.create.create_submit")
+    And I wait 4 seconds
     And I wait for all ajax requests to complete
     And I click on t("shf_applications.new.submit_button_label")
 

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -133,7 +133,7 @@ Feature: Create a new membership application
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: info@craft.se)
 
-  @selenium_browser
+  @selenium
   Scenario: A user can submit a new Membership Application with no categories
     Given I am on the "new application" page
     And I fill in the translated form with data:
@@ -145,7 +145,7 @@ Feature: Create a new membership application
     And I fill in t("companies.show.company_number") with "2286411992"
     And I fill in t("companies.show.email") with "info@craft.se"
     And I click on t("companies.create.create_submit")
-    And I wait 2 seconds
+    And I wait 4 seconds
     And I wait for all ajax requests to complete
     And I click on t("shf_applications.new.submit_button_label")
 
@@ -192,10 +192,10 @@ Feature: Create a new membership application
 
     # Create new company in modal
     And I click on t("companies.new.title")
-    And I wait 2 seconds
     And I fill in t("companies.show.company_number") with "6112107039"
     And I fill in t("companies.show.email") with "info@craft.se"
     And I click on t("companies.create.create_submit")
+    And I wait 4 seconds
     And I wait for all ajax requests to complete
     And I click on t("shf_applications.new.submit_button_label")
     Then I should see t("shf_applications.create.success", email_address: applicant_2@random.com)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/156255594

Retain flash messages since they might have important information for the user to be aware of.

Provide a button to dismiss the flash alert.

In addition to changes required to persist flash messages, also repositioned the flash message bar within the main content area - looks much better.

Screenshots:

### Create an application successfully, but reject an uploaded file that is too big:

<img width="899" alt="screen shot 2018-04-21 at 10 08 32 am" src="https://user-images.githubusercontent.com/9968213/39085241-d5822c04-454d-11e8-9b03-77b31469bb12.png">

---


Ready for review:
@AgileVentures/shf-project-team 