### PR TITLE
Images can now be used in external iframe

### DIFF
--- a/app/assets/stylesheets/company-h-brand.css
+++ b/app/assets/stylesheets/company-h-brand.css
@@ -1,8 +1,9 @@
 body {
   font-family: 'Open Sans', sans-serif;
+  margin: 0;
 }
 
-.company-h-brand-div {
+#company-h-brand {
   background-color: #e4e3df;
   border: 1px solid black;
   box-sizing: border-box;

--- a/app/assets/stylesheets/proof-of-membership.css
+++ b/app/assets/stylesheets/proof-of-membership.css
@@ -1,8 +1,9 @@
 body {
   font-family: 'Open Sans', sans-serif;
+  margin: 0;
 }
 
-.parent-div {
+#proof-of-membership {
   border: 1px solid black;
   box-sizing: border-box;
   display: block;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -90,6 +90,7 @@ class UsersController < ApplicationController
     render_to_string(partial: image_type,
                      locals: { app_config: @app_configuration, user: @user,
                                render_to: params[:render_to]&.to_sym,
+                               context: params[:context]&.to_sym,
                                company: Company.find_by_id(params[:company_id]) })
   end
 

--- a/app/views/users/_company_h_brand.html.haml
+++ b/app/views/users/_company_h_brand.html.haml
@@ -8,23 +8,41 @@
 
       - render_to = :html unless local_assigns[:render_to]
 
-      .company-h-brand-div
+      - if app_config.h_brand_logo
+        = image_tag(paperclip_path(app_config.h_brand_logo, :standard, render_to),
+                    class: 'h-brand-logo')
 
-        - if app_config.h_brand_logo
-          = image_tag(paperclip_path(app_config.h_brand_logo, :standard, render_to),
-                      class: 'h-brand-logo')
+      .current-year
+        = Time.zone.now.year
 
-        .current-year
-          = Time.zone.now.year
+      - if app_config.sweden_dog_trainers
+        = image_tag(paperclip_path(app_config.sweden_dog_trainers,
+                    :standard, render_to), class: 'sweden-dog-trainers')
 
-        - if app_config.sweden_dog_trainers
-          = image_tag(paperclip_path(app_config.sweden_dog_trainers,
-                      :standard, render_to), class: 'sweden-dog-trainers')
+      %hr.company-info-separator
 
-        %hr.company-info-separator
+      %p.company-info
+        %span.company-name
+          = company.name
+        %br
+        = list_categories(company, ', ')
 
-        %p.company-info
-          %span.company-name
-            = company.name
-          %br
-          = list_categories(company, ', ')
+    - if render_to == :html && context == :internal
+      %div
+        %br
+        = t('users.show.image_dimensions_html', width_id: 'h-brand-width',
+            height_id: 'h-brand-height')
+        %br
+        %br
+        = t('users.show.use_this_image_link_html')
+        = company_h_brand_url(user, company_id: company.id)
+
+      :javascript
+        window.onload = function(){
+          var image = document.getElementById('company-h-brand');
+
+          if (image !== undefined) {
+            document.getElementById('h-brand-width').textContent = image.offsetWidth;
+            document.getElementById('h-brand-height').textContent = image.offsetHeight;
+          }
+        };

--- a/app/views/users/_proof_of_membership.html.haml
+++ b/app/views/users/_proof_of_membership.html.haml
@@ -3,49 +3,68 @@
     = stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Open+Sans:400,700'
     = stylesheet_link_tag 'proof-of-membership', media: 'all'
   %body
+
+    - render_to = :html unless local_assigns[:render_to]
+
     #proof-of-membership
+      - if app_config.shf_logo
+        = image_tag(paperclip_path(app_config.shf_logo, :standard, render_to),
+                    class: 'shf-logo')
 
-      - render_to = :html unless local_assigns[:render_to]
+      %p.proof-banner
+        BEHÖRIGHETSBEVIS
 
-      .parent-div
-        - if app_config.shf_logo
-          = image_tag(paperclip_path(app_config.shf_logo, :standard, render_to),
-                      class: 'shf-logo')
+      .member-photo-div
+        - if user.member_photo
+          = image_tag(paperclip_path(user.member_photo, :standard, render_to),
+                      class: 'member-photo')
 
-        %p.proof-banner
-          BEHÖRIGHETSBEVIS
+      %p.member-info
+        %span.member-name
+          = user.full_name
+        %br
+        - if user.membership_current?
 
-        .member-photo-div
-          - if user.member_photo
-            = image_tag(paperclip_path(user.member_photo, :standard, render_to),
-                        class: 'member-photo')
-
-        %p.member-info
-          %span.member-name
-            = user.full_name
+          Medlemsnr.:
+          %span.membership-number
+            #{user.membership_number}
           %br
-          - if user.membership_current?
 
-            Medlemsnr.:
-            %span.membership-number
-              #{user.membership_number}
-            %br
+          #{list_app_categories(user.shf_application)}
 
-            #{list_app_categories(user.shf_application)}
+          %br
+          %span.issued-by
+            Utfärdat av:
+          %br
+          - if app_config.chair_signature
+            = image_tag(paperclip_path(app_config.chair_signature,
+                                       :standard, render_to))
+          %br
+          Giltigt till #{user.membership_expire_date}
+          %br
+          -# Kategorier: #{list_app_categories(user.shf_application)}
+        - else
+          Medlemskapet löpte ut
 
-            %br
-            %span.issued-by
-              Utfärdat av:
-            %br
-            - if app_config.chair_signature
-              = image_tag(paperclip_path(app_config.chair_signature,
-                                         :standard, render_to))
-            %br
-            Giltigt till #{user.membership_expire_date}
-            %br
-            -# Kategorier: #{list_app_categories(user.shf_application)}
-          - else
-            Medlemskapet löpte ut
+      %p.proof-footer
+        sverigeshundforetagare.se
 
-        %p.proof-footer
-          sverigeshundforetagare.se
+    - if render_to == :html && context == :internal
+      %div
+        %br
+        = t('users.show.image_dimensions_html', width_id: 'pom-width',
+            height_id: 'pom-height')
+        %br
+        %br
+        = t('users.show.use_this_image_link_html')
+        = proof_of_membership_url(@user)
+
+      :javascript
+        window.onload = function(){
+          var image = document.getElementById('proof-of-membership');
+
+          if (image !== undefined) {
+            document.getElementById('pom-width').textContent = image.offsetWidth;
+            document.getElementById('pom-height').textContent = image.offsetHeight;
+          }
+        };

--- a/app/views/users/_proof_of_membership.html.haml
+++ b/app/views/users/_proof_of_membership.html.haml
@@ -57,7 +57,7 @@
         %br
         %br
         = t('users.show.use_this_image_link_html')
-        = proof_of_membership_url(@user)
+        = proof_of_membership_url(user)
 
       :javascript
         window.onload = function(){

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -104,7 +104,8 @@
     .row
       .col-md-5
         = render partial: 'proof_of_membership',
-                 locals: { app_config: @app_configuration, user: @user }
+                 locals: { app_config: @app_configuration, user: @user,
+                           context: :user_show }
 
       .col-md-7
         %span.standard-label= t('.proof_of_membership')
@@ -118,9 +119,8 @@
                                    proof_of_membership_path(@user, render_to: :jpg),
                                    class: 'btn btn-xs btn-info'),
             show_link: link_to(t('.show_image'),
-                                 proof_of_membership_path(@user),
+                                 proof_of_membership_path(@user, context: :internal),
                                  class: 'btn btn-xs btn-info'))
-
         %br
         %br
         = t('.proof_of_membership_photo_needed')
@@ -141,7 +141,8 @@
       .row
         .col-md-5
           = render partial: 'company_h_brand',
-                   locals: { app_config: @app_configuration, company: company }
+                   locals: { app_config: @app_configuration, company: company,
+                             context: :user_show, user: @user }
 
         .col-md-7
           %span.standard-label= t('.company_h_brand', company: company.name)
@@ -158,7 +159,8 @@
                                      class: 'btn btn-xs btn-info'),
               show_link: link_to(t('.show_image'),
                                  company_h_brand_path(@user,
-                                                       company_id: company.id),
+                                                      company_id: company.id,
+                                                      context: :internal),
                                      class: 'btn btn-xs btn-info'))
           %br
           %br

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -687,15 +687,21 @@ en:
       proof_of_membership_describe: This image is your proof of membership in SHF.
       proof_of_membership_photo_needed: 'If you see "Photo Unavailable" then please
                                          upload a photo of yourself here: '
-      image_how_to_use_html: You can download the image (%{download_link}) or
-                        take a screenshot (%{show_link}) and then use it on
-                        your website, in social media or print to use in a
+      image_how_to_use_html: You can download the image (%{download_link}),
+                        take a screenshot, or link to it from your website
+                        (%{show_link}), and use it in social media or print to use in a
                         physical context, for example, to show a customer.
       image_use_guidelines_html: Please note that your use of this image is subject to
                                  these %{use_guidelines_link}.
       use_guidelines: guidelines
       download_image: Download Image
       show_image: Show Image
+      image_dimensions_html: "The image width is <span id='%{width_id}'></span>
+                             pixels and the height is
+                             <span id='%{height_id}'></span> pixels."
+      use_this_image_link_html: "<span style='font-weight: bold'>
+                                Use this link in an external website:
+                                </span>"
       company_h_brand: Company H-Brand for %{company}
       company_h_brand_describe: This image is your company's H-Brand.
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -687,15 +687,21 @@ sv:
       proof_of_membership_photo_needed: 'Om du saknar profilbild (ser "Photo
                                         Unavailable"), ladda upp en bild av dig
                                         själv (utan hund) här: '
-      image_how_to_use_html: Du kan ladda ner bilden (%{download_link}) eller
-                             ta en skärmdump (%{show_link}) för att sedan
-                             använda den på din hemsida, i sociala medier eller
-                             skriva ut för att använda i fysisk kontext, exempelvis
-                             för att visa kund.
+      image_how_to_use_html: Du kan ladda ner bilden (%{download_link}), ta en
+                             skärmdump eller länka till den från din webbplats
+                             (%{show_link}) och använda den i sociala medier
+                             eller skriva ut för att använda i ett fysiskt
+                             sammanhang, till exempel att visa en kund.
       image_use_guidelines_html: Observera att din användning av denna bild är föremål
                                  för dessa %{use_guidelines_link}.
       use_guidelines: riktlinjer
       download_image: Ladda ner bild
+      image_dimensions_html: "Bildbredden är <span id = '%{width_id}'></span>
+                              pixlar och höjden är
+                              <span id = '%{height_id}'></span> pixlar."
+      use_this_image_link_html: "<span style='font-weight: bold'>
+                                Använd den här länken på en extern webbplats:
+                                </span>"
       show_image: Visa bild
       company_h_brand: Företaget H-märke för %{company}
       company_h_brand_describe: Detta är ditt företags H-märke.


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/157625481


Changes proposed in this pull request:

1. Changed style sheets for each image (prood-of-membership, company h-brand) to prevent the browser from adding default margins (which happens if the _body_ element has no margins associated with it).  (the default margins are added even when the image is rendered in an iframe in an external site).

2. Edited HTML files for image - including adding JS - that allows the user to see the dimensions of an image that could be embedded in an external website (iframe).  The URL for such embedding is also provided.

3. Added to, and adjusted, translations text for the above changes.

Screenshots (Optional):

### User account page - showing adjusted language re image use:

<img width="847" alt="screen shot 2018-05-24 at 6 46 03 am" src="https://user-images.githubusercontent.com/9968213/40481121-67ad135c-5f1e-11e8-8caf-66402c74fa95.png">

### Image-link page 1

<img width="747" alt="screen shot 2018-05-24 at 6 48 27 am" src="https://user-images.githubusercontent.com/9968213/40481162-8a2d69cc-5f1e-11e8-82a7-f5effd817daa.png">

### Image-link page 2

<img width="814" alt="screen shot 2018-05-24 at 6 48 39 am" src="https://user-images.githubusercontent.com/9968213/40481179-90e1899c-5f1e-11e8-9cbc-67a2ef84416b.png">


Ready for review:
@AgileVentures/shf-project-team 