### PR TITLE
Fixes English headline of Company Categories page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -671,7 +671,7 @@ en:
   business_categories:
 
     index:
-      title: '*business_category / Company categories'
+      title: Company categories
       name: *business_category_name
       description: *description
       view: *view


### PR DESCRIPTION
Fizes the: "business categories" Company categories header/title 
