### PR TITLE
Added image-use guidelines links for proof-of-membership and personal h-brand

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -119,6 +119,9 @@ body {
 a, a:hover {
 	color: #003a78;
 }
+.underlined_link {
+  text-decoration: underline;
+}
 .widget .post-categories a, .widget .post-categories a:hover, .cat-links, .post-social a:hover, .post-comments a:hover .comments-number, .cat-item a:hover, .widget_archive a:hover, .wordchef .popular-title a:hover, .wordchef .recent-post-title a:hover, .recent-comment-excerpt a:hover, .site-info a, .footer-social a:hover, .paging-navigation a:hover, #author-area .author-social-profiles a:hover, #related-posts .related-post-title a:hover, #cancel-comment-reply-link:hover, .toggle-sub-menu:hover, .toggle-sub-menu-active, blockquote p:before, .recent-comment-excerpt a, .read-more-link a:hover, .featured-read-more a:hover, button:hover, input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover, .widget_recent_comments a, .scroll-to-top a, .post-categories a, .post-categories a:hover, .entry-header a:hover {
 	color: #5692CE;
 }

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -124,7 +124,13 @@
         %br
         %br
         = t('.proof_of_membership_photo_needed')
-        = link_to(t('devise.registrations.edit.title'), edit_user_registration_path)
+        = link_to(t('devise.registrations.edit.title'), edit_user_registration_path,
+                  class: 'underlined_link')
+        %br
+        %br
+        = t('.image_use_guidelines_html', use_guidelines_link: link_to(t('.use_guidelines'),
+            'https://hitta.sverigeshundforetagare.se/dokument/innehall/hmarket',
+            class: 'underlined_link'))
 
     - @user.companies.all.each do |company|
 
@@ -154,6 +160,11 @@
                                  company_h_brand_path(@user,
                                                        company_id: company.id),
                                      class: 'btn btn-xs btn-info'))
+          %br
+          %br
+          = t('.image_use_guidelines_html', use_guidelines_link: link_to(t('.use_guidelines'),
+              'https://hitta.sverigeshundforetagare.se/dokument/innehall/hmarket',
+              class: 'underlined_link'))
 
 
 = render partial: 'edit_status_modal', locals: { user: @user }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -691,6 +691,9 @@ en:
                         take a screenshot (%{show_link}) and then use it on
                         your website, in social media or print to use in a
                         physical context, for example, to show a customer.
+      image_use_guidelines_html: Please note that your use of this image is subject to
+                                 these %{use_guidelines_link}.
+      use_guidelines: guidelines
       download_image: Download Image
       show_image: Show Image
       company_h_brand: Company H-Brand for %{company}

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -692,6 +692,9 @@ sv:
                              använda den på din hemsida, i sociala medier eller
                              skriva ut för att använda i fysisk kontext, exempelvis
                              för att visa kund.
+      image_use_guidelines_html: Observera att din användning av denna bild är föremål
+                                 för dessa %{use_guidelines_link}.
+      use_guidelines: riktlinjer
       download_image: Ladda ner bild
       show_image: Visa bild
       company_h_brand: Företaget H-märke för %{company}


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/157613392


Screenshots (Optional):
<img width="854" alt="screen shot 2018-05-16 at 5 49 11 am" src="https://user-images.githubusercontent.com/9968213/40110122-32a1400e-58cd-11e8-8a46-d79d99d0ca25.png">

---

<img width="859" alt="screen shot 2018-05-16 at 5 49 21 am" src="https://user-images.githubusercontent.com/9968213/40110130-3610be7c-58cd-11e8-83d0-679c87444be4.png">

Ready for review:
@AgileVentures/shf-project-team 