### PR TITLE
Allow external site to show SHF images in iframe

### DIFF
--- a/app/assets/stylesheets/company-h-brand.css
+++ b/app/assets/stylesheets/company-h-brand.css
@@ -5,6 +5,7 @@ body {
 .company-h-brand-div {
   background-color: #e4e3df;
   border: 1px solid black;
+  box-sizing: border-box;
   display: block;
   font-size: 14px;
   font-style: normal;

--- a/app/assets/stylesheets/proof-of-membership.css
+++ b/app/assets/stylesheets/proof-of-membership.css
@@ -4,6 +4,7 @@ body {
 
 .parent-div {
   border: 1px solid black;
+  box-sizing: border-box;
   display: block;
   font-size: 14px;
   font-style: normal;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,7 @@ class UsersController < ApplicationController
   before_action :set_app_config, only: [:show, :proof_of_membership, :update,
                                         :company_h_brand]
   before_action :authorize_user, only: [:show]
+  before_action :allow_iframe_request, only: [:proof_of_membership, :company_h_brand]
 
   def show
   end
@@ -123,6 +124,12 @@ class UsersController < ApplicationController
 
   def payment_params
     params.require(:payment).permit(:expire_date, :notes)
+  end
+
+  def allow_iframe_request
+    response.headers.delete('X-Frame-Options')
+    # https://stackoverflow.com/questions/17542511/
+    # cannot-display-my-rails-4-app-in-iframe-even-if-x-frame-options-is-allowall
   end
 
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/155306891


Changes proposed in this pull request:
1. Set response header to allow an external site to show SHF images (proof-of-membership, company h-branding) in a local iframe. 
2. Adjusted css to use `box-sizing: border-box;` to remove uncertainty on browser handling of div `width` attribute.
3. This PR does _not_ include UI information for how the user may be able to use this feature, nor a simple way to get a link to do so - that is for a subsequent PR.

Screenshots (Optional):

Here is a depiction of two images shown in an "external" site:

<img width="523" alt="screen shot 2018-05-09 at 8 03 17 am" src="https://user-images.githubusercontent.com/9968213/39813707-76009f7a-535f-11e8-872b-eec738d9d369.png">

(the load-time shown in the upper leg-hand corner of each image only appears in development - the use would never see that).
---
(this was rendered with this code (in dev, local env)):
```
<!DOCTYPE html>
<html>
  <body>
    <div>
      <iframe src='http://localhost:3000/anvandare/32/proof_of_membership'
       height="510" width="276" style="border:none;">
      </iframe>

      <iframe src='http://localhost:3000/en/anvandare/32/company_h_brand?company_id=31'
       height="430" width="316" style="border:none;">
      </iframe>
    </div
  </body>
</html>
```

Ready for review:
@AgileVentures/shf-project-team 