### PR TITLE
Change production log level to INFO (not DEBUG)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
### PT Story: Change production log level to INFO (not DEBUG)
https://www.pivotaltracker.com/story/show/161821639

### Changes proposed in this pull request:
1. changed the log level in `config/environments/production.rb`


Ready for review:
@AgileVentures/shf-project-team 
