### PR TITLE
161659540 - Removes image, adds reference

### DIFF
--- a/app/views/shf_applications/information.html.haml
+++ b/app/views/shf_applications/information.html.haml
@@ -21,7 +21,7 @@
       = image_tag('medlem.png')
       %p
       %p= t('.member.using_the_h_mark')
-      %p Du hittar ditt h-märke och ditt behörighetsbevis under ditt konto. 
+      %p= t('.member.ffs')
 
   - elsif current_user.has_shf_application?
 

--- a/app/views/shf_applications/information.html.haml
+++ b/app/views/shf_applications/information.html.haml
@@ -11,6 +11,8 @@
 
     = render partial: 'check_payment_status'
 
+    %hr
+
     - unless current_user.membership_expire_date.past?
 
       %p= t('.member.using_the_logo')
@@ -19,7 +21,7 @@
       = image_tag('medlem.png')
       %p
       %p= t('.member.using_the_h_mark')
-      = image_tag('h-marke.png')
+      %p Du hittar ditt h-märke och ditt behörighetsbevis under ditt konto. 
 
   - elsif current_user.has_shf_application?
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -396,6 +396,7 @@ en:
                         This shows that you have achieved the H-mark and so
                         provide more value. The H-mark image is below.
                         It should be linked to:"
+        ffs: You find the image in your account.
 
       user:
         title: "Hey -- we're glad you're interested!"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -340,7 +340,7 @@ sv:
     create:
       success: "Tack, din ansökan har skickats. Du borde få en bekräftelse inom kort till %{email_address}."
       error: Ett eller flera problem hindrade din ansökan från att skickas.
-      success_with_file_problem: DIN ANSÖKAN HAR SKAPATS, MEN OBSERVERA FELMEDDELANDE(ER) HÄR
+      success_with_file_problem: DIN ANSÖKAN HAR SKAPATS, MEN OBSERVERA FELMEDDELANDE(N) HÄR
 
     edit:
       title: Redigera ansökan om medlemskap
@@ -390,6 +390,7 @@ sv:
         using_the_h_mark: 'Vi önskar även att du pryder din hemsida med H-märket.
                           För att visa att ni är just H-märkta med allt vad det innebär.
                           Bilden nedan nyttjas i detta syfte och länkas till: "http://sverigeshundforetagare.se/agare/h-markt-av-sveriges-hundforetagare/"'
+        ffs: Du hittar ditt h-märke och ditt behörighetsbevis under ditt konto. 
       waiting_for_approval:
         title: Hej, kul att du vill bli medlem
         in_process: Vi håller på att hantera din ansökan.


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/161659540

Changes proposed in this pull request:
1. Remove the generic H-brand image and reference to where they now can find it if they are paid up. 
