### PR TITLE
Show 'please upload again' if problem saving/updating SHF application

### DIFF
--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -271,6 +271,8 @@ class ShfApplicationsController < ApplicationController
     @shf_application = add_company_errors_to_model(@shf_application,
                                                    companies_and_numbers)
 
+    error_message = add_upload_file_again_error(error_message) if params['uploaded_file']
+
     helpers.flash_message(:alert, error_message)
     load_update_objects(company_numbers_str)
     render render_me
@@ -295,6 +297,12 @@ class ShfApplicationsController < ApplicationController
     end
     application
   end
+
+
+  def add_upload_file_again_error(orig_error_message)
+    orig_error_message + "\n" + t('shf_applications.uploads.please_upload_again')
+  end
+
 
   def load_update_objects(numbers_str)
     @company_numbers = numbers_str

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -511,7 +511,7 @@ en:
       confirm_delete: 'Are you sure you want to delete %{filename}?'
       invalid_upload_type: &invalid_upload_type Sorry, this is not a file type you can upload.
       file_too_large: &file_too_large_5MB The file must be smaller than 5 MB
-
+      please_upload_again: Please upload your files again.
 
     update_the_status: Update the status
     application_deleted: Application deleted.

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -517,6 +517,7 @@ sv:
       confirm_delete: 'Är du säker på att du vill radera %{filename}?'
       invalid_upload_type: &invalid_upload_type Tyvärr kan du inte ladda upp denna filtypen.
       file_too_large: &file_too_large_5MB Filen måste vara mindre än 5 MB
+      please_upload_again: Please upload your files again.
 
     update_the_status: Uppdatera status
     application_deleted: Ansökan raderad.

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -517,7 +517,7 @@ sv:
       confirm_delete: 'Är du säker på att du vill radera %{filename}?'
       invalid_upload_type: &invalid_upload_type Tyvärr kan du inte ladda upp denna filtypen.
       file_too_large: &file_too_large_5MB Filen måste vara mindre än 5 MB
-      please_upload_again: Please upload your files again.
+      please_upload_again: Var god ladda upp dina filer igen.
 
     update_the_status: Uppdatera status
     application_deleted: Ansökan raderad.

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -140,7 +140,7 @@ Feature: Create a new membership application
     And I should see t("shf_applications.create.success", email_address: info@craft.se)
 
   @selenium
-  Scenario: A user cannot submit a new Membership Application with no category
+  Scenario: A user cannot submit a new Membership Application with no category [SAD PATH]
     Given I am on the "user instructions" page
     And I click on first t("menus.nav.users.apply_for_membership") link
     And I fill in the translated form with data:
@@ -216,7 +216,7 @@ Feature: Create a new membership application
     Then I should see t("shf_applications.create.success", email_address: applicant_2@random.com)
 
 
-  Scenario Outline: Apply for membership - when things go wrong with application data
+  Scenario Outline: Apply for membership - when things go wrong with application data [SAD PATH]
     Given I am on the "new application" page
     And I fill in the translated form with data:
       | shf_applications.new.contact_email | shf_applications.new.phone_number |
@@ -225,6 +225,7 @@ Feature: Create a new membership application
     Then I should see error <model_attribute> <error>
     And I should receive no emails
     And "admin@shf.se" should receive no emails
+    And I should not see t("shf_applications.uploads.please_upload_again")
 
     Scenarios:
       | c_email       | phone      | model_attribute                                                   | error                            |
@@ -234,8 +235,25 @@ Feature: Create a new membership application
       | kickiimmi.nu  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")        | t("errors.messages.invalid")     |
 
 
-  @selenium
-  Scenario Outline: Apply for membership - when things go wrong with company create
+  Scenario Outline: Apply for membership with uploads, errors should show please upload again message [SAD PATH]
+    Given I am on the "new application" page
+    And I fill in the translated form with data:
+      | shf_applications.new.contact_email | shf_applications.new.phone_number |
+      | <c_email>                          | <phone>                           |
+    And I choose a file named "diploma.pdf" to upload
+    When I click on t("shf_applications.new.submit_button_label")
+    Then I should see t("shf_applications.uploads.please_upload_again")
+
+    Scenarios:
+      | c_email       | phone      |
+      |               | 0706898525 |
+      |               | 0706898525 |
+      | kicki@imminu  | 0706898525 |
+      | kickiimmi.nu  | 0706898525 |
+
+
+   @selenium
+  Scenario Outline: Apply for membership - when things go wrong with company create [SAD PATH]
     Given I am on the "new application" page
     And I fill in the translated form with data:
       | shf_applications.new.contact_email | shf_applications.new.phone_number |
@@ -259,21 +277,16 @@ Feature: Create a new membership application
       | 5562252998 |               | 0706898525 | t("activerecord.attributes.company.email")          | t("errors.messages.invalid") |
 
 
-  Scenario Outline: Apply for membership: company number wrong length
+  Scenario: Apply for membership: company number wrong length (no uploads) [SAD PATH]
     Given I am on the "new application" page
 
     # Create new company in modal
     And I click on t("companies.new.title")
     And I fill in the translated form with data:
       | companies.show.company_number | companies.show.email |
-      | <c_number>                    | <c_email>            |
-
+      | 00                   | kicki@immi.nu           |
     And I click on t("companies.create.create_submit")
-    Then I should see <error>
-
-    Scenarios:
-      | c_number | c_email       | error                                        |
-      | 00       | kicki@immi.nu | t("errors.messages.wrong_length", count: 10) |
+    Then I should not see t("shf_applications.uploads.please_upload_again")
 
 
   Scenario Outline: Cannot change locale if there are errors in the new application

--- a/features/edit_shf_application.feature
+++ b/features/edit_shf_application.feature
@@ -1,6 +1,8 @@
-Feature: As an applicant
-  In order to be able to edit my application
-  I want to be allowed to do that
+Feature: Edit SHF Application
+
+  As an applicant
+  In order to correct errors or provide more information
+  I need to be able to edit my SHF application
 
   PT: https://www.pivotaltracker.com/story/show/134078325
 
@@ -28,9 +30,9 @@ Feature: As an applicant
       | bob@barkybobs.com | 5560360793             | rejected              | Groomer    |
 
   @selenium
-  Scenario: Applicant makes mistake when editing his own application
+  Scenario: Applicant makes mistake when editing their own application (no files uploaded) [SAD PATH]
     Given I am logged in as "emma@random.com"
-    Given I am on the "user instructions" page
+    And I am on the "user instructions" page
     And I click on t("menus.nav.users.my_application")
     Then I should be on "Edit My Application" page
     And I fill in t("shf_applications.show.contact_email") with ""
@@ -40,6 +42,21 @@ Feature: As an applicant
     And I should see error t("shf_applications.show.contact_email") t("errors.messages.blank")
     Then I should see error t("activerecord.attributes.shf_application.business_categories") t("errors.messages.blank")
     And I should see button t("shf_applications.edit.submit_button_label")
+    And I should not see t("shf_applications.uploads.please_upload_again")
+
+  @selenium
+  Scenario: Applicant makes mistake when uploading a file and editing their own application [SAD PATH]
+    Given I am logged in as "emma@random.com"
+    And I am on the "user instructions" page
+    And I click on t("menus.nav.users.my_application")
+    Then I should be on "Edit My Application" page
+    And I choose a file named "diploma.pdf" to upload
+    And I fill in t("shf_applications.show.contact_email") with ""
+    And I unselect "Groomer" Category
+    And I click on t("shf_applications.edit.submit_button_label")
+    Then I should see t("shf_applications.update.error")
+    And I should see t("shf_applications.uploads.please_upload_again")
+
 
   Scenario: Applicant adds second company to application
     Given I am logged in as "emma@random.com"
@@ -90,7 +107,7 @@ Feature: As an applicant
     And I should see t("shf_applications.update.success", email_address: info@craft.se)
     And I should see "5560360793, 2120000142"
 
-  Scenario: Applicant can not edit applications not created by him
+  Scenario: Applicant can not edit applications not created by them
     Given I am logged in as "emma@random.com"
     And I am on the "edit application" page for "hans@random.com"
     Then I should see t("errors.not_permitted")


### PR DESCRIPTION
### PT Story:  Tell user to upload again if there's an error when submitting an SHF application
https://www.pivotaltracker.com/story/show/162689109

### Changes proposed in this pull request:
1. added PLACEHOLDER text for what the message should save
2. SHF controller: if there was a problem saving a new or updated application _and_ a file was uploaded, display the 'please upload your files again' message in the flash message
3. Added scenarios for New application and Edit application; made sure that message does _not_ show if no files were uploaded

### Screenshots (Optional):

**New application**
<img width="748" alt="screen shot 2019-01-16 at 5 29 45 pm" src="https://user-images.githubusercontent.com/673794/51289306-7f2d6580-19b4-11e9-8aaa-f7baa8d5f17d.png">

**Edit application**
<img width="776" alt="screen shot 2019-01-16 at 5 27 45 pm" src="https://user-images.githubusercontent.com/673794/51289307-7f2d6580-19b4-11e9-83ec-97ec32a07ca1.png">


Ready for review:
@thesuss @patmbolger 

@thesuss  - need to tell me what the text should be
