### PR TITLE
SHF Slack notifier

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -16,4 +16,4 @@ SHF_SHOW_FEATURE='yes'
 # this var in .env.test
 
 # For testing notifications (e.g. backups, exceptions.)
-#SHF_SLACK_CHANNEL='notification-testing'
+SHF_SLACK_CHANNEL='notification-testing'

--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,33 @@
+# Example of what should be in your .env.test file so that tests run successfully.
+#
+# Get the specific settings from a team member.
+# If tests are failing and you think they should be passing,
+# check to be sure you have these settings and that they are correct
+# (verify with another team member).
+
+
+# -------------------------
+# Show pre-release features
+#
+# This is used to support pre-release features that are delivered to
+# production but not yet made visible to users.
+# Most of the time, you WILL NOT define this var as the default logic used
+# in production code is to _not_ make the specific feature visible.
+# Assign the var to 'yes' if you wish to make it visible.
+SHF_SHOW_FEATURE = 'yes'
+
+
+#---------
+# Dinkurs
+#  The id for a company in Dinkurs that we use for testing.
+DINKURS_COMPANY_TEST_ID = 'get_this_from_a_SHF_team_member'
+
+
+#--------------------
+# SLACK Notifcations
+#   The official SHF Slack team webhookand settings for sending notifications:
+SHF_SLACK_WEBHOOKURL = 'get_this_from_a_SHF_team_member'
+#   Set the username to _you_ so that we know you are the one running the tests
+SHF_SLACK_USERNAME = 'your_slack_username_for_the_SHF_Slack_team'
+#   Testing Slack notifications always goes to this channel:
+SHF_SLACK_CHANNEL = 'notification-testing'

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -1,17 +1,12 @@
 require 'active_support/logger'
-require 'slack-notifier'
+require_relative './shf_notify_slack'
 
-LOG_FILE         = 'log/backup'
+
+LOG_FILE         = 'log/backup.log'
 BACKUP_FILES_DIR = '/home/deploy/SHF_BACKUPS/'
 
 CODE_BACKUPS_TO_KEEP = 4
 DB_BACKUPS_TO_KEEP   = 15
-
-SLACK_COLOR_LTBLUE  = '#439FE0'
-SLACK_SUCCESS_COLOR = "good"
-SLACK_FAIL_COLOR    = "danger"
-SLACK_SUCCESS_EMOJI = ':white_check_mark:'
-SLACK_FAIL_EMOJI    = ':x:'
 
 
 # "keep" key defines how many backups (code or DB) to retain on _local_ storage.
@@ -24,60 +19,12 @@ BACKUP_TARGETS = [
 ]
 
 
-def slack_success_notification(task_name, notification_text, emoji: SLACK_SUCCESS_EMOJI)
-
-  slack_notification(task_name, notification_text, emoji: emoji,
-                     color:                               SLACK_SUCCESS_COLOR)
-
-end
-
-
-def slack_fail_notification(task_name, notification_text, emoji: SLACK_FAIL_EMOJI)
-
-  slack_notification(task_name, notification_text, emoji: emoji,
-                     color:                               SLACK_FAIL_COLOR)
-
-end
-
-
-# Sends a notification to Slack. Adds timestamps to the text and uses the emoji.
-#
-# @param source_name [String] - shows in the footer so we know the source of the message
-# @param notification_text [String] - main text for the notification
-# @param emoji [String] (optional) - emoji name to use; must be in the
-#                   Slack format  ":emojiname:"
-#                   see https://www.webpagefx.com/tools/emoji-cheat-sheet/
-def slack_notification(source_name, notification_text,
-                       emoji: SLACK_SUCCESS_EMOJI,
-                       color: SLACK_COLOR_LTBLUE)
-
-  slack_notifier = Slack::Notifier.new ENV['SHF_SLACK_WEBHOOKURL'] do
-    defaults channel:  ENV['SHF_SLACK_CHANNEL'],
-             username: ENV['SHF_SLACK_USERNAME']
-  end
-
-  success_timestamp = DateTime.now.utc
-
-  text = "#{notification_text} #{success_timestamp}"
-
-  details = {
-      'fallback': text,
-      'color':    color,
-      'title':    text,
-      'footer':   "SHF: #{source_name}",
-      'ts':       success_timestamp.to_i
-  }
-  slack_notifier.post attachments: [details], icon_emoji: emoji
-
-end
-
-
 desc 'backup code and DB'
 task :backup => [:environment] do |task|
 
   ActivityLogger.open(LOG_FILE, 'SHF_TASK', 'Backup') do |log|
 
-    begin
+    SHFNotifySlack.notify_after(task.name) do
 
       today = Time.now.strftime '%Y-%m-%d'
 
@@ -137,18 +84,12 @@ task :backup => [:environment] do |task|
         end
       end
 
-      # Send 'backup successful' notification to Slack
-      slack_success_notification(task.name, 'Backup succeeded')
+    end # SHFNotifySlack.notify_after('Backup')
 
-    rescue => err
-
-      slack_fail_notification(task.name, 'Backup raised an error! (')
-      log.record('error', "Backup Failed with:\n #{err.message}")
-
-      raise err
-    end
-
-  end
+  rescue => err
+    log.record('error', "Backup Failed with:\n #{err.message}")
+    raise err
+  end # ActivityLogger
 
 
 end

--- a/lib/tasks/shf_notify_slack.rb
+++ b/lib/tasks/shf_notify_slack.rb
@@ -30,8 +30,14 @@ class SHFNotifySlack
   FOOTER_PREFIX = 'SHF'
 
 
-  # if an error is raised from code_run, send a fail notifcation
-  #  else send a success notification
+  # Surround a block of code with this method.
+  # If an error is raised from code_run, a failure_notification is sent
+  #  and the original error is raised.
+  #
+  # If the code block runs successfully, a successful_notification is sent.
+  #
+  # See the RSpec specification for examples.
+  #
   def self.notify_after(notification_source, success_text: SUCCESS_TEXT,
       failure_text: FAILURE_TEXT,
       success_emoji: SLACK_SUCCESS_EMOJI,

--- a/lib/tasks/shf_notify_slack.rb
+++ b/lib/tasks/shf_notify_slack.rb
@@ -1,0 +1,130 @@
+#!/usr/bin/ruby
+
+require 'slack-notifier'
+
+
+#--------------------------
+#
+# @class SHFNotifySlack
+#
+# @desc Responsibility: Send a notification out to Slack from some SHF task or code.
+#                       Standardizes the format, emjois, and colors.
+#                       Is a simple, standardized wrapper around SlackNotifier.
+#
+# @author Ashley Engelund (ashley.engelund@gmail.com  weedySeaDragon @ github)
+# @date   2018-12-10
+#
+# @file shf_notify_slack.rb
+#
+#--------------------------
+class SHFNotifySlack
+
+  SLACK_COLOR_LTBLUE  = '#439FE0'
+  SLACK_SUCCESS_COLOR = "good"
+  SLACK_FAIL_COLOR    = "danger"
+  SLACK_SUCCESS_EMOJI = ':white_check_mark:'
+  SLACK_FAIL_EMOJI    = ':x:'
+  SUCCESS_TEXT        = 'Successful'
+  FAILURE_TEXT        = 'Failure!'
+
+  FOOTER_PREFIX = 'SHF'
+
+
+  # if an error is raised from code_run, send a fail notifcation
+  #  else send a success notification
+  def self.notify_after(notification_source, success_text: SUCCESS_TEXT,
+      failure_text: FAILURE_TEXT,
+      success_emoji: SLACK_SUCCESS_EMOJI,
+      failure_emoji: SLACK_FAIL_EMOJI)
+
+    yield
+
+    begin
+      self.success_notification(notification_source, text: success_text, emoji: success_emoji)
+    rescue => err
+      raise err
+    end
+
+  rescue => some_error
+    self.failure_notification(notification_source, text: "#{failure_text} #{some_error}", emoji: failure_emoji)
+    raise some_error
+  end
+
+
+  def self.success_notification(notification_source, text: SUCCESS_TEXT,
+      emoji: SLACK_SUCCESS_EMOJI)
+
+    self.notification(notification_source, text,
+                      emoji: emoji,
+                      color: SLACK_SUCCESS_COLOR)
+  end
+
+
+  def self.failure_notification(notification_source, text: FAILURE_TEXT,
+      emoji: SLACK_FAIL_EMOJI)
+
+    self.notification(notification_source, text,
+                      emoji: emoji,
+                      color: SLACK_FAIL_COLOR)
+  end
+
+
+  # Sends a notification to Slack using a Slack::Notifier.
+  # Adds timestamps to the text and uses the emoji.
+  #
+  # @param notification_source [String] - shows in the footer
+  #                   so we know the source of the message. Cannot be blank
+  # @param text [String] - main text for the notification
+  # @param emoji [String] (optional) - emoji name to use; must be in the
+  #                   Slack format  ":emojiname:"
+  #                   see https://www.webpagefx.com/tools/emoji-cheat-sheet/
+  def self.notification(notification_source, text,
+      emoji: SLACK_SUCCESS_EMOJI,
+      color: SLACK_COLOR_LTBLUE)
+
+    raise ArgumentError if notification_source.blank?
+
+
+    slack_notifier = Slack::Notifier.new(ENV['SHF_SLACK_WEBHOOKURL'],
+                                         channel:  ENV['SHF_SLACK_CHANNEL'],
+                                         username: ENV['SHF_SLACK_USERNAME'])
+
+    details = self.make_details(notification_source, text, color: color)
+
+    slack_notifier.post attachments: [details], icon_emoji: emoji
+
+  end
+
+
+  # @param source [String] - a string describing the source of the notification
+  #              Ex: the task name if this is a Rails or Rake task
+  #              Ex: a method or class name
+  #              Ex: a short descriptive text
+  def self.make_details(source, text = '', color: SLACK_COLOR_LTBLUE)
+
+    raise ArgumentError if source.blank?
+
+    success_timestamp = DateTime.now.utc
+    ts_text           = timestamped_text(text, success_timestamp)
+
+    {
+        'fallback': ts_text,
+        'color':    color,
+        'title':    ts_text,
+        'footer':   footer_text(source),
+        'ts':       success_timestamp.to_i
+    }
+  end
+
+
+  def self.timestamped_text(t_text = '', timestamp = DateTime.now.utc)
+    "#{t_text} #{timestamp}"
+  end
+
+
+  def self.footer_text(f_text = '')
+    "#{FOOTER_PREFIX}: #{f_text}"
+  end
+
+end # SHFNotifySlack
+

--- a/spec/rake/check_env_vars_shared_ex.rb
+++ b/spec/rake/check_env_vars_shared_ex.rb
@@ -1,0 +1,25 @@
+# RSpec shared example to check that all needed ENV variables are defined
+#
+# Ex:
+#   require 'check_env_vars_shared'
+#
+#   RSpec.describe 'whatever' do
+#
+#      it_behaves_like 'expected ENV variables exist', %w( SHF_EXPECTED_VAR_1, SHF_EXPECTED_VAR_2)
+#
+#   end
+#
+#
+RSpec.shared_examples "expected ENV variables exist" do | list_of_env_names |
+
+  env_file_info = "Define this in your .env.test file.  See .env.test.example for more info."
+
+  env_hash = ENV.to_hash
+
+  list_of_env_names.each do |env_var|
+
+    it "#{env_var}" do
+      expect(env_hash.fetch(env_var, nil)).not_to be_nil, "You must have the ENV variable '#{env_var}' set.  #{env_file_info}"
+    end
+  end
+end

--- a/spec/rake/shf_notify_slack_spec.rb
+++ b/spec/rake/shf_notify_slack_spec.rb
@@ -1,0 +1,698 @@
+require 'rails_helper'
+
+require_relative './check_env_vars_shared_ex'
+
+require 'timecop'
+
+require_relative '../../lib/tasks/shf_notify_slack'
+
+NOTIFICATION_SOURCE = 'test task'
+
+
+# ===============================================================
+
+RSpec.shared_examples "it has a default and allows custom text" do |default_text, tested_method|
+
+  it "default is '#{default_text}'" do
+
+    expect(SHFNotifySlack).to receive(:notification)
+                                  .with(NOTIFICATION_SOURCE,
+                                        default_text,
+                                        any_args)
+
+    SHFNotifySlack.send(tested_method, NOTIFICATION_SOURCE)
+  end
+
+  it 'can specify custom notification text' do
+
+    custom_notification_text = 'some informative text to show in Slack'
+
+    expect(SHFNotifySlack).to receive(:notification)
+                                  .with(NOTIFICATION_SOURCE,
+                                        custom_notification_text,
+                                        any_args)
+
+
+    SHFNotifySlack.send(tested_method, NOTIFICATION_SOURCE, text: custom_notification_text)
+  end
+
+end
+
+
+RSpec.shared_examples "it has a default and allows a custom emoji" do |default_emoji, tested_method|
+
+  it "default emoji is '#{default_emoji}'" do
+
+    expect(SHFNotifySlack).to receive(:notification)
+                                  .with(anything, anything,
+                                        hash_including(emoji: default_emoji))
+
+    SHFNotifySlack.send(tested_method, NOTIFICATION_SOURCE)
+  end
+
+  it 'can specify a custom emoji' do
+
+    custom_emoji = ':nerd_face:'
+
+    expect(SHFNotifySlack).to receive(:notification)
+                                  .with(anything, anything,
+                                        hash_including(emoji: custom_emoji))
+
+
+    SHFNotifySlack.send(tested_method, NOTIFICATION_SOURCE, emoji: custom_emoji)
+  end
+
+end
+
+
+RSpec.shared_examples "it has a default and allows a custom color" do |default_color, tested_method|
+
+  it "default color is '#{default_color}'" do
+
+    expect(SHFNotifySlack).to receive(:notification)
+                                  .with(anything, anything,
+                                        hash_including(color: default_color))
+
+    SHFNotifySlack.send(tested_method, NOTIFICATION_SOURCE)
+  end
+
+  it 'can specify a custom color' do
+
+    custom_color = '#404040'
+
+    expect(SHFNotifySlack).to receive(:notification)
+                                  .with(anything, anything,
+                                        hash_including(color: custom_color))
+
+
+    SHFNotifySlack.send(tested_method, NOTIFICATION_SOURCE, color: custom_color)
+  end
+
+end
+
+
+# ===============================================================
+
+RSpec.describe 'SHFNotifySlack' do
+
+  before(:all) do
+    # send the notifications to the _testing_ channel
+    RSpec::Mocks.with_temporary_scope do
+      # must stub this way so the rest of ENV is preserved
+      stub_const('ENV', ENV.to_hash.merge({ 'SHF_SLACK_CHANNEL' => 'notification_testing' }))
+    end
+  end
+
+
+  it_behaves_like 'expected ENV variables exist', %w(SHF_SLACK_WEBHOOKURL SHF_SLACK_CHANNEL
+                                                   SHF_SLACK_USERNAME)
+
+  describe '.notify_after do <block> ...' do
+
+    it 'notification source cannot be nil' do
+
+      expect {
+        SHFNotifySlack.notify_after(nil) { true }
+      }.to raise_error ArgumentError
+    end
+
+
+    context 'no error is raised; the block of code runs fine:' do
+
+      it 'sends success_notification if the code runs fine' do
+
+        expect(SHFNotifySlack).to receive(:success_notification)
+                                      .with(NOTIFICATION_SOURCE, anything)
+                                      .and_return(true)
+
+        SHFNotifySlack.notify_after(NOTIFICATION_SOURCE) do
+          true
+        end
+      end
+
+      it "default success text is 'Successful'" do
+        expect(SHFNotifySlack).to receive(:success_notification)
+                                      .with(NOTIFICATION_SOURCE,
+                                            hash_including(text: 'Successful'))
+                                      .and_return(true)
+
+        SHFNotifySlack.notify_after(NOTIFICATION_SOURCE) do
+          true
+        end
+      end
+
+      it 'can pass in custom text to use when it calls success_notification' do
+
+        custom_text = 'custom notification text when successful'
+
+        expect(SHFNotifySlack).to receive(:success_notification)
+                                      .with(NOTIFICATION_SOURCE,
+                                            hash_including(text: custom_text))
+                                      .and_return(true)
+
+        SHFNotifySlack.notify_after(NOTIFICATION_SOURCE, success_text: custom_text) do
+          true
+        end
+      end
+
+
+      it "default success emoji is ':white_check_mark:'" do
+
+        expect(SHFNotifySlack).to receive(:success_notification)
+                                      .with(NOTIFICATION_SOURCE,
+                                            hash_including(emoji: ':white_check_mark:'))
+                                      .and_return(true)
+
+        SHFNotifySlack.notify_after(NOTIFICATION_SOURCE) do
+          true
+        end
+      end
+
+      it 'can pass in a custom emoji to use when it calls success_notification' do
+
+        custom_emoji = ':nerd_face:'
+
+        expect(SHFNotifySlack).to receive(:success_notification)
+                                      .with(NOTIFICATION_SOURCE,
+                                            hash_including(emoji: custom_emoji))
+                                      .and_return(true)
+
+        SHFNotifySlack.notify_after(NOTIFICATION_SOURCE, success_emoji: custom_emoji) do
+          true
+        end
+      end
+
+    end # context 'no error is raised; code runs fine'
+
+
+    context 'an error is raised; the block fails in some way' do
+
+      it 'sends failure_notification if an error is raised' do
+
+        expect(SHFNotifySlack).to receive(:failure_notification)
+                                      .with(NOTIFICATION_SOURCE, anything)
+                                      .and_return(true)
+
+        expect {
+          SHFNotifySlack.notify_after(NOTIFICATION_SOURCE) do
+            raise StandardError
+          end
+        }.to raise_error StandardError
+
+      end
+
+
+      it 'raises the error that happened' do
+        allow(SHFNotifySlack).to receive(:failure_notification)
+                                      .with(NOTIFICATION_SOURCE, anything)
+                                      .and_return(true)
+
+        expect {
+          SHFNotifySlack.notify_after(NOTIFICATION_SOURCE) do
+            raise IOError
+          end
+        }.to raise_error IOError
+
+      end
+
+      it "default failure text is 'Failure!' with the raised error message " do
+
+        expect(SHFNotifySlack).to receive(:failure_notification)
+                                      .with(NOTIFICATION_SOURCE,
+                                            hash_including(text: "Failure! The error message"))
+
+        expect {
+          SHFNotifySlack.notify_after(NOTIFICATION_SOURCE) do
+            raise StandardError.new('The error message')
+          end
+        }.to raise_error StandardError
+
+      end
+
+
+      it 'can pass in custom text to use when it calls failure_notification' do
+
+        custom_text = 'custom notification text when failure happens'
+
+        expect {
+          SHFNotifySlack.notify_after(NOTIFICATION_SOURCE, failure_text: custom_text) do
+            raise StandardError
+          end
+        }.to raise_error StandardError
+
+        expect(SHFNotifySlack).to receive(:failure_notification)
+                                      .with(NOTIFICATION_SOURCE,
+                                            hash_including(text: "#{custom_text} The error message"))
+
+        expect {
+          SHFNotifySlack.notify_after(NOTIFICATION_SOURCE,
+                                      failure_text: custom_text) do
+            raise StandardError.new('The error message')
+          end
+        }.to raise_error StandardError
+
+
+      end
+
+      it "default failure emoji is ':x:'" do
+
+        expect(SHFNotifySlack).to receive(:failure_notification)
+                                      .with(NOTIFICATION_SOURCE,
+                                            hash_including(emoji: ':x:'))
+                                      .and_return(true)
+
+        expect {
+          SHFNotifySlack.notify_after(NOTIFICATION_SOURCE) do
+            raise StandardError
+          end
+        }.to raise_error StandardError
+      end
+
+      it 'can pass in a custom emoji to use when it calls failure_notification' do
+
+        custom_emoji = ':nerd_face:'
+
+        expect(SHFNotifySlack).to receive(:failure_notification)
+                                      .with(NOTIFICATION_SOURCE,
+                                            hash_including(emoji: custom_emoji))
+                                      .and_return(true)
+
+        expect {
+          SHFNotifySlack.notify_after(NOTIFICATION_SOURCE, failure_emoji: custom_emoji) do
+            raise StandardError
+          end
+        }.to raise_error StandardError
+      end
+
+    end # context 'an error is raised'
+
+  end #  describe '.notify_after do <block> ...'
+
+
+  describe '.success_notification' do
+
+    success_notification_method = :success_notification
+
+
+    describe 'notification text' do
+      it_behaves_like "it has a default and allows custom text", 'Successful', success_notification_method
+    end
+
+    describe 'emoji' do
+      it_behaves_like "it has a default and allows a custom emoji", ':white_check_mark:', success_notification_method
+    end
+
+  end
+
+
+  describe '.failure_notification' do
+
+    failure_notification_method = :failure_notification
+
+
+    describe 'notification text' do
+      it_behaves_like "it has a default and allows custom text", 'Failure!', failure_notification_method
+    end
+
+    describe 'emoji' do
+      it_behaves_like "it has a default and allows a custom emoji", ':x:', failure_notification_method
+    end
+
+  end
+
+
+  describe '.notification' do
+
+    it "sends via Slack webhook ENV['SHF_SLACK_WEBHOOKURL']" do
+
+      # the ENV must be defined for testing
+      expect(ENV.to_hash.fetch('SHF_SLACK_WEBHOOKURL', nil)).not_to be_nil
+      slack_webhook = ENV['SHF_SLACK_WEBHOOKURL']
+
+      slack_notifier_dbl = double("slack_notifier")
+      expect(Slack::Notifier).to receive(:new)
+                                     .with(slack_webhook, anything)
+                                     .and_return(slack_notifier_dbl)
+
+      allow(slack_notifier_dbl).to receive(:post)
+                                       .with(anything).and_return(true)
+
+      SHFNotifySlack.notification(NOTIFICATION_SOURCE, 'some text')
+    end
+
+    it "sends to Slack channel ENV['SHF_SLACK_CHANNEL']" do
+
+      # the ENV must be defined for testing
+      expect(ENV.to_hash.fetch('SHF_SLACK_CHANNEL', nil)).not_to be_nil
+      slack_channel = ENV['SHF_SLACK_CHANNEL']
+
+      slack_notifier_dbl = double("slack_notifier")
+
+      expect(Slack::Notifier).to receive(:new)
+                                     .with(anything,
+                                           hash_including(channel: slack_channel))
+                                     .and_return(slack_notifier_dbl)
+
+      allow(slack_notifier_dbl).to receive(:post)
+                                       .with(anything).and_return(true)
+
+      SHFNotifySlack.notification(NOTIFICATION_SOURCE, 'some text')
+    end
+
+
+    it "sends ENV['SHF_SLACK_USERNAME'] as the username " do
+
+      # the ENV must be defined for testing
+      expect(ENV.to_hash.fetch('SHF_SLACK_USERNAME', nil)).not_to be_nil
+
+      slack_username = ENV['SHF_SLACK_USERNAME']
+
+      slack_notifier_dbl = double("slack_notifier")
+
+      expect(Slack::Notifier).to receive(:new)
+                                     .with(anything,
+                                           hash_including(username: slack_username))
+                                     .and_return(slack_notifier_dbl)
+
+      allow(slack_notifier_dbl).to receive(:post)
+                                       .with(anything).and_return(true)
+
+      SHFNotifySlack.notification(NOTIFICATION_SOURCE, 'some text')
+    end
+
+    it "sends details in the single attachments hash" do
+
+      slack_notifier_dbl = double("slack_notifier")
+      allow(Slack::Notifier).to receive(:new).and_return(slack_notifier_dbl)
+
+      test_time = DateTime.civil_from_format(:utc, 2018)
+      Timecop.freeze(test_time) do
+
+        expected_text       = "some text #{test_time.strftime('%F %T UTC')}"
+        expected_attachment = { color:    "#439FE0",
+                                fallback: expected_text,
+                                footer:   "SHF: test task",
+                                title:    expected_text,
+                                ts:       test_time.to_i }
+
+        expect(slack_notifier_dbl).to receive(:post)
+                                          .with(hash_including(attachments: [expected_attachment]))
+
+        SHFNotifySlack.notification(NOTIFICATION_SOURCE, 'some text')
+      end # Timecop
+    end
+
+
+    describe 'text' do
+
+      it 'can be nil' do
+
+        slack_notifier_dbl = double("slack_notifier")
+        allow(Slack::Notifier).to receive(:new).and_return(slack_notifier_dbl)
+
+        test_time = DateTime.civil_from_format(:utc, 2018)
+        Timecop.freeze(test_time) do
+
+          expected_text       = " #{test_time.strftime('%F %T UTC')}"
+          expected_attachment = { color:    "#439FE0",
+                                  fallback: expected_text,
+                                  footer:   "SHF: test task",
+                                  title:    expected_text,
+                                  ts:       test_time.to_i }
+
+          expect(slack_notifier_dbl).to receive(:post)
+                                            .with(hash_including(attachments: [expected_attachment]))
+
+          SHFNotifySlack.notification(NOTIFICATION_SOURCE, nil)
+        end # Timecop
+      end
+
+      it 'can be an empty string' do
+
+        slack_notifier_dbl = double("slack_notifier")
+        allow(Slack::Notifier).to receive(:new).and_return(slack_notifier_dbl)
+
+        test_time = DateTime.civil_from_format(:utc, 2018)
+        Timecop.freeze(test_time) do
+
+          expected_text       = " #{test_time.strftime('%F %T UTC')}"
+          expected_attachment = { color:    "#439FE0",
+                                  fallback: expected_text,
+                                  footer:   "SHF: test task",
+                                  title:    expected_text,
+                                  ts:       test_time.to_i }
+
+          expect(slack_notifier_dbl).to receive(:post)
+                                            .with(hash_including(attachments: [expected_attachment]))
+
+          SHFNotifySlack.notification(NOTIFICATION_SOURCE, '')
+        end # Timecop
+      end
+
+      it 'is the main text shown in the notification' do
+        slack_notifier_dbl = double("slack_notifier")
+        allow(Slack::Notifier).to receive(:new).and_return(slack_notifier_dbl)
+
+        test_time = DateTime.civil_from_format(:utc, 2018)
+        Timecop.freeze(test_time) do
+
+          expected_text       = "This is the text shown #{test_time.strftime('%F %T UTC')}"
+          expected_attachment = { color:    "#439FE0",
+                                  fallback: expected_text,
+                                  footer:   "SHF: test task",
+                                  title:    expected_text,
+                                  ts:       test_time.to_i }
+
+          expect(slack_notifier_dbl).to receive(:post)
+                                            .with(hash_including(attachments: [expected_attachment]))
+
+          SHFNotifySlack.notification(NOTIFICATION_SOURCE, 'This is the text shown')
+        end # Timecop
+      end
+
+    end # text
+
+
+    describe 'source of the notification' do
+
+      it 'cannot be nil' do
+        expect { SHFNotifySlack.notification(nil, 'some text') }.to raise_error ArgumentError
+      end
+
+      it 'cannot be an empty string' do
+        expect { SHFNotifySlack.notification('', 'some text') }.to raise_error ArgumentError
+      end
+
+      it 'is shown in the footer of the notification' do
+        slack_notifier_dbl = double("slack_notifier")
+        allow(Slack::Notifier).to receive(:new).and_return(slack_notifier_dbl)
+
+        test_time = DateTime.civil_from_format(:utc, 2018)
+        Timecop.freeze(test_time) do
+
+          expected_text       = "some text #{test_time.strftime('%F %T UTC')}"
+          expected_attachment = { color:    "#439FE0",
+                                  fallback: expected_text,
+                                  footer:   "SHF: this is the source",
+                                  title:    expected_text,
+                                  ts:       test_time.to_i }
+
+          expect(slack_notifier_dbl).to receive(:post)
+                                            .with(hash_including(attachments: [expected_attachment]))
+
+          SHFNotifySlack.notification('this is the source', 'some text')
+        end # Timecop
+      end
+
+    end
+
+
+    describe 'emoji' do
+
+      it 'default emoji is :white_check_mark:' do
+
+        slack_notifier_dbl = double("slack_notifier")
+        allow(Slack::Notifier).to receive(:new).and_return(slack_notifier_dbl)
+
+        expect(slack_notifier_dbl).to receive(:post)
+                                          .with(hash_including(icon_emoji: ':white_check_mark:'))
+
+        SHFNotifySlack.notification(NOTIFICATION_SOURCE, 'some text')
+      end
+
+      it 'can specify a custom emoji' do
+
+        custom_emoji = ':nerd_face:'
+
+        slack_notifier_dbl = double("slack_notifier")
+        allow(Slack::Notifier).to receive(:new).and_return(slack_notifier_dbl)
+
+        expect(slack_notifier_dbl).to receive(:post)
+                                          .with(hash_including(icon_emoji: custom_emoji))
+
+        SHFNotifySlack.notification(NOTIFICATION_SOURCE, 'some text',
+                                    emoji: custom_emoji)
+      end
+    end # emoji
+
+
+    describe 'color' do
+
+      # stub out calls to Slack::Notifier
+      before do
+        slack_notifier_dbl = double("slack_notifier")
+        allow(Slack::Notifier).to receive(:new).and_return(slack_notifier_dbl)
+        allow(slack_notifier_dbl).to receive(:post).and_return(true)
+      end
+
+
+      it 'default color is #439FE0' do
+        expect(SHFNotifySlack).to receive(:make_details)
+                                      .with(anything, anything,
+                                            hash_including(color: '#439FE0'))
+                                      .and_call_original
+
+        SHFNotifySlack.notification(NOTIFICATION_SOURCE, 'some text')
+      end
+
+      it 'can specify a custom color' do
+
+        custom_color = '#404040'
+        expect(SHFNotifySlack).to receive(:make_details)
+                                      .with(anything, anything,
+                                            hash_including(color: custom_color))
+
+        SHFNotifySlack.notification(NOTIFICATION_SOURCE, 'some text',
+                                    color: custom_color)
+      end
+    end # color
+
+  end # notification
+
+
+  describe 'make_details creates the Hash that Slack expects' do
+
+    it 'default values: text is ampty string, color is blue' do
+      test_time = DateTime.civil_from_format(:utc, 2018)
+      Timecop.freeze(test_time) do
+
+        expected_title = " #{test_time.strftime("%F %T UTC")}"
+
+        expect(SHFNotifySlack.make_details(NOTIFICATION_SOURCE))
+            .to eq({ color:    '#439FE0',
+                     fallback: expected_title,
+                     title:    expected_title,
+                     footer:   "SHF: #{NOTIFICATION_SOURCE}",
+                     ts:       test_time.to_i })
+      end # Timecop
+    end
+
+
+    it 'notification source cannot be nil' do
+      expect { SHFNotifySlack.make_details(nil) }.to raise_error ArgumentError
+    end
+
+    it 'notification source cannot be an empty String' do
+      expect { SHFNotifySlack.make_details('') }.to raise_error ArgumentError
+    end
+
+    it 'text is the title for the notification' do
+
+      test_time = DateTime.civil_from_format(:utc, 2018)
+      Timecop.freeze(test_time) do
+
+        text_to_show   = 'some text'
+        expected_title = "#{text_to_show} #{test_time.strftime("%F %T UTC")}"
+
+        details = SHFNotifySlack.make_details(NOTIFICATION_SOURCE, text_to_show)
+        expect(details[:title]).to eq(expected_title)
+      end # Timecop
+    end
+
+    it 'a UTC timestamp is appended to the text' do
+      test_time = DateTime.civil_from_format(:utc, 2018)
+      Timecop.freeze(test_time) do
+
+        text_to_show  = 'some text'
+        expected_text = "#{text_to_show} #{test_time.strftime("%F %T UTC")}"
+
+        details = SHFNotifySlack.make_details(NOTIFICATION_SOURCE, text_to_show)
+        expect(details[:title]).to eq(expected_text)
+      end # Timecop
+    end
+
+    it 'title and fallback are the same' do
+      test_time = DateTime.civil_from_format(:utc, 2018)
+      Timecop.freeze(test_time) do
+        details = SHFNotifySlack.make_details(NOTIFICATION_SOURCE, 'some text')
+
+        expect(details[:fallback]).to eq(details[:title])
+      end # Timecop
+    end
+
+    it 'given some text to show' do
+
+      test_time = DateTime.civil_from_format(:utc, 2018)
+      Timecop.freeze(test_time) do
+
+        text_to_show   = 'some text'
+        expected_title = "#{text_to_show} #{test_time.strftime("%F %T UTC")}"
+
+        expect(SHFNotifySlack.make_details(NOTIFICATION_SOURCE, text_to_show))
+            .to eq({ color:    '#439FE0',
+                     fallback: expected_title,
+                     title:    expected_title,
+                     footer:   "SHF: #{NOTIFICATION_SOURCE}",
+                     ts:       test_time.to_i })
+      end # Timecop
+    end
+
+    it 'the source of the notification is put into the footer' do
+
+      test_time = DateTime.civil_from_format(:utc, 2018)
+      Timecop.freeze(test_time) do
+
+        notification_source = 'some source'
+        expected_title      = " #{test_time.strftime("%F %T UTC")}"
+
+        expect(SHFNotifySlack.make_details(notification_source))
+            .to eq({ color:    '#439FE0',
+                     fallback: expected_title,
+                     title:    expected_title,
+                     footer:   "SHF: #{notification_source}",
+                     ts:       test_time.to_i })
+      end # Timecop
+    end
+
+    it 'can set the color' do
+      test_time = DateTime.civil_from_format(:utc, 2018)
+      Timecop.freeze(test_time) do
+
+        color          = '#121212'
+        expected_title = " #{test_time.strftime("%F %T UTC")}"
+
+        expect(SHFNotifySlack.make_details(NOTIFICATION_SOURCE, color: color))
+            .to eq({ color:    color,
+                     fallback: expected_title,
+                     title:    expected_title,
+                     footer:   "SHF: #{NOTIFICATION_SOURCE}",
+                     ts:       test_time.to_i })
+      end # Timecop
+    end
+
+  end
+
+
+  it 'timestamped_text appends a timestamp to the text' do
+
+    test_time = DateTime.civil_from_format(:utc, 2018)
+
+    Timecop.freeze(test_time) do
+      expect(SHFNotifySlack.timestamped_text('text')).to eq("text #{test_time.strftime("%F %T UTC")}")
+    end
+  end
+
+  it '.footer_text has "SHF:" at the start' do
+    expect(SHFNotifySlack.footer_text('blorf')).to eq('SHF: blorf')
+  end
+end


### PR DESCRIPTION
### PT Story:  Slack notification: create a class so it can be called by any task/code
https://www.pivotaltracker.com/story/show/162554789

### Changes proposed in this pull request:
1.  Created a class to send standardized notifications to the SHF Slack team
3. fixed the log name in the backups rake task:  I appended ".log" to the name

Ready for review:
@patmbolger 
