### PR TITLE
Membership Lapsed alert

### DIFF
--- a/app/helpers/member_mailer_helper.rb
+++ b/app/helpers/member_mailer_helper.rb
@@ -3,8 +3,10 @@ module MemberMailerHelper
   # The link and text to a member's account page (to be used in emails).
   # Uses _blank so that it will open in a new browser window.
   #
-  def member_account_link(member)
-    link_to(t('menus.nav.users.your_account'), user_url(member), target: '_blank', rel: 'nofollow')
+  def member_account_link(member, capitalize: false)
+    link_text = t('menus.nav.users.your_account')
+    link_text = capitalize ? link_text.capitalize : link_text.downcase
+    link_to(link_text, user_url(member), target: '_blank', rel: 'nofollow')
   end
 
 end

--- a/app/views/member_mailer/_user_account_link.html.haml
+++ b/app/views/member_mailer/_user_account_link.html.haml
@@ -1,7 +1,11 @@
 -# This partial shows the account link for a member and the text explaining
 -# that they may need to log in to see it.
 -#
--# The partial expects the local
--# member - the member whose account this will link to
+-# The partial expects the locals
+-#   member - the member whose account this will link to
+-#   capitalize - (boolean) whether or not to capitalize the text for the link
+-#                 default = false
 -#
-= t('mailers.member_mailer.member_account_link', account_link: member_account_link(member)).html_safe
+- capitalize_linktext = local_assigns.fetch :capitalize, false
+- acct_link = member_account_link(member, capitalize: capitalize_linktext)
+= t('mailers.member_mailer.member_account_link', account_link: acct_link).html_safe

--- a/app/views/member_mailer/membership_expiration_reminder.html.haml
+++ b/app/views/member_mailer/membership_expiration_reminder.html.haml
@@ -11,4 +11,4 @@
     = t('extend_membership', scope: message_scope)
 
   %p
-    = render 'user_account_link', member: @member
+    = render 'user_account_link', member: @member, capitalize: true

--- a/app/views/member_mailer/membership_lapsed.html.haml
+++ b/app/views/member_mailer/membership_lapsed.html.haml
@@ -11,4 +11,5 @@
     = t('renew_membership', scope: message_scope)
 
   %p
+    = t('pay_on_acct_page', scope: message_scope)
     = render 'user_account_link', member: @member

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1088,6 +1088,7 @@ en:
         message_text:
           expire_alert_html: "Your SHF membership term ended on <span class='date-warning'> %{expire_date}.</span>"
           renew_membership: You can renew your membership and keep taking advantage of SHF member benefits by logging in and paying your membership fee.
+          pay_on_acct_page: "Go to your account page to pay:"
 
 
       co_info_incomplete:
@@ -1203,7 +1204,7 @@ en:
       users:
         my_application: &my_application My Application
         apply_for_membership: Apply for Membership
-        your_account: View Your Account
+        your_account: My account
 
       members:
         shf_companies: SHF Companies

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1102,6 +1102,7 @@ sv:
         message_text:
           expire_alert_html: "Ditt medlemsskap gick ut <span class='date-warning'> %{expire_date}.</span>"
           renew_membership: Du kan förnya ditt medlemsskap och fortsätta dra nytta av medlemsfördelarna genom att logga in och betala.
+          pay_on_acct_page: "Du betalar via "
 
 
   devise:

--- a/lib/tasks/conditions/load_conditions.rake
+++ b/lib/tasks/conditions/load_conditions.rake
@@ -14,6 +14,10 @@ namespace :shf do
           timing:     :before,
           config:     { days: std_reminder_before_schedule } },
 
+        { class_name: 'MembershipLapsedAlert',
+          timing:     :after,
+          config:     { days: std_reminder_after_schedule } },
+
         { class_name: 'HBrandingFeeDueAlert',
           timing:     :after,
           config:     { days: std_reminder_after_schedule } },


### PR DESCRIPTION
### PT Story: MembershipLapsedAlert
https://www.pivotaltracker.com/story/show/164399227

### Changes proposed in this pull request:
1.  The `MembershipLapsed` code was already in there!  (Was surely my responsibility to create a PT story and get it done; and it seems I blew it.)

2. Just needed to add it to `load_conditions`


### Screenshots (Optional):

<img width="582" alt="email-membership-lapsed-sv-html-2" src="https://user-images.githubusercontent.com/673794/53903329-485cee80-3ff8-11e9-9ed3-4687e50c1393.png">

---

**en:**


<img width="577" alt="email-membership-lapsed-en-html-2" src="https://user-images.githubusercontent.com/673794/53903328-485cee80-3ff8-11e9-995f-00f151aa40d2.png">

### Ready for review:
@thesuss 
@patmbolger 
