### PR TITLE
Change all 'http' urls  to 'https' in locale files

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,7 +148,6 @@ en:
         last_login: &user_last_login Last login
         last_login_ip: &user_last_login_ip Last logged in from IP address
         sign_in_count: &sign_in_count Logins
-        created: *created
         reset_password_sent_at: &user_reset_password_sent_at Password reset info sent
         member: &member Member
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,11 +50,11 @@ en:
 
   hello: 'Hello, %{name}'
 
-  shf_home_url: &shf_home_url http://www.sverigeshundforetagare.se
-  shf_medlemssystem_url: &shf_medlemssystem_url http://hitta.sverigeshundforetagare.se
-  shf_facebook_url: &shf_facebook_url http://www.facebook.com/sverigeshundforetagare
+  shf_home_url: &shf_home_url https://www.sverigeshundforetagare.se
+  shf_medlemssystem_url: &shf_medlemssystem_url https://hitta.sverigeshundforetagare.se
+  shf_facebook_url: &shf_facebook_url https://www.facebook.com/sverigeshundforetagare
   shf_facebook_group_url: &shf_facebook_group_url https://www.facebook.com/groups/sverigeshundforetagare/
-  shf_instagram_url: &shf_instagram_url http://instagram.com/sverigeshundforetagare
+  shf_instagram_url: &shf_instagram_url https://instagram.com/sverigeshundforetagare
 
 
   info:
@@ -826,7 +826,7 @@ en:
       branding_fee_expires: H Expires
       paid: *paid
       never_paid: *never_paid
-      fee_payment_url: "Log in and pay here: http://hitta.sverigeshundforetagare.se%{payment_url}"
+      fee_payment_url: "Log in and pay here: https://hitta.sverigeshundforetagare.se%{payment_url}"
 
 
   shf_documents:
@@ -977,7 +977,7 @@ en:
 
       signoff: "Best Regards,"
       signature: &medlemsansvarig Membership Committee
-      signature_url: "http://sverigeshundforetagare.se"
+      signature_url: "https://sverigeshundforetagare.se"
 
       footer:
         text:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -50,11 +50,11 @@ sv:
 
   hello: Hallå, %{name}
 
-  shf_home_url: &shf_home_url http://www.sverigeshundforetagare.se
-  shf_medlemssystem_url: &shf_medlemssystem_url http://hitta.sverigeshundforetagare.se
-  shf_facebook_url: &shf_facebook_url http://www.facebook.com/sverigeshundforetagare
+  shf_home_url: &shf_home_url https://www.sverigeshundforetagare.se
+  shf_medlemssystem_url: &shf_medlemssystem_url https://hitta.sverigeshundforetagare.se
+  shf_facebook_url: &shf_facebook_url https://www.facebook.com/sverigeshundforetagare
   shf_facebook_group_url: &shf_facebook_group_url https://www.facebook.com/groups/sverigeshundforetagare/
-  shf_instagram_url: &shf_instagram_url http://instagram.com/sverigeshundforetagare
+  shf_instagram_url: &shf_instagram_url https://instagram.com/sverigeshundforetagare
 
 
   info:
@@ -400,10 +400,10 @@ sv:
                         skapa igenkänning, tydlighet gentemot kund. Och skydda
                         oss mot förfalskningar av H-märket.
         upload_this_image: 'Vi önskar att du lägger upp nedanstående bild på din
-                          hemsida. Samt länkar denna bild till: "http://www.sverigeshundforetagare.se"'
+                          hemsida. Samt länkar denna bild till: "https://www.sverigeshundforetagare.se"'
         using_the_h_mark: 'Vi önskar även att du pryder din hemsida med H-märket.
                           För att visa att ni är just H-märkta med allt vad det innebär.
-                          Bilden nedan nyttjas i detta syfte och länkas till: "http://sverigeshundforetagare.se/agare/h-markt-av-sveriges-hundforetagare/"'
+                          Bilden nedan nyttjas i detta syfte och länkas till: "https://sverigeshundforetagare.se/agare/h-markt-av-sveriges-hundforetagare/"'
         ffs: Du hittar ditt h-märke och ditt behörighetsbevis under ditt konto.
       waiting_for_approval:
         title: Hej, kul att du vill bli medlem
@@ -826,7 +826,7 @@ sv:
       branding_fee_expires: H Expires
       paid: *paid
       never_paid: *never_paid
-      fee_payment_url: "Betalas som inloggad via: http://hitta.sverigeshundforetagare.se%{payment_url}"
+      fee_payment_url: "Betalas som inloggad via: https://hitta.sverigeshundforetagare.se%{payment_url}"
 
 
   shf_documents:
@@ -980,7 +980,7 @@ sv:
 
       signoff: "Med vänliga hälsningar,"
       signature: &medlemsansvarig Medlemsansvarig
-      signature_url: "http://sverigeshundforetagare.se"
+      signature_url: "https://sverigeshundforetagare.se"
 
       footer:
         text:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -148,7 +148,7 @@ sv:
         last_login: &user_last_login Senast inloggad
         last_login_ip: &user_last_login_ip Senast inloggad med IP
         sign_in_count: &sign_in_count Inloggningar
-        created: *created
+
         reset_password_sent_at: &user_reset_password_sent_at Information angående återställning av lösenord sändes
         member: &member Medlem
 
@@ -327,7 +327,6 @@ sv:
       phone_number: &phone_number Telefonnummer
       first_name: *first_name
       last_name: *last_name
-      company_number: *company_number
       enter_company_number: Ange ditt företagsnummer (eller skapa ett nytt
                              företag om det inte finns i systemet)
       contact_email: *contact_email

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe User, type: :model do
                             .allow_destroy(false).update_only(true) }
   end
 
+
   describe 'Admin' do
     subject { create(:user, admin: true) }
 
@@ -180,12 +181,14 @@ RSpec.describe User, type: :model do
     it { is_expected.not_to be_member }
   end
 
+
   describe 'User' do
     subject { create(:user, admin: false) }
 
     it { is_expected.not_to be_admin }
     it { is_expected.not_to be_member }
   end
+
 
   describe 'destroy or nullify associated records when user is destroyed' do
 
@@ -233,6 +236,7 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
 
   describe 'Scopes' do
 


### PR DESCRIPTION
### PT Story:  Mail - footer links should be https
https://www.pivotaltracker.com/story/show/162752825

It didn't make sense to change _only_ the locale entries for the mails.  They all needed to be changed.

### Changes proposed in this pull request:
1.  changed all urls (including facebook, instagram, etc.)
2. removed duplicate entries


Ready for review:
@thesuss 
