### PR TITLE
Restrict cmpy numbers to digits only

### DIFF
--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -75,7 +75,7 @@ class ShfApplicationsController < ApplicationController
       end
 
     else
-      create_error(t('.error'), companies_and_numbers, numbers_str)
+      create_or_update_error(t('.error'), companies_and_numbers, numbers_str, :new)
     end
   end
 
@@ -98,7 +98,7 @@ class ShfApplicationsController < ApplicationController
       redirect_to define_path(evaluate_update(params))
     else
 
-      update_error(t('.error'), companies_and_numbers, numbers_str)
+      create_or_update_error(t('.error'), companies_and_numbers, numbers_str, :edit)
     end
   end
 
@@ -258,26 +258,17 @@ class ShfApplicationsController < ApplicationController
   end
 
 
-  def create_error(error_message, companies_and_numbers, company_numbers_str)
+  def create_or_update_error(error_message, companies_and_numbers,
+                             company_numbers_str, render_me)
 
     @shf_application = add_company_errors_to_model(@shf_application,
                                                    companies_and_numbers)
 
     helpers.flash_message(:alert, error_message)
     load_update_objects(company_numbers_str)
-    render :new
+    render render_me
   end
 
-
-  def update_error(error_message, companies_and_numbers, company_numbers_str)
-
-    @shf_application = add_company_errors_to_model(@shf_application,
-                                                   companies_and_numbers)
-
-    helpers.flash_message(:alert, error_message)
-    load_update_objects(company_numbers_str)
-    render :edit
-  end
 
   def add_company_errors_to_model(application, companies_and_numbers)
     # see #validate_company_numbers for structure of companies_and_numbers
@@ -291,7 +282,7 @@ class ShfApplicationsController < ApplicationController
       end
 
       unless companies_and_numbers[:companies][idx]
-        application.errors.add(:companies, :invalid, value: numbers[idx])
+        application.errors.add(:companies, :not_found, value: numbers[idx])
       end
 
     end
@@ -306,6 +297,7 @@ class ShfApplicationsController < ApplicationController
 
   def validate_company_numbers(application, numbers_str)
     # Validates company numbers specified in shf application form
+    # (also, strips dash(es) from number since only digits allowed)
     # Returns two parameters:
     #  >> a hash with two keys:
     #     :numbers => array of company numbers
@@ -323,6 +315,7 @@ class ShfApplicationsController < ApplicationController
     else
 
       numbers_str.split(/(?:\s*,+\s*|\s+)/).each do |number|
+        number = number.gsub(/-/, '')
 
         company = Company.find_by(company_number: number)
 

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -315,7 +315,7 @@ class ShfApplicationsController < ApplicationController
     else
 
       numbers_str.split(/(?:\s*,+\s*|\s+)/).each do |number|
-        number = number.gsub(/-/, '')
+        number = number.delete('-')
 
         company = Company.find_by(company_number: number)
 

--- a/app/views/companies/_company_create_modal.html.haml
+++ b/app/views/companies/_company_create_modal.html.haml
@@ -30,7 +30,7 @@
                                                        data: {toggle: 'tooltip'} }
 
                 .col-sm-7
-                  = f.text_field :company_number, class: 'wpcf7-form-control', size: 10
+                  = f.number_field :company_number, class: 'wpcf7-form-control', size: 10
 
               .row
                 .col-sm-5

--- a/app/views/companies/_form.html.haml
+++ b/app/views/companies/_form.html.haml
@@ -9,7 +9,7 @@
 
   %span.glyphicon.glyphicon-info-sign{ title: "#{t('.org_nr_tooltip')}",
                                        data: {toggle: 'tooltip'} }
-  = f.text_field :company_number, class: 'wpcf7-form-control'
+  = f.number_field :company_number, class: 'wpcf7-form-control'
 
   = f.label :phone_number, "#{t('companies.telephone_number')}"
   = f.text_field :phone_number, class: 'wpcf7-form-control'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,6 +263,7 @@ en:
             companies:
               blank: '- Specify an existing company number (or create new company)'
               invalid: "%{value} is not a valid Swedish company number"
+              not_found: 'Company with number %{value} not found'
 
 
       messages:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -264,6 +264,7 @@ sv:
             companies:
               blank: '- Ange ett befintligt företagsnummer (eller skapa ett nytt företag)'
               invalid: "%{value} är inte ett svenskt organisationsnummer"
+              not_found: 'Företag med organisationsnummer% {value} inte hittat'
 
       messages:
         record_invalid: 'Ett fel uppstod: %{errors}'

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -66,7 +66,7 @@ Feature: Create a new membership application
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
       | shf_applications.show.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 5560360793, 2120000142               | 031-1234567                       | info@craft.se                      |
+      | 5560360793, 212000-0142              | 031-1234567                       | info@craft.se                      |
     And I select "Groomer" Category
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
@@ -86,11 +86,11 @@ Feature: Create a new membership application
     And I click on t("menus.nav.users.apply_for_membership")
     And I fill in the translated form with data:
       | shf_applications.show.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 55603607, 2120000142                 | 031-1234567                       | info@craft.se                      |
+      | 556036-07, 2120000142                | 031-1234567                       | info@craft.se                      |
     And I select "Groomer" Category
     And I click on t("shf_applications.new.submit_button_label")
-    And I should see t("activerecord.errors.models.shf_application.attributes.companies.invalid", value: '55603607')
-    Then I fill in t("shf_applications.show.company_number") with "5560360793, 2120000142"
+    And I should see t("activerecord.errors.models.shf_application.attributes.companies.not_found", value: '55603607')
+    Then I fill in t("shf_applications.show.company_number") with "556036-0793, 2120000142"
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: info@craft.se)
@@ -102,7 +102,7 @@ Feature: Create a new membership application
     Given I am on the "new application" page
     And I fill in the translated form with data:
       | shf_applications.show.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 55603607                             | 031-1234567                       | info@craft.se                      |
+      | 556036-07                            | 031-1234567                       | info@craft.se                      |
 
     # Create new company in modal
     And I click on t("companies.new.title")
@@ -113,8 +113,8 @@ Feature: Create a new membership application
     And I wait for all ajax requests to complete
 
     And I click on t("shf_applications.new.submit_button_label")
-    And I should see t("activerecord.errors.models.shf_application.attributes.companies.invalid", value: '55603607')
-    Then I fill in t("shf_applications.show.company_number") with "5560360793, 2286411992"
+    And I should see t("activerecord.errors.models.shf_application.attributes.companies.not_found", value: '55603607')
+    Then I fill in t("shf_applications.show.company_number") with "556036-0793, 2286411992"
     And I click on t("shf_applications.new.submit_button_label")
     Then I should be on the "user instructions" page
     And I should see t("shf_applications.create.success", email_address: info@craft.se)

--- a/features/edit_shf_application.feature
+++ b/features/edit_shf_application.feature
@@ -37,7 +37,7 @@ Feature: As an applicant
     And I am on the "landing" page
     And I click on t("menus.nav.users.my_application")
     Then I should be on "Edit My Application" page
-    Then I fill in t("shf_applications.show.company_number") with "5560360793, 2120000142"
+    Then I fill in t("shf_applications.show.company_number") with "5560360793, 212000-0142"
     And I click on t("shf_applications.edit.submit_button_label")
     Then I should be on the "show my application" page for "emma@random.com"
     And I should see t("shf_applications.update.success", email_address: info@craft.se)
@@ -71,11 +71,11 @@ Feature: As an applicant
 
     And I fill in the translated form with data:
       | shf_applications.show.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 55603607, 2120000142                 | 031-1234567                       | info@craft.se                      |
+      | 556036-07, 2120000142                | 031-1234567                       | info@craft.se                      |
 
     And I click on t("shf_applications.edit.submit_button_label")
-    And I should see t("activerecord.errors.models.shf_application.attributes.companies.invalid", value: '55603607')
-    Then I fill in t("shf_applications.show.company_number") with "5560360793, 2120000142"
+    And I should see t("activerecord.errors.models.shf_application.attributes.companies.not_found", value: '55603607')
+    Then I fill in t("shf_applications.show.company_number") with "556036-0793, 2120000142"
     And I click on t("shf_applications.edit.submit_button_label")
     Then I should be on the "show my application" page for "hans@random.com"
     And I should see t("shf_applications.update.success", email_address: info@craft.se)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/157127772

Changes proposed in this pull request:
1. Change company `_form` and `_create_company_modal` to only allow digits in company_number field
2. Correct error message in SHF form when an incorrect company_number is entered in the company_number field (previously, the error said that the number was _invalid_ (even though is might be an actual valid number) but now states that the number is not found in the system.
3. Allow the user to enter a company_number using dash(es) within the number (a typical way of writing the number) (the code strips out the number before validation).
4. Adjusted acceptance tests to include data that tests the above changes.

Screenshots (Optional):

### Creating a company number but entering non-digit in number field:

<img width="523" alt="screen shot 2018-04-27 at 8 53 13 am" src="https://user-images.githubusercontent.com/9968213/39363797-8a219e60-49f9-11e8-8ead-fd9e2b8020db.png">

### User enters company_number that is not in the DB (in SHF application form):

<img width="772" alt="screen shot 2018-04-27 at 8 53 57 am" src="https://user-images.githubusercontent.com/9968213/39363820-a46a9592-49f9-11e8-9591-e2eecb56e439.png">

### User enters a valid (in DB) number (shf app form), but with a dash:

<img width="434" alt="screen shot 2018-04-27 at 8 54 12 am" src="https://user-images.githubusercontent.com/9968213/39363849-c324031a-49f9-11e8-8418-77a02676ef96.png">

### Company number from above is processed correctly:

<img width="392" alt="screen shot 2018-04-27 at 8 54 21 am" src="https://user-images.githubusercontent.com/9968213/39363869-d2c63554-49f9-11e8-9521-6b415b9710ad.png">




Ready for review:
@AgileVentures/shf-project-team 