### PR TITLE
Selective loading of hips.js and ckeditor.js

### DIFF
--- a/app/views/companies/edit.html.haml
+++ b/app/views/companies/edit.html.haml
@@ -1,3 +1,6 @@
+- content_for :javascript_for_view do
+  = javascript_include_tag Ckeditor.cdn_url
+
 %header.entry-header
   %h1.entry-title= t('.title', company_name: @company.name)
   .post-title-divider

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,11 +16,11 @@
     = javascript_include_tag 'application'
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.2/js/select2.full.min.js'
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/i18n/sv.js'
-    = javascript_include_tag Ckeditor.cdn_url
     = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=" + |
                              "#{Geocoder.config[:api_key]}&language=#{I18n.locale}" + |
                              "&region=SE" |
-    = javascript_include_tag HIPS_JS_CDN
+
+    = yield :javascript_for_view  # javascript markup specific to a view
 
 
     - if Rails.env.test?
@@ -29,7 +29,7 @@
         increase speed of the test suite and fix intermittent integration test failures.
 
         Without this, we were seeing frequent intermittent test failures with
-        jquery functions that invovle animations, especially with show() and hide().
+        jquery functions that involve animations, especially with show() and hide().
         @see https://github.com/guidance-guarantee-programme/pension_guidance/pull/610
 
       :javascript

--- a/app/views/payments/create.html.haml
+++ b/app/views/payments/create.html.haml
@@ -1,3 +1,6 @@
+- content_for :javascript_for_view do
+  = javascript_include_tag HIPS_JS_CDN
+
 %header.entry-header
   %h1.entry-title
     - payment_type = t("payment.payment_type.#{@payment.payment_type}")

--- a/app/views/shf_documents/_contents_form.html.haml
+++ b/app/views/shf_documents/_contents_form.html.haml
@@ -1,4 +1,4 @@
-= form_tag({ controller: 'shf_documents', action: 'contents_update' },
+= form_tag({ controller: 'shf_documents', action: 'contents_update', page: @page },
            { method: 'patch' }) do
 
   = label_tag :title, t('.member_page_title')

--- a/app/views/shf_documents/contents_edit.html.haml
+++ b/app/views/shf_documents/contents_edit.html.haml
@@ -1,3 +1,6 @@
+- content_for :javascript_for_view do
+  = javascript_include_tag Ckeditor.cdn_url
+  
 %header.entry-header
   %h1.entry-title= t('.page_title', document_title: @page)
 

--- a/spec/views/selective_asset_load_spec.rb
+++ b/spec/views/selective_asset_load_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe 'selective loading of external assets on specific pages' do
+
+  before(:each) { view.lookup_context.prefixes +=
+                   ['application', 'companies', 'shf_documents'] }
+
+  describe 'hips.js' do
+
+    let(:member_payment) do
+      create(:payment, status: Payment::ORDER_PAYMENT_STATUS['successful'],
+                       expire_date: Time.zone.today + 1.day)
+    end
+
+    it 'is loaded on payments/create' do
+      assign(:payment, member_payment)
+      assign(:hips_id, '12345')
+
+      render template: 'payments/create', layout: 'layouts/application'
+
+      expect(rendered).to have_xpath("//head/script[contains(@src,'hips.js')]",
+                                     visible: false)
+    end
+
+    it 'is not loaded on other pages' do
+      allow(view).to receive(:current_user) { Visitor.new }
+
+      assign(:all_visible_companies, [])
+      assign(:all_companies, Company.all)
+      assign(:search_params, Company.ransack(nil))
+      assign(:companies, Company.ransack(nil).result.page(params[:page]).per_page(10))
+
+      render template: 'companies/index', layout: 'layouts/application'
+
+      expect(rendered).not_to have_xpath("//head/script[contains(@src,'hips.js')]",
+                                         visible: false)
+    end
+  end
+
+  describe 'ckeditor.js' do
+    let(:document) { create(:shf_document, :txt) }
+    let(:company)  { create(:company) }
+
+    it 'is loaded on companies/edit' do
+      assign(:company, company)
+
+      render template: 'companies/edit', layout: 'layouts/application'
+
+      expect(rendered).to have_xpath("//head/script[contains(@src,'ckeditor.js')]",
+                                     visible: false)
+    end
+
+    it 'is loaded on shf_documents/contents_edit' do
+      assign(:page, document.actual_file_file_name)
+      assign(:title, document.title)
+      assign(:contents, 'This if the document contents')
+
+      render template: 'shf_documents/contents_edit', layout: 'layouts/application'
+
+      expect(rendered).to have_xpath("//head/script[contains(@src,'ckeditor.js')]",
+                                     visible: false)
+    end
+
+    it 'is not loaded on other pages' do
+      allow(view).to receive(:current_user) { Visitor.new }
+      assign(:company, company)
+      assign(:shf_document, document)
+
+      without_partial_double_verification do
+        # http://rspec.info/blog/2017/05/rspec-3-6-has-been-released/
+        allow(view).to receive(:policy).and_return(double('cmpy policy',
+                                                          update?: false,
+                                                          index?: false,
+                                                          destroy?: false))
+
+        render template: 'companies/show', layout: 'layouts/application'
+        expect(rendered).not_to have_xpath("//head/script[contains(@src,'ckeditor.js')]",
+                                           visible: false)
+
+        render template: 'shf_documents/show', layout: 'layouts/application'
+        expect(rendered).not_to have_xpath("//head/script[contains(@src,'ckeditor.js')]",
+                                           visible: false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/153991394

This PR uses the same selective-load strategy as #456, but with these differences:
1. Selectively loads _only_ hips.js and creditor.js - google maps JS could be handled in another PR, following the pattern established here (although in almost all cases the likelihood of a session _not_ loading that JS is very small, so it may not be worth handling selectively).
2. I used rspec `view` specs for testing selective loading (instead of cucumber tests).


Ready for review:
@AgileVentures/shf-project-team 