### PR TITLE
added translations for en/sv.activerecord.errors.models.shf_applicati…

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -273,6 +273,9 @@ en:
               not_found: 'with number %{value} not found.
                           Click the “New company” button to create the company,
                           then try to send your application again.'
+            company_number: 
+              invalid: " is not a valid Swedish company number"
+
 
 
       messages:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -272,6 +272,8 @@ sv:
               not_found: 'med organisationsnummer %{value} inte hittat.
                           Klicka på knappen "Nytt företag" för att skapa företaget
                           och försök sedan skicka din ansökan igen.'
+            company_number: 
+              invalid: " är inte ett svenskt organisationsnummer"
 
       messages:
         record_invalid: 'Ett fel uppstod: %{errors}'


### PR DESCRIPTION
…on.attributes.company_number.invalid

PT Story: 


Changes proposed in this pull request:
1. Adding translations for en/sv.activerecord.errors.models.shf_application.attributes.company_number.invalid (I don't know swedish, sv.activerecord.errors.models.shf_application.attributes.companies.invalid used as with english)

Ready for review:
@
