### PR TITLE
HOTFIX actually deliver member expire nightly task emails

### DIFF
--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -342,10 +342,16 @@ class ShfApplicationsController < ApplicationController
 
   def send_new_app_emails(new_shf_app)
 
-    ShfApplicationMailer.acknowledge_received(new_shf_app).deliver_now
+    begin
+      ShfApplicationMailer.acknowledge_received(new_shf_app).deliver_now
+    rescue => _mail_error
+      helpers.flash_message(:error, t('mailers.shf_application_mailer.acknowledge_received.error_sending', email: @shf_application.user.email))
+    end
+
+    # if there is a problem sending email to the admin, do not display an error to the user.
     send_new_shf_application_notice_to_admins(new_shf_app)
 
-  end
+end
 
 
   def send_new_shf_application_notice_to_admins(new_shf_app)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -58,7 +58,9 @@ class ApplicationMailer < ActionMailer::Base
 
   # If there is a problem communicating with the MailGun REST server, log the problem
   # TODO notify the SHF admin(s) using the ExceptionNotfication gem (must be able to send a notification that does not use MailGun)
-  # Do not raise the error.  Do not want to show anything to the user
+  #
+  # Raise any errors caught after writing to the log so that other systems
+  #    (e.g. rake nightly tasks) know if this fails.
   def self.deliver_mail(mail)
 
     super
@@ -70,6 +72,8 @@ class ApplicationMailer < ActionMailer::Base
       log.record('error', "Could not send email via mailgun at #{Time.zone.now}  Error received from Mailgun: #{mailgun_error}")
 
     end
+
+    raise mailgun_error
 
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -26,7 +26,7 @@ class ApplicationMailer < ActionMailer::Base
 
 
 
-  LOG_FILE = File.join(Rails.configuration.paths['log'].absolute_current, "#{Rails.env}_#{self.class.name}.log")
+  LOG_FILE = File.join(Rails.configuration.paths['log'].absolute_current, "#{Rails.env}_#{self.name}.log")
   LOG_FACILITY = 'ApplicationMailer'
 
 
@@ -63,7 +63,7 @@ class ApplicationMailer < ActionMailer::Base
 
     super
 
-  rescue  Mailgun::CommunicationError => mailgun_error
+  rescue  => mailgun_error
 
     ActivityLogger.open(LOG_FILE, LOG_FACILITY, 'Mailgun::CommunicationError', false) do |log|
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -999,6 +999,7 @@ en:
       acknowledge_received:
         subject: Your application to Sveriges Hundföretagare has been received
         message_text: "Your application has been received.  We are all working hard, so it might take a while before we get to it. So do not worry if it takes a while before you hear from us."
+        error_sending: &shf_email_error "There was a problem sending email to you at {%email} about your application."
 
       app_approved:
         subject: Your application to Sveriges Hundföretagare is approved
@@ -1006,6 +1007,7 @@ en:
           app_approved_and_next: "Your application is now approved. What is left before you are registered as a member in the system is to pay your membership fee.  Log in to the website and then pay at this link: "
           h_branding_not_paid: "When this is done you will need to finish your company page and pay your H-branding fee. More information about how to do that will come after you paid your membership fee."
           thanks:  "Thank you for wanting to be a member and contributing to a Sweden with an ethical dog industry."
+          error_sending: *shf_email_error
 
 
     member_mailer:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1001,6 +1001,7 @@ sv:
       acknowledge_received:
         subject: Din ansökan till Sveriges Hundföretagare är mottagen
         message_text: "Din ansökan är mottagen. Vi hanterar den så fort vi kan. Säkerställ att du laddat upp eller mailar in allt relevant underlag."
+        error_sending: &shf_email_error  "Det gick inte att skicka e-post till dig på {% email} om din ansökan."
 
       app_approved:
         subject: Din ansökan till Sveriges Hundföretagare är godkänd.
@@ -1008,6 +1009,7 @@ sv:
           app_approved_and_next: "Din ansökan har nu blivit godkänd. Det som är kvar innan du är medlem i systemet är att betala din medlemsavgift. Det gör du via "
           h_branding_not_paid: "När detta är gjort behöver du göra färdigt din företagssida och betala din H-märkesavgift. Mer information om hur du gör det kommer i ett mail efter att du betalt din medlemsavgift."
           thanks:  "Tack för att du vill vara medlem och bidrar till ett kvalitetssäkrat hundsverige."
+          error_sending: *shf_email_error
 
 
     member_mailer:

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -235,8 +235,9 @@ RSpec.describe ApplicationMailer, type: :mailer do
 
       before_mailgun_errors = num_matches_in_file(log_fname, mailgun_error_regexp)
 
+
       # this is a mocked post and response that will return an error from the vcr cassette file
-      mail_to_send.deliver_now
+      expect{mail_to_send.deliver_now}.to raise_error(Mailgun::CommunicationError)
 
       after_mailgun_errors = num_matches_in_file(log_fname, mailgun_error_regexp)
       expect(after_mailgun_errors - before_mailgun_errors).to eq 1

--- a/spec/models/conditions_response/membership_expire_alert_spec.rb
+++ b/spec/models/conditions_response/membership_expire_alert_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 require 'email_spec/rspec'
 
+
 RSpec.describe MembershipExpireAlert, type: :model do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, email: FFaker::InternetSE.disposable_email) }
+
   let(:membership_will_expire_condition) do
     create(:condition, class_name: 'MembershipExpireAlert',
                        name: 'membership_will_expire',
@@ -38,24 +40,61 @@ RSpec.describe MembershipExpireAlert, type: :model do
 
     context 'membership_will_expire' do
 
-      it 'sends alert email to user and logs a message' do
+      context 'days-before includes today' do
 
-        user.update_attribute(:email, FFaker::InternetSE.disposable_email)
+        before(:each) { Rails.configuration.action_mailer.delivery_method = :mailgun
+        ApplicationMailer.mailgun_client.enable_test_mode!
+        }
 
-        expect(MemberMailer).to receive(:membership_expiration_reminder).with(user)
-          .exactly(membership_will_expire_condition.config[:days].length).times
+        after(:each) { ApplicationMailer.mailgun_client.disable_test_mode! }
 
-        membership_will_expire_condition.config[:days].each do |days_until|
 
-          Timecop.freeze(payment_date_2018_11_21 - days_until.days)
+        it 'sends alert email to user and logs a message' do
 
-          MembershipExpireAlert.condition_response(membership_will_expire_condition, log)
+          expect(MemberMailer).to receive(:membership_expiration_reminder).with(user)
+            .exactly(membership_will_expire_condition.config[:days].length).times
+            .and_call_original
 
-          Timecop.return
+          membership_will_expire_condition.config[:days].each do |days_until|
 
-          expect(File.read(filepath)).to include "[info] Expire alert sent to #{user.email}"
+            Timecop.freeze(payment_date_2018_11_21 - days_until.days)
+
+            MembershipExpireAlert.condition_response(membership_will_expire_condition, log)
+
+            Timecop.return
+
+            email = ActionMailer::Base.deliveries.last
+            expect(email).to deliver_to(user.email)
+
+            expect(File.read(filepath)).to include "[info] Expire alert sent to #{user.email}"
+          end
         end
-      end
+
+
+        it 'logs an error if any error is raised or mail has errors' do
+
+          expect(MemberMailer).to receive(:membership_expiration_reminder).with(user)
+                                      .exactly(membership_will_expire_condition.config[:days].length).times
+                                      .and_call_original
+
+          allow_any_instance_of(Mail::Message).to receive(:deliver)
+            .and_raise(  Net::ProtocolError )
+
+          membership_will_expire_condition.config[:days].each do |days_until|
+
+            Timecop.freeze(payment_date_2018_11_21 - days_until.days)
+
+            MembershipExpireAlert.condition_response(membership_will_expire_condition, log)
+
+            Timecop.return
+
+            expect(ActionMailer::Base.deliveries.size).to eq 0
+            expect(File.read(filepath)).to include "[info] Expire alert mail ATTEMPT FAILED: to #{user.email}"
+          end
+        end
+
+      end # context 'days-before includes today'
+
 
       it 'does not send email if days-before does not include today' do
 


### PR DESCRIPTION
### PT Story:  The emails for the nightly task were not being delivered. We created them, but didn't call _deliver_.

https://www.pivotaltracker.com/story/show/161635575

### Changes proposed in this pull request:
1.   Call _deliver_ on the membership expire emails
2.  Catch any errors raised when mail is sent by ApplicationMailer
3. Put in simple flash message in `ShfApplicationsController` if, after the user submits their new application, we cannot send email.  Will make this better next. (just wanted to get this in for the nightly processing)

Ready for review:
@
