### PR TITLE
BUG: Edit user profile fails for users with "legacy" applications

### DIFF
--- a/app/models/shf_application.rb
+++ b/app/models/shf_application.rb
@@ -31,11 +31,12 @@ class ShfApplication < ApplicationRecord
              foreign_key: "member_app_waiting_reasons_id",
              class_name: 'AdminOnly::MemberAppWaitingReason'
 
-  belongs_to :file_delivery_method,
+  belongs_to :file_delivery_method, optional: true,
              class_name: 'AdminOnly::FileDeliveryMethod'
 
-  validates :contact_email, :state, :companies, :file_delivery_method,
-            :business_categories, presence: true
+  validates :contact_email, :state, :companies, :business_categories, presence: true
+
+  validates :file_delivery_method, presence: { on: :create }
 
   validates_format_of :contact_email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: [:create, :update]
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,7 +139,6 @@ en:
         one: User
         other: Users
 
-
     attributes:
 
       user:
@@ -183,6 +182,7 @@ en:
         state/being_destroyed: &status_being_destroyed Being Destroyed
         companies: Company
         business_categories: Business Services
+        file_delivery_method: File Delivery Method
 
       member:
         true: Member

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -139,7 +139,6 @@ sv:
         one: Användaren
         other: Användare
 
-
     attributes:
 
       user:
@@ -184,6 +183,7 @@ sv:
         state/being_destroyed: &status_being_destroyed Förstört
         companies: Företag
         business_categories: Företagstjänster
+        file_delivery_method: Filleveransmetod
 
       member:
         true: Medlem
@@ -1276,7 +1276,7 @@ sv:
       not_a_number: är inte ett nummer
       not_an_integer: måste vara ett heltal
       odd: måste vara udda
-      required: must exist
+      required: måste existera
       taken: används redan
       too_long:
         one: är för lång (max är ett tecken)

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,4 +1,10 @@
 Given(/^the following users exist(?:s|)$/) do |table|
+
+  # Hash value "is_legacy" indicates a user accounte that was created before we
+  # migrated the user's name attributes (first_name, last_name) from the
+  # ShfApplication model to the User model.
+  # If a "legacy" user, we create the user with nil values for those attributes.
+
   table.hashes.each do |user|
 
     user['membership_number'] = nil if user['membership_number'].blank?

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,6 +1,6 @@
 Given(/^the following users exist(?:s|)$/) do |table|
 
-  # Hash value "is_legacy" indicates a user accounte that was created before we
+  # Hash value "is_legacy" indicates a user account that was created before we
   # migrated the user's name attributes (first_name, last_name) from the
   # ShfApplication model to the User model.
   # If a "legacy" user, we create the user with nil values for those attributes.

--- a/features/user_profile/user-edits-profile.feature
+++ b/features/user_profile/user-edits-profile.feature
@@ -10,8 +10,8 @@ Feature: As a registered user
       | user@random.com   | password | false | false     | ulysses    | user      |
 
     And the following applications exist:
-      | user_email        | company_number | state    | contact_email     |
-      | member@random.com | 5560360793     | accepted | public@random.com |
+      | user_email        | company_number | state    | contact_email     | legacy |
+      | member@random.com | 5560360793     | accepted | public@random.com | true   |
 
     And the following payments exist
       | user_email        | start_date | expire_date | payment_type | status | hips_id |

--- a/features/user_profile/user-edits-profile.feature
+++ b/features/user_profile/user-edits-profile.feature
@@ -7,15 +7,18 @@ Feature: As a registered user
       | email             | password | admin | member    | first_name | last_name |
       | admin@random.com  | password | true  | false     | emma       | admin     |
       | member@random.com | password | false | true      | mary       | member    |
+      | newmember@me.com  | password | false | true      | newest     | member    |
       | user@random.com   | password | false | false     | ulysses    | user      |
 
     And the following applications exist:
-      | user_email        | company_number | state    | contact_email     | legacy |
-      | member@random.com | 5560360793     | accepted | public@random.com | true   |
+      | user_email        | company_number | state    | contact_email     | is_legacy |
+      | member@random.com | 5560360793     | accepted | public@random.com | true      |
+      | newmember@me.com  | 9999999999     | accepted | public@random.com |           |
 
     And the following payments exist
       | user_email        | start_date | expire_date | payment_type | status | hips_id |
       | member@random.com | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |
+      | newmember@me.com  | 2019-01-01 | 2019-12-31  | member_fee   | betald | none    |
 
   Scenario: Admin edits profile
     Given I am logged in as "admin@random.com"
@@ -41,7 +44,7 @@ Feature: As a registered user
     Then I should see t("devise.registrations.edit.success")
 
   @time_adjust
-  Scenario: Member edits profile, uploads photo, returns to prior page after update
+  Scenario: "Legacy" member edits profile, uploads photo, returns to prior page after update
     Given the date is set to "2017-10-01"
     And I am logged in as "member@random.com"
     And I am on the "show my application" page
@@ -52,6 +55,22 @@ Feature: As a registered user
     And I fill in t("devise.registrations.edit.current_password") with "password"
     And I click on t("devise.registrations.edit.submit_button_label") button
     And I should see t("hello", name: 'NewMary')
+    And I should be on "show my application" page
+    Then I click on the t("devise.registrations.edit.title") link
+    And I should see "member_with_dog.png"
+
+  @time_adjust
+  Scenario: Member edits profile
+    Given the date is set to "2019-01-02"
+    And I am logged in as "newmember@me.com"
+    And I am on the "show my application" page
+    And I should see t("hello", name: 'newest')
+    Then I click on the t("devise.registrations.edit.title") link
+    And I fill in t("activerecord.attributes.user.first_name") with "Henry"
+    And I choose a "user_member_photo" file named "member_with_dog.png" to upload
+    And I fill in t("devise.registrations.edit.current_password") with "password"
+    And I click on t("devise.registrations.edit.submit_button_label") button
+    And I should see t("hello", name: 'Henry')
     And I should be on "show my application" page
     Then I click on the t("devise.registrations.edit.title") link
     And I should see "member_with_dog.png"

--- a/spec/factories/shf_applications.rb
+++ b/spec/factories/shf_applications.rb
@@ -17,6 +17,11 @@ FactoryBot.define do
     file_delivery_method { AdminOnly::FileDeliveryMethod.first ||
                            association(:file_delivery_method) }
 
+    trait :legacy_application do
+      file_delivery_method { nil }
+      to_create { |instance| instance.save(validate: false) }
+    end
+
     trait :accepted do
       state { :accepted }
       when_approved { Time.zone.now }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -256,9 +256,9 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     it 'adds a count of errors' do
       I18n.locale = :sv
-      expect(errors_html_sv).to match(/#{t('model_errors', count: 7)}/)
+      expect(errors_html_sv).to match(/#{t('model_errors', count: 6)}/)
       I18n.locale = :en
-      expect(errors_html_en).to match(/#{t('model_errors', count: 7)}/)
+      expect(errors_html_en).to match(/#{t('model_errors', count: 6)}/)
     end
 
     it 'returns all model errors - swedish' do

--- a/spec/models/shf_application_spec.rb
+++ b/spec/models/shf_application_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ShfApplication, type: :model do
     it { is_expected.to validate_presence_of :state }
     it { is_expected.to validate_presence_of :companies }
     it { is_expected.to validate_presence_of :business_categories }
-    it { is_expected.to validate_presence_of :file_delivery_method }
+    it { is_expected.to validate_presence_of(:file_delivery_method).on(:create) }
 
     it { is_expected.to allow_value('user@example.com').for(:contact_email) }
     it { is_expected.not_to allow_value('userexample.com').for(:contact_email) }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/164439014


Changes proposed in this pull request:
1. Change app validation to only validate the presence of a file-delivery method (FDM) on `create`.  (that is, do not validate on `update` - this allows users to update the SHF application - via the user profile edit - without triggering a validation failure due to lack of an FDM for the app).
2. Fix validation error translations (errors shown in English instead of Swedish)
3. For test purposes, add ability to create a "legacy" application - which is created without an associated FDM.

Screenshots (Optional):


Ready for review:
@AgileVentures/shf-project-team 