### PR TITLE
Improve backup structure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,5 +129,8 @@ group :test do
   gem 'vcr'      # to record and 'playback' (mock) http requests
 
   gem 'timecop'
+end
 
+group :production do
+  gem 'aws-sdk-s3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,21 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (8.2.0)
       execjs
+    aws-eventstream (1.0.1)
+    aws-partitions (1.91.0)
+    aws-sdk-core (3.21.2)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.5.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.14.0)
+      aws-sdk-core (~> 3, >= 3.21.2)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.2)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -268,6 +283,7 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jmespath (1.4.0)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -543,6 +559,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm (~> 4.11.1)
+  aws-sdk-s3
   bcrypt (~> 3.1.7)
   better_errors
   binding_of_caller

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -74,21 +74,12 @@ class UsersController < ApplicationController
 
   private
 
-<<<<<<< HEAD
-
-  def download_image(type, render_to, width)
-=======
   def download_or_show_image(type, render_to, width)
->>>>>>> 77e160563ea9a5931de07c33524e34352a0302fa
     html = image_html(type)
 
     render html: html.html_safe and return unless render_to == 'jpg'
 
-<<<<<<< HEAD
-    kit = build_kit(html, "#{type.gsub /_/, '-'}.css", width)
-=======
     kit = build_kit(html, "#{type.tr('_', '-')}.css", width)
->>>>>>> 77e160563ea9a5931de07c33524e34352a0302fa
 
     send_data(kit.to_jpg, type: 'image/jpg', filename: "#{type}.jpeg")
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,23 +11,11 @@ class UsersController < ApplicationController
   end
 
   def proof_of_membership
-    html = image_html('proof_of_membership')
-
-    render html: html.html_safe and return unless params[:render_to] == 'jpg'
-
-    kit = build_kit(html, 'proof-of-membership.css', 260)
-
-    send_data(kit.to_jpg, type: 'image/jpg', filename: 'proof_of_membership.jpeg')
+    download_image('proof_of_membership', params[:render_to], 260)
   end
 
   def company_h_brand
-    html = image_html('company_h_brand')
-
-    render html: html.html_safe and return unless params[:render_to] == 'jpg'
-
-    kit = build_kit(html, 'company-h-brand.css', 300)
-
-    send_data(kit.to_jpg, type: 'image/jpg', filename: 'company_h_brand.jpeg')
+    download_image('company_h_brand', params[:render_to], 300)
   end
 
   def index
@@ -85,6 +73,17 @@ class UsersController < ApplicationController
 
 
   private
+
+
+  def download_image(type, render_to, width)
+    html = image_html(type)
+
+    render html: html.html_safe and return unless render_to == 'jpg'
+
+    kit = build_kit(html, "#{type.gsub /_/, '-'}.css", width)
+
+    send_data(kit.to_jpg, type: 'image/jpg', filename: "#{type}.jpeg")
+  end
 
   def image_html(image_type)
     render_to_string(partial: image_type,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,11 +11,23 @@ class UsersController < ApplicationController
   end
 
   def proof_of_membership
-    download_image('proof_of_membership', params[:render_to], 260)
+    html = image_html('proof_of_membership')
+
+    render html: html.html_safe and return unless params[:render_to] == 'jpg'
+
+    kit = build_kit(html, 'proof-of-membership.css', 260)
+
+    send_data(kit.to_jpg, type: 'image/jpg', filename: 'proof_of_membership.jpeg')
   end
 
   def company_h_brand
-    download_image('company_h_brand', params[:render_to], 300)
+    html = image_html('company_h_brand')
+
+    render html: html.html_safe and return unless params[:render_to] == 'jpg'
+
+    kit = build_kit(html, 'company-h-brand.css', 300)
+
+    send_data(kit.to_jpg, type: 'image/jpg', filename: 'company_h_brand.jpeg')
   end
 
   def index
@@ -73,17 +85,6 @@ class UsersController < ApplicationController
 
 
   private
-
-
-  def download_image(type, render_to, width)
-    html = image_html(type)
-
-    render html: html.html_safe and return unless render_to == 'jpg'
-
-    kit = build_kit(html, "#{type.gsub /_/, '-'}.css", width)
-
-    send_data(kit.to_jpg, type: 'image/jpg', filename: "#{type}.jpeg")
-  end
 
   def image_html(image_type)
     render_to_string(partial: image_type,

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -1,0 +1,83 @@
+require 'active_support/logger'
+
+LOG_FILE = 'log/backup'
+BACKUP_FILES_DIR = '/home/deploy/SHF_BACKUPS/'
+
+CODE_BACKUPS_TO_KEEP = 4
+DB_BACKUPS_TO_KEEP = 15
+
+
+# "keep" key defines how many backups (code or DB) to retain on _local_ storage.
+# AWS (S3) backup files are retained based on settings in AWS.
+BACKUP_TARGETS = [
+  { location: '/var/www/shf/current/', filebase: 'current.tar.',
+    type: 'file', keep: CODE_BACKUPS_TO_KEEP },
+  { location: 'shf_project_production', filebase: 'db_backup.sql.',
+    type: 'db', keep: DB_BACKUPS_TO_KEEP }
+]
+
+desc 'backup code and DB'
+task :backup => [:environment] do
+
+  ActivityLogger.open(LOG_FILE, 'SHF_TASK', 'Backup') do |log|
+
+    today = Time.now.strftime '%Y-%m-%d'
+
+    # Backup to local storage
+
+    backup_files = []
+
+    BACKUP_TARGETS.each do |backup_target|
+
+      backup_file = BACKUP_FILES_DIR + backup_target[:filebase] + today + '.gz'
+      backup_files << backup_file
+
+      log.record('info', "Backing up to: #{backup_file}")
+
+      case backup_target[:type]
+      when 'file'
+        %x<tar -chzf #{backup_file} #{backup_target[:location]}>
+
+      when 'db'
+        %x(pg_dump -d #{backup_target[:location]} | gzip > #{backup_file})
+
+      end
+
+    end
+
+    # Copy backup files to S3
+
+    log.record('info', 'Moving backup files to AWS S3')
+
+    s3 = Aws::S3::Resource.new(
+      region: ENV['SHF_AWS_S3_BACKUP_REGION'],
+      credentials: Aws::Credentials.new(ENV['SHF_AWS_S3_BACKUP_KEY_ID'],
+                                        ENV['SHF_AWS_S3_BACKUP_SECRET_ACCESS_KEY']))
+
+    bucket = ENV['SHF_AWS_S3_BACKUP_BUCKET']
+
+    bucket_folder = "production_backup/#{today}/" # S3 will show objects in folders
+
+    backup_files.each do |file|
+      obj = s3.bucket(bucket).object(bucket_folder + File.basename(file))
+
+      obj.upload_file(file)
+    end
+
+    # Prune older backups beyond "keep" (days) limit
+
+    log.record('info', 'Pruning older backups on local storage')
+
+    BACKUP_TARGETS.each do |backup_target|
+      file_pattern = BACKUP_FILES_DIR + backup_target[:filebase] + '*'
+      backup_files = Dir.glob(file_pattern)
+
+      if backup_files.length > backup_target[:keep]
+        delete_files = backup_files.sort[0, backup_files.length - backup_target[:keep]]
+
+        delete_files.each { |file| File.delete(file) }
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/157839677


Changes proposed in this pull request:
1. Created a rails task to perform backups in production
2. Added AWS S3 SDK gem to production group

NOTE: backup logging will now go to the standard `/log` directory.

The rails task file has been moved to production at this point.  The cron job that runs it looks like this:
```
30 2 * * * cd /home/deploy/shf/current && /bin/bash -l -c 'bin/rails backup 2>&1'
```
So, when we move this PR to production we don't have to do anything special to initiate backups with this structure.

Ready for review:
@AgileVentures/shf-project-team 