### PR TITLE
Admin export CSV: include login and profile emails

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -39,7 +39,7 @@ class AdminController < ApplicationController
 
       app_company = m_app.companies.last
 
-      out_str << "#{m_app.contact_email},#{m_app.user.first_name},#{m_app.user.last_name},#{m_app.user.membership_number},"
+      out_str << "#{m_app.contact_email},#{m_app.user.email},#{m_app.user.first_name},#{m_app.user.last_name},#{m_app.user.membership_number},"
       out_str << t("shf_applications.state.#{m_app.state}")
       out_str << ','
 
@@ -84,6 +84,7 @@ class AdminController < ApplicationController
     # build the header string from strings in the locale file
 
     header_member_strs = [t('activerecord.attributes.shf_application.contact_email'),
+                          t('activerecord.attributes.user.email'),
                           t('activerecord.attributes.shf_application.first_name'),
                           t('activerecord.attributes.shf_application.last_name'),
                           t('activerecord.attributes.user.membership_number'),


### PR DESCRIPTION
### PT Story:  Admin export CSV: include login and profile emails

https://www.pivotaltracker.com/story/show/163203106


### Changes proposed in this pull request:
1.  added user `login_email` as the 2nd col. to the exported CSV
2. cleaned up the specification some.  Because the columns have and do change, the cleanup will make the next specification / test change a little easier.

Ready for review:
@thesuss @patmbolger 
