### PR TITLE
Record when an application is approved

### DIFF
--- a/app/models/shf_application.rb
+++ b/app/models/shf_application.rb
@@ -164,6 +164,8 @@ class ShfApplication < ApplicationRecord
   def accept_application
     begin
 
+      update(when_approved: Time.zone.now)
+
       # Default company email = user's membership contact email
       companies.first.email = contact_email
 
@@ -172,6 +174,7 @@ class ShfApplication < ApplicationRecord
 
     rescue => e
       puts "ERROR: could not accept_membership.  error: #{e.inspect}"
+      update(when_approved: nil)
       raise e
     end
   end
@@ -181,6 +184,7 @@ class ShfApplication < ApplicationRecord
 
     user.update(membership_number: nil)
 
+    update(when_approved: nil)
     destroy_uploaded_files
 
   end

--- a/db/migrate/20181228073947_add_when_approved_to_shf_application.rb
+++ b/db/migrate/20181228073947_add_when_approved_to_shf_application.rb
@@ -1,0 +1,5 @@
+class AddWhenApprovedToShfApplication < ActiveRecord::Migration[5.2]
+  def change
+    add_column :shf_applications, :when_approved, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_14_011549) do
+ActiveRecord::Schema.define(version: 2018_12_28_073947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -189,6 +189,7 @@ ActiveRecord::Schema.define(version: 2018_12_14_011549) do
     t.string "state", default: "new"
     t.integer "member_app_waiting_reasons_id"
     t.string "custom_reason_text"
+    t.datetime "when_approved"
     t.index ["member_app_waiting_reasons_id"], name: "index_shf_applications_on_member_app_waiting_reasons_id"
     t.index ["user_id"], name: "index_shf_applications_on_user_id"
   end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,9 +1,7 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
-SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
@@ -22,6 +20,8 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
+SET search_path = public, pg_catalog;
+
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -30,7 +30,7 @@ SET default_with_oids = false;
 -- Name: addresses; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.addresses (
+CREATE TABLE addresses (
     id bigint NOT NULL,
     street_address character varying,
     post_code character varying,
@@ -51,7 +51,7 @@ CREATE TABLE public.addresses (
 -- Name: addresses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.addresses_id_seq
+CREATE SEQUENCE addresses_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -63,14 +63,14 @@ CREATE SEQUENCE public.addresses_id_seq
 -- Name: addresses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.addresses_id_seq OWNED BY public.addresses.id;
+ALTER SEQUENCE addresses_id_seq OWNED BY addresses.id;
 
 
 --
 -- Name: app_configurations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.app_configurations (
+CREATE TABLE app_configurations (
     id bigint NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
@@ -97,7 +97,7 @@ CREATE TABLE public.app_configurations (
 -- Name: app_configurations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.app_configurations_id_seq
+CREATE SEQUENCE app_configurations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -109,14 +109,14 @@ CREATE SEQUENCE public.app_configurations_id_seq
 -- Name: app_configurations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.app_configurations_id_seq OWNED BY public.app_configurations.id;
+ALTER SEQUENCE app_configurations_id_seq OWNED BY app_configurations.id;
 
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.ar_internal_metadata (
+CREATE TABLE ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
     created_at timestamp without time zone NOT NULL,
@@ -128,7 +128,7 @@ CREATE TABLE public.ar_internal_metadata (
 -- Name: business_categories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.business_categories (
+CREATE TABLE business_categories (
     id bigint NOT NULL,
     name character varying,
     description character varying,
@@ -141,7 +141,7 @@ CREATE TABLE public.business_categories (
 -- Name: business_categories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.business_categories_id_seq
+CREATE SEQUENCE business_categories_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -153,14 +153,14 @@ CREATE SEQUENCE public.business_categories_id_seq
 -- Name: business_categories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.business_categories_id_seq OWNED BY public.business_categories.id;
+ALTER SEQUENCE business_categories_id_seq OWNED BY business_categories.id;
 
 
 --
 -- Name: business_categories_shf_applications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.business_categories_shf_applications (
+CREATE TABLE business_categories_shf_applications (
     id bigint NOT NULL,
     shf_application_id bigint,
     business_category_id bigint
@@ -171,7 +171,7 @@ CREATE TABLE public.business_categories_shf_applications (
 -- Name: business_categories_shf_applications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.business_categories_shf_applications_id_seq
+CREATE SEQUENCE business_categories_shf_applications_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -183,14 +183,14 @@ CREATE SEQUENCE public.business_categories_shf_applications_id_seq
 -- Name: business_categories_shf_applications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.business_categories_shf_applications_id_seq OWNED BY public.business_categories_shf_applications.id;
+ALTER SEQUENCE business_categories_shf_applications_id_seq OWNED BY business_categories_shf_applications.id;
 
 
 --
 -- Name: ckeditor_assets; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.ckeditor_assets (
+CREATE TABLE ckeditor_assets (
     id bigint NOT NULL,
     data_file_name character varying NOT NULL,
     data_content_type character varying,
@@ -209,7 +209,7 @@ CREATE TABLE public.ckeditor_assets (
 -- Name: ckeditor_assets_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.ckeditor_assets_id_seq
+CREATE SEQUENCE ckeditor_assets_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -221,14 +221,14 @@ CREATE SEQUENCE public.ckeditor_assets_id_seq
 -- Name: ckeditor_assets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.ckeditor_assets_id_seq OWNED BY public.ckeditor_assets.id;
+ALTER SEQUENCE ckeditor_assets_id_seq OWNED BY ckeditor_assets.id;
 
 
 --
 -- Name: companies; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.companies (
+CREATE TABLE companies (
     id bigint NOT NULL,
     name character varying,
     company_number character varying,
@@ -248,7 +248,7 @@ CREATE TABLE public.companies (
 -- Name: companies_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.companies_id_seq
+CREATE SEQUENCE companies_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -260,14 +260,14 @@ CREATE SEQUENCE public.companies_id_seq
 -- Name: companies_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.companies_id_seq OWNED BY public.companies.id;
+ALTER SEQUENCE companies_id_seq OWNED BY companies.id;
 
 
 --
 -- Name: company_applications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.company_applications (
+CREATE TABLE company_applications (
     id bigint NOT NULL,
     company_id bigint NOT NULL,
     shf_application_id bigint NOT NULL,
@@ -280,7 +280,7 @@ CREATE TABLE public.company_applications (
 -- Name: company_applications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.company_applications_id_seq
+CREATE SEQUENCE company_applications_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -292,14 +292,14 @@ CREATE SEQUENCE public.company_applications_id_seq
 -- Name: company_applications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.company_applications_id_seq OWNED BY public.company_applications.id;
+ALTER SEQUENCE company_applications_id_seq OWNED BY company_applications.id;
 
 
 --
 -- Name: conditions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.conditions (
+CREATE TABLE conditions (
     id bigint NOT NULL,
     class_name character varying,
     timing character varying,
@@ -313,7 +313,7 @@ CREATE TABLE public.conditions (
 -- Name: conditions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.conditions_id_seq
+CREATE SEQUENCE conditions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -325,14 +325,14 @@ CREATE SEQUENCE public.conditions_id_seq
 -- Name: conditions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.conditions_id_seq OWNED BY public.conditions.id;
+ALTER SEQUENCE conditions_id_seq OWNED BY conditions.id;
 
 
 --
 -- Name: events; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.events (
+CREATE TABLE events (
     id bigint NOT NULL,
     fee numeric(8,2),
     start_date date,
@@ -354,7 +354,7 @@ CREATE TABLE public.events (
 -- Name: events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.events_id_seq
+CREATE SEQUENCE events_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -366,14 +366,14 @@ CREATE SEQUENCE public.events_id_seq
 -- Name: events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.events_id_seq OWNED BY public.events.id;
+ALTER SEQUENCE events_id_seq OWNED BY events.id;
 
 
 --
 -- Name: kommuns; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.kommuns (
+CREATE TABLE kommuns (
     id bigint NOT NULL,
     name character varying,
     created_at timestamp without time zone NOT NULL,
@@ -385,7 +385,7 @@ CREATE TABLE public.kommuns (
 -- Name: kommuns_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.kommuns_id_seq
+CREATE SEQUENCE kommuns_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -397,14 +397,14 @@ CREATE SEQUENCE public.kommuns_id_seq
 -- Name: kommuns_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.kommuns_id_seq OWNED BY public.kommuns.id;
+ALTER SEQUENCE kommuns_id_seq OWNED BY kommuns.id;
 
 
 --
 -- Name: member_app_waiting_reasons; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.member_app_waiting_reasons (
+CREATE TABLE member_app_waiting_reasons (
     id bigint NOT NULL,
     name_sv character varying,
     description_sv character varying,
@@ -420,49 +420,49 @@ CREATE TABLE public.member_app_waiting_reasons (
 -- Name: TABLE member_app_waiting_reasons; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON TABLE public.member_app_waiting_reasons IS 'reasons why SHF is waiting for more info from applicant. Add more columns when more locales needed.';
+COMMENT ON TABLE member_app_waiting_reasons IS 'reasons why SHF is waiting for more info from applicant. Add more columns when more locales needed.';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.name_sv; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.member_app_waiting_reasons.name_sv IS 'name of the reason in svenska/Swedish';
+COMMENT ON COLUMN member_app_waiting_reasons.name_sv IS 'name of the reason in svenska/Swedish';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.description_sv; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.member_app_waiting_reasons.description_sv IS 'description for the reason in svenska/Swedish';
+COMMENT ON COLUMN member_app_waiting_reasons.description_sv IS 'description for the reason in svenska/Swedish';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.name_en; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.member_app_waiting_reasons.name_en IS 'name of the reason in engelsk/English';
+COMMENT ON COLUMN member_app_waiting_reasons.name_en IS 'name of the reason in engelsk/English';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.description_en; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.member_app_waiting_reasons.description_en IS 'description for the reason in engelsk/English';
+COMMENT ON COLUMN member_app_waiting_reasons.description_en IS 'description for the reason in engelsk/English';
 
 
 --
 -- Name: COLUMN member_app_waiting_reasons.is_custom; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.member_app_waiting_reasons.is_custom IS 'was this entered as a new ''custom'' reason?';
+COMMENT ON COLUMN member_app_waiting_reasons.is_custom IS 'was this entered as a new ''custom'' reason?';
 
 
 --
 -- Name: member_app_waiting_reasons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.member_app_waiting_reasons_id_seq
+CREATE SEQUENCE member_app_waiting_reasons_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -474,14 +474,14 @@ CREATE SEQUENCE public.member_app_waiting_reasons_id_seq
 -- Name: member_app_waiting_reasons_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.member_app_waiting_reasons_id_seq OWNED BY public.member_app_waiting_reasons.id;
+ALTER SEQUENCE member_app_waiting_reasons_id_seq OWNED BY member_app_waiting_reasons.id;
 
 
 --
 -- Name: member_pages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.member_pages (
+CREATE TABLE member_pages (
     id bigint NOT NULL,
     filename character varying NOT NULL,
     title character varying,
@@ -494,7 +494,7 @@ CREATE TABLE public.member_pages (
 -- Name: member_pages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.member_pages_id_seq
+CREATE SEQUENCE member_pages_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -506,14 +506,14 @@ CREATE SEQUENCE public.member_pages_id_seq
 -- Name: member_pages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.member_pages_id_seq OWNED BY public.member_pages.id;
+ALTER SEQUENCE member_pages_id_seq OWNED BY member_pages.id;
 
 
 --
 -- Name: membership_number_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.membership_number_seq
+CREATE SEQUENCE membership_number_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -525,7 +525,7 @@ CREATE SEQUENCE public.membership_number_seq
 -- Name: payments; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.payments (
+CREATE TABLE payments (
     id bigint NOT NULL,
     user_id bigint,
     company_id bigint,
@@ -544,7 +544,7 @@ CREATE TABLE public.payments (
 -- Name: payments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.payments_id_seq
+CREATE SEQUENCE payments_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -556,14 +556,14 @@ CREATE SEQUENCE public.payments_id_seq
 -- Name: payments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.payments_id_seq OWNED BY public.payments.id;
+ALTER SEQUENCE payments_id_seq OWNED BY payments.id;
 
 
 --
 -- Name: regions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.regions (
+CREATE TABLE regions (
     id bigint NOT NULL,
     name character varying,
     code character varying,
@@ -576,7 +576,7 @@ CREATE TABLE public.regions (
 -- Name: regions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.regions_id_seq
+CREATE SEQUENCE regions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -588,14 +588,14 @@ CREATE SEQUENCE public.regions_id_seq
 -- Name: regions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.regions_id_seq OWNED BY public.regions.id;
+ALTER SEQUENCE regions_id_seq OWNED BY regions.id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.schema_migrations (
+CREATE TABLE schema_migrations (
     version character varying NOT NULL
 );
 
@@ -604,7 +604,7 @@ CREATE TABLE public.schema_migrations (
 -- Name: shf_applications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.shf_applications (
+CREATE TABLE shf_applications (
     id bigint NOT NULL,
     phone_number character varying,
     created_at timestamp without time zone NOT NULL,
@@ -613,7 +613,8 @@ CREATE TABLE public.shf_applications (
     contact_email character varying,
     state character varying DEFAULT 'new'::character varying,
     member_app_waiting_reasons_id integer,
-    custom_reason_text character varying
+    custom_reason_text character varying,
+    when_approved timestamp without time zone
 );
 
 
@@ -621,7 +622,7 @@ CREATE TABLE public.shf_applications (
 -- Name: shf_applications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.shf_applications_id_seq
+CREATE SEQUENCE shf_applications_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -633,14 +634,14 @@ CREATE SEQUENCE public.shf_applications_id_seq
 -- Name: shf_applications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.shf_applications_id_seq OWNED BY public.shf_applications.id;
+ALTER SEQUENCE shf_applications_id_seq OWNED BY shf_applications.id;
 
 
 --
 -- Name: shf_documents; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.shf_documents (
+CREATE TABLE shf_documents (
     id bigint NOT NULL,
     uploader_id bigint NOT NULL,
     title character varying,
@@ -658,7 +659,7 @@ CREATE TABLE public.shf_documents (
 -- Name: shf_documents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.shf_documents_id_seq
+CREATE SEQUENCE shf_documents_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -670,14 +671,14 @@ CREATE SEQUENCE public.shf_documents_id_seq
 -- Name: shf_documents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.shf_documents_id_seq OWNED BY public.shf_documents.id;
+ALTER SEQUENCE shf_documents_id_seq OWNED BY shf_documents.id;
 
 
 --
 -- Name: uploaded_files; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.uploaded_files (
+CREATE TABLE uploaded_files (
     id bigint NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
@@ -693,7 +694,7 @@ CREATE TABLE public.uploaded_files (
 -- Name: uploaded_files_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.uploaded_files_id_seq
+CREATE SEQUENCE uploaded_files_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -705,14 +706,14 @@ CREATE SEQUENCE public.uploaded_files_id_seq
 -- Name: uploaded_files_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.uploaded_files_id_seq OWNED BY public.uploaded_files.id;
+ALTER SEQUENCE uploaded_files_id_seq OWNED BY uploaded_files.id;
 
 
 --
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.users (
+CREATE TABLE users (
     id bigint NOT NULL,
     email character varying DEFAULT ''::character varying NOT NULL,
     encrypted_password character varying DEFAULT ''::character varying NOT NULL,
@@ -743,7 +744,7 @@ CREATE TABLE public.users (
 -- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.users_id_seq
+CREATE SEQUENCE users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -755,292 +756,292 @@ CREATE SEQUENCE public.users_id_seq
 -- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
+ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
--- Name: addresses id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.addresses ALTER COLUMN id SET DEFAULT nextval('public.addresses_id_seq'::regclass);
-
-
---
--- Name: app_configurations id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.app_configurations ALTER COLUMN id SET DEFAULT nextval('public.app_configurations_id_seq'::regclass);
+ALTER TABLE ONLY addresses ALTER COLUMN id SET DEFAULT nextval('addresses_id_seq'::regclass);
 
 
 --
--- Name: business_categories id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.business_categories ALTER COLUMN id SET DEFAULT nextval('public.business_categories_id_seq'::regclass);
-
-
---
--- Name: business_categories_shf_applications id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.business_categories_shf_applications ALTER COLUMN id SET DEFAULT nextval('public.business_categories_shf_applications_id_seq'::regclass);
+ALTER TABLE ONLY app_configurations ALTER COLUMN id SET DEFAULT nextval('app_configurations_id_seq'::regclass);
 
 
 --
--- Name: ckeditor_assets id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ckeditor_assets ALTER COLUMN id SET DEFAULT nextval('public.ckeditor_assets_id_seq'::regclass);
-
-
---
--- Name: companies id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.companies ALTER COLUMN id SET DEFAULT nextval('public.companies_id_seq'::regclass);
+ALTER TABLE ONLY business_categories ALTER COLUMN id SET DEFAULT nextval('business_categories_id_seq'::regclass);
 
 
 --
--- Name: company_applications id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.company_applications ALTER COLUMN id SET DEFAULT nextval('public.company_applications_id_seq'::regclass);
-
-
---
--- Name: conditions id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.conditions ALTER COLUMN id SET DEFAULT nextval('public.conditions_id_seq'::regclass);
+ALTER TABLE ONLY business_categories_shf_applications ALTER COLUMN id SET DEFAULT nextval('business_categories_shf_applications_id_seq'::regclass);
 
 
 --
--- Name: events id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.events ALTER COLUMN id SET DEFAULT nextval('public.events_id_seq'::regclass);
-
-
---
--- Name: kommuns id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.kommuns ALTER COLUMN id SET DEFAULT nextval('public.kommuns_id_seq'::regclass);
+ALTER TABLE ONLY ckeditor_assets ALTER COLUMN id SET DEFAULT nextval('ckeditor_assets_id_seq'::regclass);
 
 
 --
--- Name: member_app_waiting_reasons id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.member_app_waiting_reasons ALTER COLUMN id SET DEFAULT nextval('public.member_app_waiting_reasons_id_seq'::regclass);
-
-
---
--- Name: member_pages id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.member_pages ALTER COLUMN id SET DEFAULT nextval('public.member_pages_id_seq'::regclass);
+ALTER TABLE ONLY companies ALTER COLUMN id SET DEFAULT nextval('companies_id_seq'::regclass);
 
 
 --
--- Name: payments id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.payments ALTER COLUMN id SET DEFAULT nextval('public.payments_id_seq'::regclass);
-
-
---
--- Name: regions id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.regions ALTER COLUMN id SET DEFAULT nextval('public.regions_id_seq'::regclass);
+ALTER TABLE ONLY company_applications ALTER COLUMN id SET DEFAULT nextval('company_applications_id_seq'::regclass);
 
 
 --
--- Name: shf_applications id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.shf_applications ALTER COLUMN id SET DEFAULT nextval('public.shf_applications_id_seq'::regclass);
-
-
---
--- Name: shf_documents id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.shf_documents ALTER COLUMN id SET DEFAULT nextval('public.shf_documents_id_seq'::regclass);
+ALTER TABLE ONLY conditions ALTER COLUMN id SET DEFAULT nextval('conditions_id_seq'::regclass);
 
 
 --
--- Name: uploaded_files id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.uploaded_files ALTER COLUMN id SET DEFAULT nextval('public.uploaded_files_id_seq'::regclass);
-
-
---
--- Name: users id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
+ALTER TABLE ONLY events ALTER COLUMN id SET DEFAULT nextval('events_id_seq'::regclass);
 
 
 --
--- Name: addresses addresses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.addresses
+ALTER TABLE ONLY kommuns ALTER COLUMN id SET DEFAULT nextval('kommuns_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY member_app_waiting_reasons ALTER COLUMN id SET DEFAULT nextval('member_app_waiting_reasons_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY member_pages ALTER COLUMN id SET DEFAULT nextval('member_pages_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY payments ALTER COLUMN id SET DEFAULT nextval('payments_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY regions ALTER COLUMN id SET DEFAULT nextval('regions_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY shf_applications ALTER COLUMN id SET DEFAULT nextval('shf_applications_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY shf_documents ALTER COLUMN id SET DEFAULT nextval('shf_documents_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY uploaded_files ALTER COLUMN id SET DEFAULT nextval('uploaded_files_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+
+
+--
+-- Name: addresses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY addresses
     ADD CONSTRAINT addresses_pkey PRIMARY KEY (id);
 
 
 --
--- Name: app_configurations app_configurations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: app_configurations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.app_configurations
+ALTER TABLE ONLY app_configurations
     ADD CONSTRAINT app_configurations_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ar_internal_metadata
+ALTER TABLE ONLY ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
 --
--- Name: business_categories business_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: business_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.business_categories
+ALTER TABLE ONLY business_categories
     ADD CONSTRAINT business_categories_pkey PRIMARY KEY (id);
 
 
 --
--- Name: business_categories_shf_applications business_categories_shf_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: business_categories_shf_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.business_categories_shf_applications
+ALTER TABLE ONLY business_categories_shf_applications
     ADD CONSTRAINT business_categories_shf_applications_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ckeditor_assets ckeditor_assets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ckeditor_assets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ckeditor_assets
+ALTER TABLE ONLY ckeditor_assets
     ADD CONSTRAINT ckeditor_assets_pkey PRIMARY KEY (id);
 
 
 --
--- Name: companies companies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: companies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.companies
+ALTER TABLE ONLY companies
     ADD CONSTRAINT companies_pkey PRIMARY KEY (id);
 
 
 --
--- Name: company_applications company_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: company_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.company_applications
+ALTER TABLE ONLY company_applications
     ADD CONSTRAINT company_applications_pkey PRIMARY KEY (id);
 
 
 --
--- Name: conditions conditions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: conditions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.conditions
+ALTER TABLE ONLY conditions
     ADD CONSTRAINT conditions_pkey PRIMARY KEY (id);
 
 
 --
--- Name: events events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.events
+ALTER TABLE ONLY events
     ADD CONSTRAINT events_pkey PRIMARY KEY (id);
 
 
 --
--- Name: kommuns kommuns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: kommuns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.kommuns
+ALTER TABLE ONLY kommuns
     ADD CONSTRAINT kommuns_pkey PRIMARY KEY (id);
 
 
 --
--- Name: member_app_waiting_reasons member_app_waiting_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: member_app_waiting_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.member_app_waiting_reasons
+ALTER TABLE ONLY member_app_waiting_reasons
     ADD CONSTRAINT member_app_waiting_reasons_pkey PRIMARY KEY (id);
 
 
 --
--- Name: member_pages member_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: member_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.member_pages
+ALTER TABLE ONLY member_pages
     ADD CONSTRAINT member_pages_pkey PRIMARY KEY (id);
 
 
 --
--- Name: payments payments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: payments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.payments
+ALTER TABLE ONLY payments
     ADD CONSTRAINT payments_pkey PRIMARY KEY (id);
 
 
 --
--- Name: regions regions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: regions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.regions
+ALTER TABLE ONLY regions
     ADD CONSTRAINT regions_pkey PRIMARY KEY (id);
 
 
 --
--- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.schema_migrations
+ALTER TABLE ONLY schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
 --
--- Name: shf_applications shf_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: shf_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.shf_applications
+ALTER TABLE ONLY shf_applications
     ADD CONSTRAINT shf_applications_pkey PRIMARY KEY (id);
 
 
 --
--- Name: shf_documents shf_documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: shf_documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.shf_documents
+ALTER TABLE ONLY shf_documents
     ADD CONSTRAINT shf_documents_pkey PRIMARY KEY (id);
 
 
 --
--- Name: uploaded_files uploaded_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: uploaded_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.uploaded_files
+ALTER TABLE ONLY uploaded_files
     ADD CONSTRAINT uploaded_files_pkey PRIMARY KEY (id);
 
 
 --
--- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.users
+ALTER TABLE ONLY users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
@@ -1048,257 +1049,257 @@ ALTER TABLE ONLY public.users
 -- Name: index_addresses_on_addressable_type_and_addressable_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_addresses_on_addressable_type_and_addressable_id ON public.addresses USING btree (addressable_type, addressable_id);
+CREATE INDEX index_addresses_on_addressable_type_and_addressable_id ON addresses USING btree (addressable_type, addressable_id);
 
 
 --
 -- Name: index_addresses_on_kommun_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_addresses_on_kommun_id ON public.addresses USING btree (kommun_id);
+CREATE INDEX index_addresses_on_kommun_id ON addresses USING btree (kommun_id);
 
 
 --
 -- Name: index_addresses_on_latitude_and_longitude; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_addresses_on_latitude_and_longitude ON public.addresses USING btree (latitude, longitude);
+CREATE INDEX index_addresses_on_latitude_and_longitude ON addresses USING btree (latitude, longitude);
 
 
 --
 -- Name: index_addresses_on_region_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_addresses_on_region_id ON public.addresses USING btree (region_id);
+CREATE INDEX index_addresses_on_region_id ON addresses USING btree (region_id);
 
 
 --
 -- Name: index_ckeditor_assets_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ckeditor_assets_on_company_id ON public.ckeditor_assets USING btree (company_id);
+CREATE INDEX index_ckeditor_assets_on_company_id ON ckeditor_assets USING btree (company_id);
 
 
 --
 -- Name: index_ckeditor_assets_on_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ckeditor_assets_on_type ON public.ckeditor_assets USING btree (type);
+CREATE INDEX index_ckeditor_assets_on_type ON ckeditor_assets USING btree (type);
 
 
 --
 -- Name: index_companies_on_company_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_companies_on_company_number ON public.companies USING btree (company_number);
+CREATE UNIQUE INDEX index_companies_on_company_number ON companies USING btree (company_number);
 
 
 --
 -- Name: index_company_applications_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_company_applications_on_company_id ON public.company_applications USING btree (company_id);
+CREATE INDEX index_company_applications_on_company_id ON company_applications USING btree (company_id);
 
 
 --
 -- Name: index_company_applications_on_shf_application_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_company_applications_on_shf_application_id ON public.company_applications USING btree (shf_application_id);
+CREATE INDEX index_company_applications_on_shf_application_id ON company_applications USING btree (shf_application_id);
 
 
 --
 -- Name: index_events_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_events_on_company_id ON public.events USING btree (company_id);
+CREATE INDEX index_events_on_company_id ON events USING btree (company_id);
 
 
 --
 -- Name: index_events_on_latitude_and_longitude; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_events_on_latitude_and_longitude ON public.events USING btree (latitude, longitude);
+CREATE INDEX index_events_on_latitude_and_longitude ON events USING btree (latitude, longitude);
 
 
 --
 -- Name: index_events_on_start_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_events_on_start_date ON public.events USING btree (start_date);
+CREATE INDEX index_events_on_start_date ON events USING btree (start_date);
 
 
 --
 -- Name: index_on_applications; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_on_applications ON public.business_categories_shf_applications USING btree (shf_application_id);
+CREATE INDEX index_on_applications ON business_categories_shf_applications USING btree (shf_application_id);
 
 
 --
 -- Name: index_on_categories; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_on_categories ON public.business_categories_shf_applications USING btree (business_category_id);
+CREATE INDEX index_on_categories ON business_categories_shf_applications USING btree (business_category_id);
 
 
 --
 -- Name: index_payments_on_company_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_payments_on_company_id ON public.payments USING btree (company_id);
+CREATE INDEX index_payments_on_company_id ON payments USING btree (company_id);
 
 
 --
 -- Name: index_payments_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_payments_on_user_id ON public.payments USING btree (user_id);
+CREATE INDEX index_payments_on_user_id ON payments USING btree (user_id);
 
 
 --
 -- Name: index_shf_applications_on_member_app_waiting_reasons_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_shf_applications_on_member_app_waiting_reasons_id ON public.shf_applications USING btree (member_app_waiting_reasons_id);
+CREATE INDEX index_shf_applications_on_member_app_waiting_reasons_id ON shf_applications USING btree (member_app_waiting_reasons_id);
 
 
 --
 -- Name: index_shf_applications_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_shf_applications_on_user_id ON public.shf_applications USING btree (user_id);
+CREATE INDEX index_shf_applications_on_user_id ON shf_applications USING btree (user_id);
 
 
 --
 -- Name: index_shf_documents_on_uploader_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_shf_documents_on_uploader_id ON public.shf_documents USING btree (uploader_id);
+CREATE INDEX index_shf_documents_on_uploader_id ON shf_documents USING btree (uploader_id);
 
 
 --
 -- Name: index_uploaded_files_on_shf_application_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_uploaded_files_on_shf_application_id ON public.uploaded_files USING btree (shf_application_id);
+CREATE INDEX index_uploaded_files_on_shf_application_id ON uploaded_files USING btree (shf_application_id);
 
 
 --
 -- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
+CREATE UNIQUE INDEX index_users_on_email ON users USING btree (email);
 
 
 --
 -- Name: index_users_on_membership_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_membership_number ON public.users USING btree (membership_number);
+CREATE UNIQUE INDEX index_users_on_membership_number ON users USING btree (membership_number);
 
 
 --
 -- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_reset_password_token ON public.users USING btree (reset_password_token);
+CREATE UNIQUE INDEX index_users_on_reset_password_token ON users USING btree (reset_password_token);
 
 
 --
--- Name: payments fk_rails_081dc04a02; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_081dc04a02; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.payments
-    ADD CONSTRAINT fk_rails_081dc04a02 FOREIGN KEY (user_id) REFERENCES public.users(id);
-
-
---
--- Name: payments fk_rails_0fc68a9316; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.payments
-    ADD CONSTRAINT fk_rails_0fc68a9316 FOREIGN KEY (company_id) REFERENCES public.companies(id);
+ALTER TABLE ONLY payments
+    ADD CONSTRAINT fk_rails_081dc04a02 FOREIGN KEY (user_id) REFERENCES users(id);
 
 
 --
--- Name: ckeditor_assets fk_rails_1b8d2a3863; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_0fc68a9316; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ckeditor_assets
-    ADD CONSTRAINT fk_rails_1b8d2a3863 FOREIGN KEY (company_id) REFERENCES public.companies(id);
-
-
---
--- Name: uploaded_files fk_rails_2224289299; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.uploaded_files
-    ADD CONSTRAINT fk_rails_2224289299 FOREIGN KEY (shf_application_id) REFERENCES public.shf_applications(id);
+ALTER TABLE ONLY payments
+    ADD CONSTRAINT fk_rails_0fc68a9316 FOREIGN KEY (company_id) REFERENCES companies(id);
 
 
 --
--- Name: shf_applications fk_rails_3ee395b045; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_1b8d2a3863; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.shf_applications
-    ADD CONSTRAINT fk_rails_3ee395b045 FOREIGN KEY (member_app_waiting_reasons_id) REFERENCES public.member_app_waiting_reasons(id);
-
-
---
--- Name: addresses fk_rails_76a66052a5; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.addresses
-    ADD CONSTRAINT fk_rails_76a66052a5 FOREIGN KEY (kommun_id) REFERENCES public.kommuns(id);
+ALTER TABLE ONLY ckeditor_assets
+    ADD CONSTRAINT fk_rails_1b8d2a3863 FOREIGN KEY (company_id) REFERENCES companies(id);
 
 
 --
--- Name: events fk_rails_88786fdf2d; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_2224289299; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.events
-    ADD CONSTRAINT fk_rails_88786fdf2d FOREIGN KEY (company_id) REFERENCES public.companies(id);
-
-
---
--- Name: shf_documents fk_rails_bb6df17516; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.shf_documents
-    ADD CONSTRAINT fk_rails_bb6df17516 FOREIGN KEY (uploader_id) REFERENCES public.users(id);
+ALTER TABLE ONLY uploaded_files
+    ADD CONSTRAINT fk_rails_2224289299 FOREIGN KEY (shf_application_id) REFERENCES shf_applications(id);
 
 
 --
--- Name: shf_applications fk_rails_be394644c4; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_3ee395b045; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.shf_applications
-    ADD CONSTRAINT fk_rails_be394644c4 FOREIGN KEY (user_id) REFERENCES public.users(id);
-
-
---
--- Name: company_applications fk_rails_cf393e2864; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.company_applications
-    ADD CONSTRAINT fk_rails_cf393e2864 FOREIGN KEY (company_id) REFERENCES public.companies(id);
+ALTER TABLE ONLY shf_applications
+    ADD CONSTRAINT fk_rails_3ee395b045 FOREIGN KEY (member_app_waiting_reasons_id) REFERENCES member_app_waiting_reasons(id);
 
 
 --
--- Name: company_applications fk_rails_cfd957fb2a; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_76a66052a5; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.company_applications
-    ADD CONSTRAINT fk_rails_cfd957fb2a FOREIGN KEY (shf_application_id) REFERENCES public.shf_applications(id);
+ALTER TABLE ONLY addresses
+    ADD CONSTRAINT fk_rails_76a66052a5 FOREIGN KEY (kommun_id) REFERENCES kommuns(id);
 
 
 --
--- Name: addresses fk_rails_f7aa0f06a9; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_88786fdf2d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.addresses
-    ADD CONSTRAINT fk_rails_f7aa0f06a9 FOREIGN KEY (region_id) REFERENCES public.regions(id);
+ALTER TABLE ONLY events
+    ADD CONSTRAINT fk_rails_88786fdf2d FOREIGN KEY (company_id) REFERENCES companies(id);
+
+
+--
+-- Name: fk_rails_bb6df17516; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY shf_documents
+    ADD CONSTRAINT fk_rails_bb6df17516 FOREIGN KEY (uploader_id) REFERENCES users(id);
+
+
+--
+-- Name: fk_rails_be394644c4; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY shf_applications
+    ADD CONSTRAINT fk_rails_be394644c4 FOREIGN KEY (user_id) REFERENCES users(id);
+
+
+--
+-- Name: fk_rails_cf393e2864; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY company_applications
+    ADD CONSTRAINT fk_rails_cf393e2864 FOREIGN KEY (company_id) REFERENCES companies(id);
+
+
+--
+-- Name: fk_rails_cfd957fb2a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY company_applications
+    ADD CONSTRAINT fk_rails_cfd957fb2a FOREIGN KEY (shf_application_id) REFERENCES shf_applications(id);
+
+
+--
+-- Name: fk_rails_f7aa0f06a9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY addresses
+    ADD CONSTRAINT fk_rails_f7aa0f06a9 FOREIGN KEY (region_id) REFERENCES regions(id);
 
 
 --
@@ -1372,6 +1373,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180717043851'),
 ('20180719021503'),
 ('20181203121315'),
-('20181214011549');
+('20181214011549'),
+('20181228073947');
 
 

--- a/spec/factories/shf_applications.rb
+++ b/spec/factories/shf_applications.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     phone_number { 'MyString' }
     contact_email { 'MyString@email.com' }
     state { :new }
+    when_approved { nil }
 
     updated_at { Time.zone.now }
 
@@ -13,10 +14,12 @@ FactoryBot.define do
 
     trait :accepted do
       state { :accepted }
+      when_approved { Time.zone.now }
     end
 
     trait :rejected do
       state { :rejected }
+      when_approved { nil }
     end
 
     transient do

--- a/spec/models/shf_application_spec.rb
+++ b/spec/models/shf_application_spec.rb
@@ -6,12 +6,7 @@ require 'support/ae_aasm_matchers/ae_aasm_matchers'
 require 'shared_examples/scope_updated_in_date_range_spec'
 
 
-# alias shared example call for readability
-RSpec.configure do |c|
-  c.alias_it_should_behave_like_to :it_will, 'it will'
-end
-
-
+#================================================================================
 # Shared examples:
 
 RSpec.shared_examples 'allow transition to' do |start_state, to_state, transition_event|
@@ -31,7 +26,7 @@ RSpec.shared_examples 'not allow transition to' do |start_state, to_state|
   end
 end
 
-#--------------------------------------------------------------------------
+#================================================================================
 
 
 RSpec.describe ShfApplication, type: :model do
@@ -359,77 +354,77 @@ RSpec.describe ShfApplication, type: :model do
 
     describe 'new' do
 
-      it_will 'not allow transition to', :new, :new
+      it_should 'not allow transition to', :new, :new
 
-      it_will 'allow transition to', :new, :under_review, :start_review
+      it_should 'allow transition to', :new, :under_review, :start_review
 
-      it_will 'not allow transition to', :new, :waiting_for_applicant
-      it_will 'not allow transition to', :new, :ready_for_review
+      it_should 'not allow transition to', :new, :waiting_for_applicant
+      it_should 'not allow transition to', :new, :ready_for_review
 
-      it_will 'not allow transition to', :new, :accepted
-      it_will 'not allow transition to', :new, :rejected
+      it_should 'not allow transition to', :new, :accepted
+      it_should 'not allow transition to', :new, :rejected
 
     end
 
 
     describe 'under_review' do
 
-      it_will 'not allow transition to', :under_review, :new
+      it_should 'not allow transition to', :under_review, :new
 
-      it_will 'not allow transition to', :under_review, :under_review
+      it_should 'not allow transition to', :under_review, :under_review
 
-      it_will 'allow transition to', :under_review, :waiting_for_applicant, :ask_applicant_for_info
+      it_should 'allow transition to', :under_review, :waiting_for_applicant, :ask_applicant_for_info
 
-      it_will 'not allow transition to', :under_review, :ready_for_review
+      it_should 'not allow transition to', :under_review, :ready_for_review
 
-      it_will 'allow transition to', :under_review, :accepted, :accept
+      it_should 'allow transition to', :under_review, :accepted, :accept
 
-      it_will 'allow transition to', :under_review, :rejected, :reject
+      it_should 'allow transition to', :under_review, :rejected, :reject
 
     end
 
 
     describe 'waiting_for_applicant' do
 
-      it_will 'not allow transition to', :waiting_for_applicant, :new
+      it_should 'not allow transition to', :waiting_for_applicant, :new
 
-      it_will 'allow transition to', :waiting_for_applicant, :under_review, :cancel_waiting_for_applicant
+      it_should 'allow transition to', :waiting_for_applicant, :under_review, :cancel_waiting_for_applicant
 
-      it_will 'not allow transition to', :waiting_for_applicant, :waiting_for_applicant
-      it_will 'allow transition to', :waiting_for_applicant, :ready_for_review, :is_ready_for_review
+      it_should 'not allow transition to', :waiting_for_applicant, :waiting_for_applicant
+      it_should 'allow transition to', :waiting_for_applicant, :ready_for_review, :is_ready_for_review
 
-      it_will 'not allow transition to', :waiting_for_applicant, :accepted, :accept
-      it_will 'not allow transition to', :waiting_for_applicant, :rejected, :reject
+      it_should 'not allow transition to', :waiting_for_applicant, :accepted, :accept
+      it_should 'not allow transition to', :waiting_for_applicant, :rejected, :reject
 
     end
 
 
     describe 'state accepted' do
 
-      it_will 'not allow transition to', :accepted, :new
+      it_should 'not allow transition to', :accepted, :new
 
-      it_will 'not allow transition to', :accepted, :under_review
+      it_should 'not allow transition to', :accepted, :under_review
 
-      it_will 'not allow transition to', :accepted, :waiting_for_applicant
-      it_will 'not allow transition to', :accepted, :ready_for_review
+      it_should 'not allow transition to', :accepted, :waiting_for_applicant
+      it_should 'not allow transition to', :accepted, :ready_for_review
 
-      it_will 'not allow transition to', :accepted, :accepted
-      it_will 'allow transition to', :accepted, :rejected, :reject
+      it_should 'not allow transition to', :accepted, :accepted
+      it_should 'allow transition to', :accepted, :rejected, :reject
 
     end
 
 
     describe 'state rejected' do
 
-      it_will 'not allow transition to', :rejected, :new
+      it_should 'not allow transition to', :rejected, :new
 
-      it_will 'not allow transition to', :rejected, :under_review
+      it_should 'not allow transition to', :rejected, :under_review
 
-      it_will 'not allow transition to', :rejected, :waiting_for_applicant
-      it_will 'not allow transition to', :rejected, :ready_for_review
+      it_should 'not allow transition to', :rejected, :waiting_for_applicant
+      it_should 'not allow transition to', :rejected, :ready_for_review
 
-      it_will 'allow transition to', :rejected, :accepted, :accept
-      it_will 'not allow transition to', :rejected, :rejected
+      it_should 'allow transition to', :rejected, :accepted, :accept
+      it_should 'not allow transition to', :rejected, :rejected
 
     end
 

--- a/spec/shared_examples/scope_updated_in_date_range_spec.rb
+++ b/spec/shared_examples/scope_updated_in_date_range_spec.rb
@@ -69,9 +69,8 @@ RSpec.shared_examples 'it_has_updated_in_date_range_scope' do | factory_method |
 
 
     it 'causes a SQL error if start_date is a date exception and end_date a number:' do
-      #expect{described_class.updated_in_date_range(start_date, 99)}.to raise_error ActiveRecord::StatementInvalid
-      pending 'This causes a SQL error and raises ActiveRecord::StatementInvalid but I cannot figure out a way to get RSpec matchers to catch it '
-      expect(false).to be_truthy
+      # the SQL statement is only executed if it has a .count or other method chained after it.  That's why .count is included below
+      expect{ described_class.updated_in_date_range(start_date, 99).count }.to raise_error ActiveRecord::StatementInvalid
     end
 
     it 'raises exception if end_date is not a date or a Number: ArgumentError: bad value for range' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,4 +42,8 @@ RSpec.configure do |config|
   config.after(:suite) do
     FileUtils.rm_rf(Dir["#{Rails.root}/spec/test_paperclip_files/"]) if Object.const_defined?('Rails')
   end
+
+  # Alias shared example call for readability so that you can call it with just it_should
+  #   and it will display 'it should'
+  config.alias_it_should_behave_like_to :it_should, 'it should'
 end


### PR DESCRIPTION
### PT Story: Email alert to: Member's application = Accepted but have not paid their membership fee
https://www.pivotaltracker.com/story/show/161889630

This is the first step for being able to figure out when a Membership fee is past due:  we have to know (save) when an application was approved.  

### Changes proposed in this pull request:
1. add `when_approved` datetime to the ShfApplication model
2. when an application is approved, record the Time (Time.zone now).  
      _Should it be UTC?_  
   When it's rejected, erase the DateTime when it was approved (by setting it to `nil`)
3. Improved the ShfApplication specs a little:
   - fixed the spec in `spec/shared_examples/scope_updated_in_date_range_spec.rb` that was pending:  the SQL statement wasn't being executed; it needs a .count after it to actually execute it.
   - changed the shared example alias 'it_will' to `it_should`  -- which is more accurate and consistent
   - moved the shared examples alias `it_should` into spec_helper.rb so it can be used everywhere (it was in the spec for ShfApplication)


Ready for review:
@patmbolger @thesuss 
