### PR TITLE
[WIP] Sprint63 member packet date #163505574

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -14,4 +14,10 @@ $(function() {
   $('#editUserStatusSubmit').click(function() {
     $('#editStatusModal').modal('hide');
   });
+
+  $('#packetSentForm').on('ajax:success', function(e, data){
+    console.log('success!');
+    console.log(data)
+  } );
+
 });

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
 
   LOG_FILE = "#{Rails.root}/log/#{Rails.env}_users.log"
 
-  before_action :set_user, except: :index
+  before_action :set_user, except: [:index, :toggle_membership_package_sent]
   before_action :set_app_config, only: [:show, :proof_of_membership, :update]
   before_action :authorize_user, only: [:show]
   before_action :allow_iframe_request, only: [:proof_of_membership]
@@ -74,6 +74,31 @@ class UsersController < ApplicationController
            locals: { user: @user, error: t('users.update.error') }
   end
 
+
+  # Toggle whether or not a membership package was sent to a user.
+  #
+  # Just return a success or fail with error message.  Don't
+  # render a new page.  Just update info as needed and send
+  # 'success' or 'fail' info back.
+  def toggle_membership_package_sent
+
+    authorize User
+
+    user =  User.find_by_id(params[:user_id])
+    if user
+      user.toggle_membership_packet_status
+
+      respond_to do |format|
+        format.json { head :ok }
+      end
+
+    else
+      raise ActiveRecord::RecordNotFound,  "User not found! user_id = #{params[:user_id]}"
+    end
+
+  end
+
+
   def destroy
     @user.destroy
 
@@ -101,7 +126,8 @@ class UsersController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def user_params
     params.require(:user).permit(:name, :email, :member, :password,
-                                 :password_confirmation)
+                                 :password_confirmation,
+                                 :date_membership_packet_sent)
   end
 
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -60,8 +60,6 @@ module UsersHelper
   #   <'membership packet' translation> <sent | not sent>  <date if it was sent>
   def membership_packet_str(user)
 
-    return '' unless user.member?
-
     mem_packet    = t('member_packet', scope: I18N_USERS_SHOW).capitalize
     packet_status = membership_packet_status_str(user.membership_packet_sent?)
     add_on_date   = ''

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -4,15 +4,17 @@ module UsersHelper
     user.current_sign_in_at.blank? ? user.last_sign_in_at : user.current_sign_in_at
   end
 
+
   def pay_member_fee_link(user)
     # Returns link styled as a button
     return nil unless user.allow_pay_member_fee?
 
     link_to("#{t('menus.nav.members.pay_membership')}",
             payments_path(user_id: user.id,
-                          type: Payment::PAYMENT_TYPE_MEMBER),
+                          type:    Payment::PAYMENT_TYPE_MEMBER),
             { method: :post, class: 'btn btn-primary btn-xs' })
   end
+
 
   def paperclip_path_str(attached_file, image_type, render_to)
     # Produces path for attached_file, for use in image_tag method.
@@ -36,14 +38,59 @@ module UsersHelper
                            attached_file.url(image_type)).to_s
   end
 
+
   def user_has_open_application(user)
     return nil unless user.shf_application
 
     user.shf_application.state.to_sym.in?([:accepted, :rejected]) ? nil : t('yes')
   end
 
+
   def short_proof_of_membership_url(user)
     url = proof_of_membership_url(user.id)
     user.get_short_proof_of_membership_url(url)
   end
+
+
+  I18N_USERS_SHOW = 'users.show'.freeze
+
+  # creates a human-readable string that says if the membership packet
+  # was sent and on what date.
+  # @return [String] - a string in the form
+  #   <'membership packet' translation> <sent | not sent>  <date if it was sent>
+  def membership_packet_str(user)
+
+    return '' unless user.member?
+
+    mem_packet    = t('member_packet', scope: I18N_USERS_SHOW).capitalize
+    packet_status = membership_packet_status_str(user.membership_packet_sent?)
+    add_on_date   = ''
+
+    add_on_date << ' ' + user.date_membership_packet_sent.to_date.to_s if user.membership_packet_sent?
+
+    "#{mem_packet} #{packet_status}#{add_on_date}"
+  end
+
+
+  def membership_packet_status_str(was_sent)
+    t(was_sent ? 'sent' : 'not_sent', scope: I18N_USERS_SHOW)
+  end
+
+
+  # Checkbox for whether or not a membership packet has been sent to a user.
+  # Set the checkbox HTML id to so that
+  #
+  # @param user [User]- the user that may or may not have a membership packet sent yet
+  # @return [String] - html_safe string that is a checkbox with a label for it
+  def member_packet_sent_checkbox(user)
+
+    (check_box_tag 'date_membership_packet_sent',
+                   user.membership_packet_sent?,
+                   user.membership_packet_sent?,
+                  class:    'checkbox.membership-packet',
+                   data: { remote: true,
+                           method: :post,
+                           url: user_toggle_membership_package_sent_path(user) }).html_safe
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -195,6 +195,24 @@ class User < ApplicationRecord
   end
 
 
+  def membership_packet_sent?
+    !date_membership_packet_sent.nil?
+  end
+
+
+  # Toggle whether or not a membership package was sent to this user.
+  #
+  # If the old value was "true", now set it to false.
+  # If the old value was "false", now make it true and set the date sent
+  #
+  # @param date_sent [Time] - when the packet was sent. default = now
+  # @return [Boolean] - result of updating :date_membership_packet_sent
+  def toggle_membership_packet_status(date_sent = Time.zone.now)
+    new_sent_time = membership_packet_sent? ? nil : date_sent
+    update(date_membership_packet_sent: new_sent_time)
+  end
+
+
   # The fact that this can no longer be private is a smell that it should be refactored out into a separate class
   def issue_membership_number
     self.membership_number = self.membership_number.blank? ? get_next_membership_number : self.membership_number

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -10,4 +10,9 @@ class UserPolicy < ApplicationPolicy
   def show?
     user.admin? || record.id == user.id
   end
+
+  def toggle_membership_package_sent?
+    user.admin?
+  end
+
 end

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -5,6 +5,7 @@
     %small= i18n_time_ago_in_words(user.created_at)
   %td.sign-in-count= user.sign_in_count
   %td.applications-open= user_has_open_application(user)
+  %td.member-packet=  member_packet_sent_checkbox(user)
   %td.is-member
     - if user.member?
       %span.yes= t('.yes')

--- a/app/views/users/_users_list.html.haml
+++ b/app/views/users/_users_list.html.haml
@@ -10,6 +10,7 @@
           %th
             = t('.application')
             = fas_tooltip(t('.applications_tooltip'))
+          %th= t('users.show.member_packet')
           %th= t('.member')
           %th= t('.expire_date')
           %th

--- a/app/views/users/_users_list.html.haml
+++ b/app/views/users/_users_list.html.haml
@@ -10,7 +10,7 @@
           %th
             = t('.application')
             = fas_tooltip(t('.applications_tooltip'))
-          %th= t('users.show.member_packet')
+          %th= sort_link(q, :date_membership_packet_sent, t('users.users_list.member_packet'), {}, { class: 'users_pagination member-packet', remote: true } )
           %th= t('.member')
           %th= t('.expire_date')
           %th

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -63,6 +63,11 @@
 
     - if current_user.admin?
 
+      %p{class: "membership-packet #{ @user.membership_packet_sent? ? 'sent' : 'not-sent'}",
+      id: 'date-membership-packet-sent'}
+        = membership_packet_str(@user)
+
+
       - if @user.last_sign_in_at.blank? && @user.current_sign_in_at.blank?
         #{@user.email} #{t('.user_has_never_signed_in')}
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -772,7 +772,7 @@ en:
                                 </span>"
       company_h_brand: Company H-Brand for %{company}
       company_h_brand_describe: This image is your company's H-Brand.
-      member_packet: member packet
+      member_packet: &member_packet member packet
       sent: sent
       not_sent: not sent
 
@@ -817,6 +817,7 @@ en:
       application: *application
       applications_tooltip: User has an open application
       expire_date: *expire_date
+      member_packet: *member_packet
 
     destroy:
       success: User deleted successfully.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,7 @@ en:
         sign_in_count: &sign_in_count Logins
         reset_password_sent_at: &user_reset_password_sent_at Password reset info sent
         member: &member Member
+        date_member_packet_sent: &date_member_packet_sent Date Member Packet sent
 
       payment:
         payment_type: Payment Type
@@ -406,7 +407,7 @@ en:
       org_nr: *org_nr
       state: *state
       manage: *manage
-      no_search_results: No records matched your search criteria.
+      no_search_results: &no_search_results No records matched your search criteria.
 
     information:
       title: About Application and Membership
@@ -607,7 +608,7 @@ en:
       h_companies_listed_below: Member companies are listed below.
       how_to_search: Search for companies using the search form.
       confirm_are_you_sure: *are_you_sure_confirm
-      no_search_results: No records matched your search criteria.
+      no_search_results: *no_search_results
       delete: *delete
 
     destroy:
@@ -721,7 +722,7 @@ en:
   users:
     index:
       title: All Users
-      no_search_results: No records matched your search criteria.
+      no_search_results: *no_search_results
 
     delete_user: Delete %{user}
 
@@ -771,6 +772,9 @@ en:
                                 </span>"
       company_h_brand: Company H-Brand for %{company}
       company_h_brand_describe: This image is your company's H-Brand.
+      member_packet: member packet
+      sent: sent
+      not_sent: not sent
 
     update:
       passwords_dont_match: "The two passwords entered don't match."
@@ -846,7 +850,10 @@ en:
     export_ansokan_csv:
       success: Export successful. Check your browser downloads for the file.
       error: There was a problem with the export.
+      date_state_changed: Date State changed
+      member_fee_paid: M fee paid
       member_fee_expires: M Expires
+      branding_fee_paid: H-brand paid
       branding_fee_expires: H Expires
       paid: *paid
       never_paid: *never_paid
@@ -1047,7 +1054,7 @@ en:
           shf_motto: KOMPETENS – GLÄDJE – OMTANKE
           email_sent_to: This email was sent to %{email_sent_to}
           why_you_are_receiving: You are receiving this email because you are interested in a membership to SVERIGES HUNDFÖRETAGARE or you are a member.
-
+        no_search_results: *no_search_results
 
     admin_mailer:
       signoff: Thanks

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -161,6 +161,7 @@ sv:
         sign_in_count: &sign_in_count Inloggningar
         reset_password_sent_at: &user_reset_password_sent_at Information angående återställning av lösenord sändes
         member: &member Medlem
+        date_member_packet_sent: &date_member_packet_sent Date Member Packet sent
 
       payment:
         payment_type: Betalningstyp
@@ -409,7 +410,7 @@ sv:
       org_nr: *org_nr
       manage: *manage
       state: *state
-      no_search_results: Din sökning gav inget resultat, prova att ta bort något av dina val.
+      no_search_results: &no_search_results Din sökning gav inget resultat, prova att ta bort något av dina val.
 
     information:
       title: Om ansökan och medlemskap
@@ -612,7 +613,7 @@ sv:
       h_companies_listed_below: Nedan listas anslutna företag.
       how_to_search: Sök efter företag genom att använda sökfunktionen.
       confirm_are_you_sure: *are_you_sure_confirm
-      no_search_results: Din sökning gav inget resultat, prova att ta bort något av dina val.
+      no_search_results: *no_search_results
       delete: *delete
 
     destroy:
@@ -728,7 +729,7 @@ sv:
   users:
     index:
       title: Alla Användare
-      no_search_results: Din sökning gav inget resultat, prova att ta bort något av dina val.
+      no_search_results: *no_search_results
 
     delete_user: Radera %{user}
 
@@ -779,6 +780,9 @@ sv:
       show_image: Visa bild
       company_h_brand: Företaget H-märke för %{company}
       company_h_brand_describe: Detta är ditt företags H-märke.
+      member_packet: member packet
+      sent: sent
+      not_sent: not sent
 
     update:
       passwords_dont_match: De två lösenord du angivit matchar inte.
@@ -845,7 +849,10 @@ sv:
     export_ansokan_csv:
       success: Exporten lyckades. Du hittar filen bland din webbläsares nedladdade filer.
       error: Ett problem uppstod med exporten.
+      date_state_changed: Date State changed
+      member_fee_paid: M fee paid
       member_fee_expires: M Expires
+      branding_fee_paid: H-brand paid
       branding_fee_expires: H Expires
       paid: *paid
       never_paid: *never_paid
@@ -1048,7 +1055,7 @@ sv:
           shf_motto: KOMPETENS – GLÄDJE – OMTANKE
           email_sent_to: Det här mailet skickades till %{email_sent_to}
           why_you_are_receiving: Du får detta e-postmeddelande eftersom du är intresserad av medlemsskap i Sveriges Hundföretagare eller för att du redan är medlem.
-
+        no_search_results: *no_search_results
 
     admin_mailer:
       signoff: Tack

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -161,7 +161,7 @@ sv:
         sign_in_count: &sign_in_count Inloggningar
         reset_password_sent_at: &user_reset_password_sent_at Information angående återställning av lösenord sändes
         member: &member Medlem
-        date_member_packet_sent: &date_member_packet_sent Date Member Packet sent
+        date_member_packet_sent: &date_member_packet_sent Datumpaket Skickat
 
       payment:
         payment_type: Betalningstyp
@@ -780,9 +780,9 @@ sv:
       show_image: Visa bild
       company_h_brand: Företaget H-märke för %{company}
       company_h_brand_describe: Detta är ditt företags H-märke.
-      member_packet: member packet
-      sent: sent
-      not_sent: not sent
+      member_packet: &member_packet medlemspaket
+      sent: skickat
+      not_sent: inte skickat
 
     update:
       passwords_dont_match: De två lösenord du angivit matchar inte.
@@ -824,6 +824,7 @@ sv:
       application: *application
       applications_tooltip: Användaren har en öppen ansökan
       expire_date: *expire_date
+      member_packet: *member_packet
 
     destroy:
       success: Användaren raderades framgångsrikt.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,9 @@ Rails.application.routes.draw do
       member do
         put 'edit_status', to: 'users#edit_status', as: 'edit_status'
       end
+
+      post 'toggle_membership_package_sent', to: 'users#toggle_membership_package_sent'
+
     end
 
     get 'anvandare/:id/proof_of_membership', to: 'users#proof_of_membership',

--- a/db/migrate/20190312204251_add_membership_packet_sent_to_user.rb
+++ b/db/migrate/20190312204251_add_membership_packet_sent_to_user.rb
@@ -1,0 +1,6 @@
+class AddMembershipPacketSentToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :date_membership_packet_sent, :timestamp, null: true,
+               comment: 'When the user was sent a membership welcome packet'
+  end
+end

--- a/db/seed_helpers.rb
+++ b/db/seed_helpers.rb
@@ -117,6 +117,23 @@ module SeedHelper
   end
 
 
+  # Create a SHF Application for the user and set the application
+  # to the given :state.
+  # If the application is accepted, then also create payments
+  # (a membership payment and H-brand payment for the company).
+  #
+  # Set the file delivery method for the user and then finally
+  # set when the membership packet was sent to the user (as
+  # applicable depending on the application state).
+  #
+  # save the user.
+  #
+  # @param user [User] - the user
+  # @param state [String] - the state to put the Shf Application in
+  # @param co_number [String] - the Company Number (Org nummer) for
+  #   the company associated with the user; needed for the application
+  #
+  # @return [User] - the user
   def make_n_save_app(user, state, co_number = get_company_number)
     # Reset instance vars so AR records will be reloaded when run in TEST
     # (rspec DB tests load tasks but there is no "reload" available)
@@ -167,6 +184,9 @@ module SeedHelper
     user.shf_application = ma
 
     user.save!
+
+    set_membership_packet_sent user
+
     user
   end
 
@@ -184,6 +204,30 @@ module SeedHelper
     when MA_UNDER_REVIEW_STATE
       @email ||= klass.get_method(:email)
     end
+  end
+
+
+  PERCENT_WITH_SENT_PACKETS = 60
+
+  # If the user is a member, set a date for when the membership
+  # packet was sent -- about <PERCENT_WITH_SENT_PACKETS>% of the time.
+  # (It is left blank for the other %, which means it has not been sent.)
+  #
+  # Choose a random date within the last 30 days
+  #
+  # update (save) the user if the :date_membership_packet_sent was set
+  #
+  # @param user [User] - the user to check and possible set the :date_membership_packet_sent for
+  # @return [User] - return the user
+  def set_membership_packet_sent(user)
+
+    if user.shf_application.accepted?
+      if Random.rand(100) <= PERCENT_WITH_SENT_PACKETS
+        user.update(date_membership_packet_sent: (Date.current - Random.rand(0..30)).to_time )
+      end
+    end
+
+    user
   end
 
 

--- a/features/admins/show-user-account-to-admin.feature
+++ b/features/admins/show-user-account-to-admin.feature
@@ -1,0 +1,208 @@
+Feature: Admin sees user account information
+
+  As an admin
+  So that I can see and update the account info for a user
+  Show me all of the the user account information for a user
+
+  PT:  https://www.pivotaltracker.com/story/show/140358959
+
+  Background:
+
+    Given the following users exists
+      | email                           | admin | membership_number | member |
+      | emma-new-app@bowsers.com        |       |                   |        |
+      | lars-member@happymutts.com      |       | 101               | true   |
+      | hannah-member@happymutts.com    |       | 102               | true   |
+      | rejected@happymutts.com         |       |                   |        |
+      | user-never-logged-in@example.se |       |                   |        |
+      | user-anna@personal.se           |       |                   |        |
+      | user-sam@personal.se            |       |                   |        |
+      | admin@shf.se                    | true  |                   |        |
+      | yesterday_admin@shf.se          | true  |                   |        |
+      | lazy_admin@shf.se               | true  |                   |        |
+
+
+    And the following regions exist:
+      | name         |
+      | Stockholm    |
+      | Västerbotten |
+
+    And the following companies exist:
+      | name        | company_number | email               | region       |
+      | Happy Mutts | 5560360793     | woof@happymutts.com | Stockholm    |
+      | Bowsers     | 2120000142     | bark@bowsers.com    | Västerbotten |
+
+
+    And the following applications exist:
+      | user_email                   | contact_email           | company_number | state    |
+      | lars-member@happymutts.com   | lars@happymutts.com     | 5560360793     | accepted |
+      | hannah-member@happymutts.com | hannah@happymutts.com   | 5560360793     | accepted |
+      | emma-new-app@bowsers.com     | emma@bowsers.com        | 2120000142     | new      |
+      | rejected@happymutts.com      | rejected@happymutts.com | 5560360793     | rejected |
+
+
+    And the following membership packets have been sent:
+      | user_email                 | date_sent  |
+      | lars-member@happymutts.com | 2019-03-01 |
+
+
+    And I am logged in as "admin@shf.se"
+
+
+  # -----------------------------------
+  # Login info - when, how many times
+
+  Scenario: Show an admin who has never logged in
+    When I am on the "user details" page for "lazy_admin@shf.se"
+    Then I should see t("users.show.is_an_admin")
+    And I should see t("users.show.user_has_never_signed_in")
+    And I should not see t("users.show.last_login")
+
+
+
+  Scenario: Show an admin that is currently logged in
+    When I am on the "user details" page for "admin@shf.se"
+    Then I should see t("users.show.is_an_admin")
+    And I should not see t("users.show.user_has_never_signed_in")
+    And I should see t("users.show.last_login")
+
+
+  Scenario: Show an admin that logged in 1 day ago
+    Given The user "yesterday_admin@shf.se" last logged in 1 day ago
+    When I am on the "user details" page for "yesterday_admin@shf.se"
+    Then I should see t("users.show.is_an_admin")
+    And I should not see t("users.show.user_has_never_signed_in")
+    And I should see t("users.show.last_login")
+
+
+  Scenario: Show a member who has never logged in
+    When I am on the "user details" page for "hannah-member@happymutts.com"
+    Then I should not see t("users.show.is_an_admin")
+    And I should see t("users.show.user_has_never_signed_in")
+    And I should not see t("users.show.last_login")
+
+
+  Scenario: Show a member that is currently logged in
+    Given The user "emma-new-app@bowsers.com" is currently signed in
+    When I am on the "user details" page for "emma-new-app@bowsers.com"
+    Then I should not see t("users.show.is_an_admin")
+    And I should not see t("users.show.user_has_never_signed_in")
+    And I should see t("users.show.last_login")
+
+
+  Scenario: Show a member that logged 3 days ago
+    Given The user "lars-member@happymutts.com" last logged in 3 days ago
+    When I am on the "user details" page for "lars-member@happymutts.com"
+    Then I should not see t("users.show.is_an_admin")
+    And I should not see t("users.show.user_has_never_signed_in")
+    And I should see t("users.show.last_login")
+
+
+  Scenario: Show a member that has logged in 42 times
+    Given The user "lars-member@happymutts.com" has logged in 42 times
+    When I am on the "user details" page for "lars-member@happymutts.com"
+    Then I should see t("users.show.logged_in_count")
+    And I should see "42"
+    And I should see t("users.show.last_login")
+
+
+  Scenario: Show an user who has never logged in
+    When I am on the "user details" page for "user-never-logged-in@example.se"
+    Then I should not see t("users.show.is_an_admin")
+    And I should see t("users.show.user_has_never_signed_in")
+    And I should not see t("users.show.last_login")
+
+
+  Scenario: Show an user that is currently logged in
+    Given The user "user-anna@personal.se" is currently signed in
+    When I am on the "user details" page for "user-anna@personal.se"
+    Then I should not see t("users.show.is_an_admin")
+    And I should not see t("users.show.user_has_never_signed_in")
+    And I should see t("users.show.last_login")
+
+
+  Scenario: Show an user that logged in 100 days ago
+    Given The user "user-sam@personal.se" last logged in 100 days ago
+    When I am on the "user details" page for "user-sam@personal.se"
+    Then I should not see t("users.show.is_an_admin")
+    And I should not see t("users.show.user_has_never_signed_in")
+    And I should see t("users.show.last_login")
+
+
+  # -----------------------------------
+  # Password reset info
+
+  Scenario: Show a member that has had her password reset
+    Given The user "emma-new-app@bowsers.com" has had her password reset now
+    When I am on the "user details" page for "emma-new-app@bowsers.com"
+    Then I should see t("users.show.reset_password_sent_at")
+
+
+  Scenario: Show a member that has never had her password reset
+    When I am on the "user details" page for "emma-new-app@bowsers.com"
+    Then I should see t("users.show.password_never_reset")
+
+
+  # -----------------------------------
+  # Membership number
+
+  Scenario: Show the membership number for a member
+    When I am on the "user details" page for "lars-member@happymutts.com"
+    Then I should see t("users.show.membership_number")
+    And I should see "101"
+
+
+
+  Scenario: Do not show the membership number when there is none
+    When I am on the "user details" page for "user-never-logged-in@example.se"
+    Then I should not see t("users.show.membership_number")
+
+
+  # -----------------------------------
+  # Email address and application state
+
+  Scenario: Show email addresses and application for a user
+    When I am on the "user details" page for "emma-new-app@bowsers.com"
+    Then I should see "emma-new-app@bowsers.com"
+    And I should see "emma@bowsers.com"
+    And I should see "2120000142"
+    And I should see t("shf_applications.state.new")
+    Then I click on "change-lang-to-english"
+    And I should see t("shf_applications.state.new")
+
+
+  # -----------------------------------
+  # Membership Packet info
+
+  Scenario: Membership packet sent to a member: show that it was sent and the date
+    When I am on the "user details" page for "lars-member@happymutts.com"
+    Then I should see t("users.show.member_packet")
+    And I should see t("users.show.sent")
+    And I should see "2019-03-01"
+
+
+  Scenario: Membership packet: If a member but no date sent, should show 'Membership packet not sent'
+    When I am on the "user details" page for "hannah-member@happymutts.com"
+    Then I should see t("users.show.member_packet")
+    And I should see t("users.show.not_sent")
+
+
+  Scenario: Membership packet info shows for non-members (maybe they used to be a member)
+    When I am on the "user details" page for "rejected@happymutts.com"
+    Then I should see t("users.show.member_packet")
+    And I should see t("users.show.not_sent")
+
+
+  Scenario: A member cannot see membership packet info
+    When I am logged out
+    And I am logged in as "lars-member@happymutts.com"
+    And I am on the "user details" page for "lars-member@happymutts.com"
+    Then I should not see t("users.show.member_packet")
+
+
+  Scenario: A user cannot see membership packet info
+    When I am logged out
+    And I am logged in as "user-anna@personal.se"
+    And I am on the "user details" page for "user-anna@personal.se"
+    Then I should not see t("users.show.member_packet")
+

--- a/features/admins/users_list_edit_member_packets_sent.feature
+++ b/features/admins/users_list_edit_member_packets_sent.feature
@@ -1,0 +1,74 @@
+Feature: Admin sets when member packets were sent on the all users page
+
+  As an admin
+  So that I can manage who has and has not had a membership packet sent to them,
+  For each user, I need to be able to set or clear the date I've sent the packet
+  On the 'all users' page
+
+
+  Background:
+
+    Given the following users exists
+      | email                  | admin | membership_number | member |
+      | emma@bowsers.se        |       | 100               | true   |
+      | lars@happymutts.se     |       | 101               | true   |
+      | hannah@happymutts.se   |       | 102               | true   |
+      | nils@kitty.se          |       |                   |        |
+      | admin@shf.se           | true  |                   |        |
+      | rejected@happymutts.se |       |                   |        |
+
+    And the following regions exist:
+      | name         |
+      | Stockholm    |
+      | Västerbotten |
+
+    And the following companies exist:
+      | name        | company_number | email               | region       |
+      | Happy Mutts | 5560360793     | woof@happymutts.com | Stockholm    |
+      | Bowsers     | 2120000142     | bark@bowsers.com    | Västerbotten |
+
+
+    And the following applications exist:
+      | user_email             | contact_email          | company_number | state    |
+      | lars@happymutts.se     | lars@happymutts.se     | 5560360793     | accepted |
+      | hannah@happymutts.se   | hannah@happymutts.se   | 5560360793     | accepted |
+      | emma@bowsers.se        | emma@bowsers.se        | 2120000142     | new      |
+      | rejected@happymutts.se | rejected@happymutts.se | 5560360793     | rejected |
+
+
+    And the following membership packets have been sent:
+      | user_email         | date_sent  |
+      | lars@happymutts.se | 2019-03-01 |
+
+
+    And I am logged in as "admin@shf.se"
+
+
+  Scenario: I see the membership packet info for users
+    Given I am on the "all users" page
+    Then I should see the checkbox with id "date_membership_packet_sent" checked in the row for user "lars@happymutts.se"
+    And I should see the checkbox with id "date_membership_packet_sent" unchecked in the row for user "hannah@happymutts.se"
+    And I should see the checkbox with id "date_membership_packet_sent" unchecked in the row for user "emma@bowsers.se"
+    And I should see the checkbox with id "date_membership_packet_sent" unchecked in the row for user "rejected@happymutts.se"
+    And I should see the checkbox with id "date_membership_packet_sent" unchecked in the row for user "nils@kitty.se"
+
+
+  @selenium
+  Scenario: I set the membership packet sent to today for a user
+    Given I am on the "all users" page
+    And the date is set to "2019-03-01"
+    Then I should see the checkbox with id "date_membership_packet_sent" unchecked in the row for user "hannah@happymutts.se"
+    When I check the checkbox with id "date_membership_packet_sent" for the row with "hannah@happymutts.se"
+    Then I should see the checkbox with id "date_membership_packet_sent" checked in the row for user "hannah@happymutts.se"
+    When I am on the "user details" page for "hannah@happymutts.se"
+    Then I should see "Member packet sent 2019-03-01"
+
+
+  @selenium
+  Scenario: I clear the membership packet sent date for a user
+    Given I am on the "all users" page
+    Then I should see the checkbox with id "date_membership_packet_sent" checked in the row for user "lars@happymutts.se"
+    When I uncheck the checkbox with id "date_membership_packet_sent" for the row with "lars@happymutts.se"
+    Then I should see the checkbox with id "date_membership_packet_sent" unchecked in the row for user "lars@happymutts.se"
+    When I am on the "user details" page for "lars@happymutts.se"
+    Then I should see "Member packet not sent"

--- a/features/delete-company.feature
+++ b/features/delete-company.feature
@@ -194,7 +194,7 @@ Feature: As an admin
     Then I should see "11" applications
 
 
-  @selenium @focus
+  @selenium
   Scenario: Admin tries to delete a company with 1 rejected app, 1 category (only co. associated with it)
     Given I am logged in as "admin@shf.se"
     When I am on the "business categories" page

--- a/features/delete_shf_application.feature
+++ b/features/delete_shf_application.feature
@@ -85,7 +85,7 @@ Feature: As an admin
     And I am on the "all companies" page
     And I should see "2120000142"
 
-  @focus @time_adjust
+  @time_adjust
   Scenario: Admin deletes the only membership application associated with a company. Company is deleted
     Given the date is set to "2017-10-01"
     Given I am logged in as "admin@shf.se"

--- a/features/search_and_sort_users.feature
+++ b/features/search_and_sort_users.feature
@@ -1,40 +1,55 @@
-Feature:
+Feature: Admin searches and sorts users
 
   As an admin
   I would like to search and sort users
-  to find a particular user among many
-  and to know which users are members and which are not
+  to quickly and easily find users I am interested in
+
 
   Background:
+
     Given the following users exist
-      | first_name | last_name | email                               | admin | membership_number | member |
-      | John       | Adams     | ja@hotmail.com                      | false | 1                 | false  |
-      | Sarah      | Connor    | sconnor@example.com                 | false | 2                 | true   |
-      | Luke       | Skywalker | luke@force.net                      | false | 14                | false  |
-      | admin      | admin     | admin@sverigeshundforetagare.se     | true  | 3                 | false  |
+      | first_name | last_name | email                           | admin | membership_number | member |
+      | John       | Adams     | ja@hotmail.com                  | false | 1                 | false  |
+      | Sarah      | Connor    | sconnor@example.com             | false | 2                 | true   |
+      | Lars       | Member    | lars-member@happymutts.com      | false | 101               | true   |
+      | Hannah     | Member    | hannah-member@happymutts.com    | false | 102               | true   |
+      | Former     | Member    | former-member@happymutts.com    | false |                   | false  |
+      | Luke       | Skywalker | luke@force.net                  | false | 14                | false  |
+      | admin      | admin     | admin@sverigeshundforetagare.se | true  | 3                 | false  |
+
     And the following applications exist:
-      | user_email          | state                 | company_number |
-      | ja@hotmail.com      | waiting_for_applicant | 0000000000     |
-      | sconnor@example.com | accepted              | 0000000000     |
-      | luke@force.net      | rejected              | 0000000000     |
+      | user_email                   | state                 | company_number |
+      | ja@hotmail.com               | waiting_for_applicant | 0000000000     |
+      | sconnor@example.com          | accepted              | 0000000000     |
+      | luke@force.net               | rejected              | 0000000000     |
+      | lars-member@happymutts.com   | accepted              | 5560360793     |
+      | hannah-member@happymutts.com | accepted              | 5560360793     |
+
+    And the following membership packets have been sent:
+      | user_email                   | date_sent  |
+      | sconnor@example.com          | 2019-03-01 |
+      | lars-member@happymutts.com   | 2019-02-01 |
+      | former-member@happymutts.com | 2018-02-01 |
+
+
     And I am logged in as "admin@sverigeshundforetagare.se"
+    And I am on the "all users" page
+
+
 
   Scenario: Admin searches for luke
-    Given I am on the "all users" page
     When I fill in t("users.search_form.profile_email") with "luke"
     And I click on t("search")
     Then I should see "luke@force.net"
     And I should not see "sconnor@example.com"
 
   Scenario: Admin searches for @sverigeshundföretagare.se
-    Given I am on the "all users" page
     When I fill in t("users.search_form.profile_email") with "@sverigeshundföretagare.se"
     And I click on t("search")
     Then I should not see "admin@sverigeshundforetagare.se"
     And I should see t("users.index.no_search_results")
 
   Scenario: Admin searches for membership number
-    Given I am on the "all users" page
     And I select "1" in select list t("users.search_form.membership_number")
     And I click on t("search")
     Then I should see "ja@hotmail.com"
@@ -46,7 +61,6 @@ Feature:
     Then I should see "luke@force.net" before "sconnor@example.com"
 
   Scenario: Admin sorts users by membership number
-    Given I am on the "all users" page
     When I click on t("users.users_list.membership_number")
     Then I should see "ja@hotmail.com" before "sconnor@example.com"
     Then I should see "sconnor@example.com" before "admin@sverigeshundforetagare.se"
@@ -56,9 +70,8 @@ Feature:
     Then I should see "admin@sverigeshundforetagare.se" before "sconnor@example.com"
     Then I should see "sconnor@example.com" before "ja@hotmail.com"
 
-  Scenario: Admin filters users by membership status
-    Given I am on the "all users" page
 
+  Scenario: Admin filters users by membership status
     When I click the radio button with id "radio-membership-filter-all"
     And I click on t("search")
     Then I should see "sconnor@example.com"
@@ -76,3 +89,17 @@ Feature:
     Then I should see "luke@force.net"
     And I should see "ja@hotmail.com"
     And I should not see "sconnor@example.com"
+
+
+  @focus
+  Scenario: Sort by member packet sent status
+    When I click on t("users.users_list.member_packet")
+    Then I should see "sconnor@example.com" before "ja@hotmail.com"
+    And I should see "lars-member@happymutts.com" before "ja@hotmail.com"
+    And I should see "former-member@happymutts.com" before "ja@hotmail.com"
+
+    # search in DESC order
+    When I click on t("users.users_list.member_packet")
+    Then I should see "luke@force.net" before "sconnor@example.com"
+    And I should see "luke@force.net" before "lars-member@happymutts.com"
+    And I should see "luke@force.net" before "former-member@happymutts.com"

--- a/features/show-user-details.feature
+++ b/features/show-user-details.feature
@@ -1,4 +1,6 @@
-Feature: As an admin
+Feature: Admin sees user detail information
+
+  As an admin
   So that I can see the details for a user
   Show me all of the details about a user
 
@@ -7,16 +9,17 @@ Feature: As an admin
   Background:
 
     Given the following users exists
-      | email                   | admin | membership_number |
-      | emma@personal.com       |       | 100               |
-      | lars@personal.com       |       | 101               |
-      | hannah@personal.com     |       | 102               |
-      | nils@personal.se        |       |                   |
-      | anna@personal.se        |       |                   |
-      | sam@personal.se         |       |                   |
-      | admin@shf.se            | true  |                   |
-      | yesterday_admin@shf.se  | true  |                   |
-      | lazy_admin@shf.se       | true  |                   |
+      | email                  | admin | membership_number | member |
+      | emma@personal.com      |       | 100               | true   |
+      | lars@personal.com      |       | 101               | true   |
+      | hannah@personal.com    |       | 102               | true   |
+      | nils@personal.se       |       |                   |        |
+      | anna@personal.se       |       |                   |        |
+      | sam@personal.se        |       |                   |        |
+      | admin@shf.se           | true  |                   |        |
+      | yesterday_admin@shf.se | true  |                   |        |
+      | lazy_admin@shf.se      | true  |                   |        |
+      | rejected@personal.com  |       |                   |        |
 
     And the following regions exist:
       | name         |
@@ -30,11 +33,16 @@ Feature: As an admin
 
 
     And the following applications exist:
-      | user_email          | contact_email         | company_number | state    |
-      | lars@personal.com   | lars@happymutts.com   | 5560360793     | accepted |
-      | hannah@personal.com | hannah@happymutts.com | 5560360793     | accepted |
-      | emma@personal.com   | emma@bowsers.com      | 2120000142     | new      |
+      | user_email            | contact_email           | company_number | state    |
+      | lars@personal.com     | lars@happymutts.com     | 5560360793     | accepted |
+      | hannah@personal.com   | hannah@happymutts.com   | 5560360793     | accepted |
+      | emma@personal.com     | emma@bowsers.com        | 2120000142     | new      |
+      | rejected@personal.com | rejected@happymutts.com | 5560360793     | accepted |
 
+
+    And the following membership packets have been sent:
+      | user_email          | date_sent  |
+      | lars@personal.com   | 2019-03-01 |
 
 
     And I am logged in as "admin@shf.se"
@@ -151,3 +159,34 @@ Feature: As an admin
   Scenario: Do not show the membership number when there is none
     When I am on the "user details" page for "nils@personal.se"
     Then I should not see t("users.show.membership_number")
+
+
+  @focus
+  Scenario: Membership Package sent to a member: show that it was sent and the date
+    When I am on the "user details" page for "lars@personal.com"
+    Then I should see "Member packet sent 2019-03-01"
+
+  @focus
+  Scenario: Membership Package: If a member but no date sent, should show 'Membership Package not sent'
+    When I am on the "user details" page for "hannah@personal.com"
+    Then I should see "Member packet not sent"
+
+  @focus
+  Scenario: Membership Package info does not show for non-members
+    When I am on the "user details" page for "rejected@personal.com"
+    Then I should not see t("users.show.member_packet")
+
+
+  Scenario: A member cannot see membership packet info
+    When I am logged out
+    And I am logged in as "lars@personal.com"
+    And I am on the "user details" page for "lars@personal.com"
+    Then I should not see t("users.show.member_packet")
+
+
+  Scenario: A user cannot see membership packet info
+    When I am logged out
+    And I am logged in as "anna@personal.se"
+    And I am on the "user details" page for "anna@personal.se"
+    Then I should not see t("users.show.member_packet")
+

--- a/features/show-user-details.feature
+++ b/features/show-user-details.feature
@@ -161,17 +161,16 @@ Feature: Admin sees user detail information
     Then I should not see t("users.show.membership_number")
 
 
-  @focus
   Scenario: Membership Package sent to a member: show that it was sent and the date
     When I am on the "user details" page for "lars@personal.com"
     Then I should see "Member packet sent 2019-03-01"
 
-  @focus
+
   Scenario: Membership Package: If a member but no date sent, should show 'Membership Package not sent'
     When I am on the "user details" page for "hannah@personal.com"
     Then I should see "Member packet not sent"
 
-  @focus
+
   Scenario: Membership Package info does not show for non-members
     When I am on the "user details" page for "rejected@personal.com"
     Then I should not see t("users.show.member_packet")

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -58,10 +58,8 @@ module PathHelpers
         path = shf_documents_path
       when 'new shf document'
         path = new_shf_document_path
-      when 'user details', 'user account'
+      when 'user details', 'user profile'
         path = user_path(user)
-      when 'user profile'
-        path = edit_user_registration_path(user)
       when 'test exception notifications'
         path = test_exception_notifications_path
       when 'admin dashboard'

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -135,7 +135,7 @@ end
 
 
 Then "I should{negate} see {capture_string} in the row for {capture_string}" do |negate, text, row_identifier|
-  row = find(:xpath, "//tr[td//text()[contains(.,'#{row_identifier}')]]")
+  row = find(:xpath, "//tr[@id='#{row_identifier}']")
   expect(row).send (negate ? :not_to : :to), have_content(text)
 end
 
@@ -223,6 +223,25 @@ Then "I should{negate} see {capture_string} in the row for user {capture_string}
   td = page.find(:css, 'td', text: user_email) # find the td with text = user_email
   tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
   expect(tr.text).send (negate ? :not_to : :to), match(Regexp.new(expected_text))
+end
+
+
+Then "I should{negate} see the checkbox with id {capture_string} {checked} in the row for user {capture_string}" do | negate_see_it, checkbox_id, checked, user_email  |
+  td = page.find(:css, 'td', text: user_email)  # find the td with text = user_email
+  tr = td.find(:xpath, './parent::tr') # get the parent tr of the td
+
+  expect(tr).send (negate_see_it ? :not_to : :to), have_selector(:id, checkbox_id)
+  #checkbox = tr.find(:xpath, '//td[descendant::input[@id="date_membership_packet_sent"]]')
+
+  unless negate_see_it
+    case checked
+    when 'checked'
+      expect(tr).to have_checked_field(checkbox_id)
+    when 'unchecked'
+      expect(tr).to have_unchecked_field(checkbox_id)
+    end
+  end
+
 end
 
 

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -58,8 +58,10 @@ module PathHelpers
         path = shf_documents_path
       when 'new shf document'
         path = new_shf_document_path
-      when 'user details', 'user profile'
+      when 'user details', 'user account'
         path = user_path(user)
+      when 'user profile'
+        path = edit_user_registration_path(user)
       when 'test exception notifications'
         path = test_exception_notifications_path
       when 'admin dashboard'

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -119,6 +119,13 @@ rescue Capybara::ElementNotFound
   page.execute_script("document.getElementById(\"#{element_id}\").click()")
 end
 
+When "I {action} the checkbox with id {capture_string} for the row with {capture_string}" do |check_action, checkbox_id, row_content|
+
+  checkbox = find(:xpath, "//tr[contains(.,'#{row_content}')]/td//input[@id='#{checkbox_id}']")
+  checkbox.send check_action
+end
+
+
 When "I click the radio button with id {capture_string}" do |element_id|
   find("##{element_id}").click
 end

--- a/features/step_definitions/company_steps.rb
+++ b/features/step_definitions/company_steps.rb
@@ -81,6 +81,14 @@ When "I click the {ordinal} address for company {capture_string}" do |ordinal, c
   click_link(addr_link)
 end
 
+
+
+Then "I should{negate} see {capture_string} in the row for the company named {capture_string}" do |negate, text, co_name|
+  row = find(:xpath, "//tr[contains(.,'#{co_name}')]")
+
+  expect(row.text).send (negate ? :not_to : :to), match(Regexp.new(text))
+end
+
 And(/I scroll so the top of the list of companies is visible/) do
   step %{I scroll so element with id "shf_applications_list" is visible}
 end

--- a/features/step_definitions/membership_packet_steps.rb
+++ b/features/step_definitions/membership_packet_steps.rb
@@ -1,0 +1,10 @@
+Given(/^the following membership packets have been sent:$/) do |table|
+  table.hashes.each do | hash |
+
+    user = User.find_by(email: hash['user_email'].downcase)
+    user.date_membership_packet_sent = hash['date_sent']
+
+    user.save
+
+  end
+end

--- a/features/support/parameter_types.rb
+++ b/features/support/parameter_types.rb
@@ -51,6 +51,12 @@ ParameterType(
 )
 
 ParameterType(
+  name: 'checked',
+  regexp: /(checked|unchecked)/,
+  transformer: -> (str) { str }
+)
+
+ParameterType(
   name: 'digits',
   regexp: /(\d+)/,
   transformer: -> (str) { str.to_i }

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -176,13 +176,13 @@ Feature: Visitor sees all companies
     # Ensure the list is sorted by name so we will see Company02
     And I click on t("activerecord.attributes.company.name")
     And I should see "Company02"
-    And I should see "Västerbotten" in the row for "Company02"
-    And I should see "Norrbotten" in the row for "Company02"
-    And I should see "Uppsala" in the row for "Company02"
-    And I should see "Bromölla" in the row for "Company02"
-    And I should see "Alvesta" in the row for "Company02"
-    And I should see "Aneby" in the row for "Company02"
-    And I should not see "Stockholm" in the row for "Company02"
+    And I should see "Västerbotten" in the row for the company named "Company02"
+    And I should see "Norrbotten" in the row for the company named "Company02"
+    And I should see "Uppsala" in the row for the company named "Company02"
+    And I should see "Bromölla" in the row for the company named "Company02"
+    And I should see "Alvesta" in the row for the company named "Company02"
+    And I should see "Aneby" in the row for the company named "Company02"
+    And I should not see "Stockholm" in the row for the company named "Company02"
 
   @time_adjust
   Scenario: User sees all the companies

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -60,4 +60,44 @@ RSpec.describe UsersController, type: :controller do
 
   end
 
+
+  describe '#toggle_membership_package_sent' do
+
+    context 'user found' do
+
+      it 'returns success response' do
+        u = create(:user)
+
+        post :toggle_membership_package_sent,
+             xhr: true,
+             params:  { "utf8" => "✓",
+                       "date_membership_packet_sent"=>"false",
+                       "user_id"=>"#{u.id}",
+                       "locale"=>"en"
+                      }
+
+        expect(response).to have_http_status(:success) # 200
+      end
+    end
+
+
+    context 'cannot find user' do
+
+      it 'raises RecordNotFound error' do
+
+        expect{
+          post :toggle_membership_package_sent,
+               xhr: true,
+               params:  { "utf8" => "✓",
+                          "date_membership_packet_sent"=>"false",
+                          "user_id"=>"999",
+                          "locale"=>"en",
+                          format: :js
+               }
+          expect(response).to have_http_status(:not_found) # 404
+        }.to raise_exception ActiveRecord::RecordNotFound
+      end
+    end
+  end
+
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     member { false }
     short_proof_of_membership_url { nil }
     member_photo {nil}
+    date_membership_packet_sent { nil }
 
     factory :user_without_first_and_lastname do
 

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -105,12 +105,13 @@ RSpec.describe UsersHelper, type: :helper do
 
   describe '#membership_packet_str' do
 
-    it 'empty string if user is not a member' do
-      not_a_member = create(:user)
-      expect(membership_packet_str(not_a_member)).to be_empty
-    end
-
     let(:i18n_scope) { 'users.show' }
+
+
+    it 'not empty even if user is not a member' do
+      not_a_member = create(:user)
+      expect(membership_packet_str(not_a_member)).not_to be_empty
+    end
 
     context 'date_package_sent is nil' do
       it 'says not sent; has no date sent' do

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -101,4 +101,44 @@ RSpec.describe UsersHelper, type: :helper do
       expect(short_proof_of_membership_url(user)).to eq(url)
     end
   end
+
+
+  describe '#membership_packet_str' do
+
+    it 'empty string if user is not a member' do
+      not_a_member = create(:user)
+      expect(membership_packet_str(not_a_member)).to be_empty
+    end
+
+    let(:i18n_scope) { 'users.show' }
+
+    context 'date_package_sent is nil' do
+      it 'says not sent; has no date sent' do
+        not_sent_member = create(:member_with_membership_app)
+        expect(membership_packet_str(not_sent_member)).to eq("#{t('member_packet', scope: i18n_scope).capitalize} #{t('not_sent', scope: i18n_scope)}")
+      end
+    end
+
+    context 'date_package_sent not nil' do
+      it 'says sent; has the date sent' do
+        today = DateTime.current
+        sent_member = create(:member_with_membership_app, date_membership_packet_sent: today)
+        expect(membership_packet_str(sent_member)).to eq("#{t('member_packet', scope: i18n_scope).capitalize} #{t('sent', scope: i18n_scope)} #{today.to_date}")
+      end
+    end
+
+  end
+
+
+  describe '#membership_packet_status_str' do
+
+    it 'is t(sent) if the package was sent' do
+      expect(membership_packet_status_str(true)).to eq I18n.t('users.show.sent')
+    end
+
+    it 'is t(not_sent) if the package was not sent' do
+      expect(membership_packet_status_str(false)).to eq I18n.t('users.show.not_sent')
+    end
+
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -129,6 +129,8 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_db_column :member_photo_content_type }
     it { is_expected.to have_db_column :member_photo_file_size }
     it { is_expected.to have_db_column :member_photo_updated_at }
+    it { is_expected.to have_db_column :short_proof_of_membership_url }
+    it { is_expected.to have_db_column :date_membership_packet_sent }
   end
 
   describe 'Validations' do
@@ -1334,6 +1336,20 @@ RSpec.describe User, type: :model do
         expect(user.get_short_proof_of_membership_url(url)).to eq(url)
         expect(user.short_proof_of_membership_url).to eq(nil)
       end
+    end
+  end
+
+
+  describe '#membership_packet_sent?' do
+
+    it 'true if there is a date' do
+      user_sent_package = create(:user, date_membership_packet_sent: Date.current )
+      expect(user_sent_package.membership_packet_sent?).to be_truthy
+    end
+
+    it 'false if there is no date' do
+      user_sent_package = create(:user, date_membership_packet_sent: nil )
+      expect(user_sent_package.membership_packet_sent?).to be_falsey
     end
   end
 end


### PR DESCRIPTION
### PT Story:  Admin: when was a member packet sent?
https://www.pivotaltracker.com/story/show/163505574

This is a WIP to see how the tests go here on Semaphore.
I still need to merge this with the latest version of AV/develop.

Nearly all functionality is here and working, but I plan to make a new branch and clean up the commits.
- need to add to db seeding

### Changes proposed in this pull request:
1.  add column `date_membership_packet_sent` to `users` table
1. When admin checks the box, the date is set to _today_ (or cleared if the box is unset)
2. add info to User view for admin
3. add sortable column to all users view for admin

### Screenshots (Optional):

<img width="761" alt="Screen Shot 2019-03-28 at 10 14 14 AM" src="https://user-images.githubusercontent.com/673794/55178365-77bbd280-5142-11e9-822b-26739ce98d53.png">

<img width="469" alt="Screen Shot 2019-03-28 at 10 14 34 AM" src="https://user-images.githubusercontent.com/673794/55178364-77bbd280-5142-11e9-8f21-303d2f65f0fb.png">


<img width="373" alt="Screen Shot 2019-03-28 at 10 15 00 AM" src="https://user-images.githubusercontent.com/673794/55178363-77bbd280-5142-11e9-9481-4670de888bf8.png">


### Ready for review:
@
