### PR TITLE
Admin manage app: Show/Hide Button -> Toggle text; put Export button on the right

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -38,6 +38,7 @@ $(function() {
 
     // Bind 'show/hide' search form accordion label switch
     $('#company_search_form').click(Utility.toggle_accordion_label);
+    $('#application_search_form').click(Utility.toggle_accordion_label);
 
     $('#toggle_search_form').click(Utility.toggle);
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -38,7 +38,7 @@ $(function() {
 
     // Bind 'show/hide' search form accordion label switch
     $('#company_search_form').click(Utility.toggle_accordion_label);
-    $('#application_search_form').click(Utility.toggle_accordion_label);
+    $('#application_search_form_toggler').click(Utility.toggle_accordion_label);
 
     // Bind the click action to the Utility toggle (show/hide) function
     $('#toggle_search_form').click(Utility.toggle);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -40,8 +40,8 @@ $(function() {
     $('#company_search_form').click(Utility.toggle_accordion_label);
     $('#application_search_form').click(Utility.toggle_accordion_label);
 
+    // Bind the click action to the Utility toggle (show/hide) function
     $('#toggle_search_form').click(Utility.toggle);
-
     $('#toggle_admin_set_password_form').click(Utility.toggle);
 
     // Enable all Bootstrap tooltips

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -40,11 +40,11 @@ var Utility = {
 
     if ($(this).attr('aria-expanded') === 'true') {
       // We are in the process of collapsing the accordion
-      var showStr = 'accordion_label.' + toggleId.replace('#','') + '.show';
+      var showStr = 'accordion_label.' + toggleId + '.show';
       $(this).text(I18n.t(showStr));
     } else {
       // We are in the process of opening the accordion
-      var hideStr = 'accordion_label.' + toggleId.replace('#','') + '.hide';
+      var hideStr = 'accordion_label.' + toggleId + '.hide';
       $(this).text(I18n.t(hideStr));
     }
   }

--- a/app/views/application/_accordion_showhide_toggle.html.haml
+++ b/app/views/application/_accordion_showhide_toggle.html.haml
@@ -1,0 +1,29 @@
+-# This partial expects the following locals to be set:
+-#
+-#  toggler_id = the id for a% element of the toggler; also used to look
+-#               the translation text from the locale files
+-#               Will default to "search_form_toggler" if it is blank
+-#
+-# The element to be shown/hidden (e.g. the search form)
+-# can then be written:
+-#
+-#    .panel.panel-default.search-form{id: 'toggled_search_form', 'aria-labelledby' => 'toggle-heading', role: 'tabpanel' }
+-#      = render 'search_form'
+-#
+-#   (where 'search_form' is the search form)
+-#
+- toggler_id = 'search_form_toggler' unless defined?(:toggler_id)
+
+- search_form_id = 'toggled_search_form'
+
+.panel-group.m-2#accordion{ role: 'tablist' }
+.panel.panel-default
+  .panel-heading#toggle-heading{ role: 'tab' }
+    %h4.panel-title.hide-toggler
+      %a{ 'aria-controls' => search_form_id, 'aria-expanded' => 'true',
+            'data-parent' => '#accordion', 'data-toggle' => 'collapse',
+            href: "##{search_form_id}", role: 'button',
+            id: toggler_id }
+
+        #{t("accordion_label.#{toggler_id}.hide")}
+

--- a/app/views/application/_accordion_showhide_toggle_panel_heading.html.haml
+++ b/app/views/application/_accordion_showhide_toggle_panel_heading.html.haml
@@ -5,7 +5,7 @@
 -#
 -#  toggler_id = the id for a% element of the toggler; also used to look
 -#               the translation text from the locale files
--#               Will default to "search_form_toggler" if it is blank
+-#               Default = "search_form_toggler" if it is not provided
 -#
 -# The element to be shown/hidden (e.g. the search form)
 -# can then be written:
@@ -18,7 +18,12 @@
 - toggler_id = local_assigns.fetch(:toggler_id, false) ? local_assigns[:toggler_id] : 'search_form_toggler'
 - toggled_searchform_id = local_assigns.fetch(:search_form_id, false) ? local_assigns[:search_form_id] : 'toggled_search_form'
 
-.panel-group.m-2#accordion{ role: 'tablist' }
-  .panel.panel-default
-    = render 'application/accordion_showhide_toggle_panel_heading',
-     search_form_id: toggled_searchform_id, toggler_id: toggler_id
+.panel-heading#toggle-heading{ role: 'tab' }
+  %h4.panel-title.hide-toggler
+    %a{ 'aria-controls' => toggled_searchform_id, 'aria-expanded' => 'true',
+          'data-parent' => '#accordion', 'data-toggle' => 'collapse',
+          href: "##{toggled_searchform_id}", role: 'button',
+          id: toggler_id }
+
+      #{t("accordion_label.#{toggler_id}.hide")}
+

--- a/app/views/companies/_companies_list.html.haml
+++ b/app/views/companies/_companies_list.html.haml
@@ -1,48 +1,47 @@
-#companies_list
-  .table-responsive
-    %table.table.table-hover.table-sm
-      %thead
-        %tr
-          %th
-            = t('activerecord.models.business_category.one')
-          %th
-            = sort_link(search_params, :name,
-                        t('activerecord.attributes.company.name'), {},
-                        { class: 'companies_pagination', remote: true })
-          %th
-            = sort_link(search_params, :addresses_region_name,
-                        t('activerecord.attributes.address.region'), {},
-                        { class: 'companies_pagination', remote: true })
-          %th
-            = sort_link(search_params, :addresses_kommun_name,
-                        t('activerecord.attributes.address.kommun'), {},
-                        { class: 'companies_pagination', remote: true })
+.table-responsive
+  %table.table.table-hover.table-sm
+    %thead
+      %tr
+        %th
+          = t('activerecord.models.business_category.one')
+        %th
+          = sort_link(search_params, :name,
+                      t('activerecord.attributes.company.name'), {},
+                      { class: 'companies_pagination', remote: true })
+        %th
+          = sort_link(search_params, :addresses_region_name,
+                      t('activerecord.attributes.address.region'), {},
+                      { class: 'companies_pagination', remote: true })
+        %th
+          = sort_link(search_params, :addresses_kommun_name,
+                      t('activerecord.attributes.address.kommun'), {},
+                      { class: 'companies_pagination', remote: true })
 
-          - if current_user.admin?
-            %th
-              = sort_link(search_params, :company_number,
-                        t('activerecord.attributes.company.company_number'), {},
-                        { class: 'companies_pagination', remote: true })
-            %th
-            %th
+        - if current_user.admin?
+          %th
+            = sort_link(search_params, :company_number,
+                      t('activerecord.attributes.company.company_number'), {},
+                      { class: 'companies_pagination', remote: true })
+          %th
+          %th
 
-      %tbody
-        - companies.each do |company|
-          %tr.company
-            %td.categories
-              = safe_join(company.categories_names, tag.br)
-            %td.name= link_to company.name.blank? ? t('name_missing') : company.name, company
-            %td.region
-              = safe_join(company.addresses_region_names, tag.br)
-            %td.kommun
-              = safe_join(company.kommuns_names, tag.br)
-              - if current_user.admin?
-                %td.company-number= company.company_number
-                %td.edit= link_to icon('fas', 'edit'), edit_company_path(company)
-                %td.delete= link_to icon('fas', 'trash', class: 'delete'), company, method: :delete,
-                                data: { :confirm => "#{t('confirm_are_you_sure')}" }
+    %tbody
+      - companies.each do |company|
+        %tr.company
+          %td.categories
+            = safe_join(company.categories_names, tag.br)
+          %td.name= link_to company.name.blank? ? t('name_missing') : company.name, company
+          %td.region
+            = safe_join(company.addresses_region_names, tag.br)
+          %td.kommun
+            = safe_join(company.kommuns_names, tag.br)
+            - if current_user.admin?
+              %td.company-number= company.company_number
+              %td.edit= link_to icon('fas', 'edit'), edit_company_path(company)
+              %td.delete= link_to icon('fas', 'trash', class: 'delete'), company, method: :delete,
+                              data: { :confirm => "#{t('confirm_are_you_sure')}" }
 
-  = render 'application/paginate_footer', entities: companies,
-                                          paginate_class: 'companies_pagination',
-                                          items_count: @items_count,
-                                          url: companies_path
+= render 'application/paginate_footer', entities: companies,
+                                        paginate_class: 'companies_pagination',
+                                        items_count: @items_count,
+                                        url: companies_path

--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -12,16 +12,11 @@
     .col-lg-8
       .panel-group.m-2#accordion{ role: 'tablist' }
         .panel.panel-default
-          .panel-heading#heading-2{ role: 'tab' }
-            %h4.panel-title.hide-toggler
-              %a{ 'aria-controls' => 'collapse-2', 'aria-expanded' => 'true',
-                  'data-parent' => '#accordion', 'data-toggle' => 'collapse',
-                  href: '#collapse-2', role: 'button',
-                  id: 'company_search_form' }
 
-                #{t('accordion_label.company_search_form.hide')}
+          = render 'application/accordion_showhide_toggle_panel_heading',
+           toggler_id: 'company_search_form'
 
-          .panel-collapse.collapse.show#collapse-2{ 'aria-labelledby' => 'heading-2', role: 'tabpanel' }
+          .panel-collapse.collapse.show#toggled_search_form{ 'aria-labelledby' => 'toggle-heading', role: 'tabpanel' }
             .panel-body
               = render 'search_form', all_companies: @all_companies, search_params: @search__params
 

--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -24,4 +24,5 @@
     %strong
       #{t('.no_search_results')}
   - else
-    = render 'companies_list', companies: @companies, search_params: @search_params
+    #companies_list
+      = render 'companies_list', companies: @companies, search_params: @search_params

--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -10,18 +10,18 @@
       = render 'map_companies', markers: location_and_markers_for(@all_visible_companies)
 
     .col-lg-8
-      .panel-group.m-2#accordion{ "aria-multiselectable" => "true", :role => "tablist" }
+      .panel-group.m-2#accordion{ role: 'tablist' }
         .panel.panel-default
-          .panel-heading#heading-2{ :role => "tab" }
+          .panel-heading#heading-2{ role: 'tab' }
             %h4.panel-title.hide-toggler
-              %a{ "aria-controls" => "collapse-2", "aria-expanded" => "true",
-                  "data-parent" => "#accordion", "data-toggle" => "collapse",
-                  :href => "#collapse-2", :role => "button",
+              %a{ 'aria-controls' => 'collapse-2', 'aria-expanded' => 'true',
+                  'data-parent' => '#accordion', 'data-toggle' => 'collapse',
+                  href: '#collapse-2', role: 'button',
                   id: 'company_search_form' }
 
                 #{t('accordion_label.company_search_form.hide')}
 
-          .panel-collapse.collapse.show#collapse-2{ "aria-labelledby" => "heading-2", :role => "tabpanel" }
+          .panel-collapse.collapse.show#collapse-2{ 'aria-labelledby' => 'heading-2', role: 'tabpanel' }
             .panel-body
               = render 'search_form', all_companies: @all_companies, search_params: @search__params
 

--- a/app/views/shf_applications/_shf_applications_list.html.haml
+++ b/app/views/shf_applications/_shf_applications_list.html.haml
@@ -1,47 +1,46 @@
-#shf_applications_list
-  .table-responsive
-    %table.table.table-hover.table-sm
-      %thead
-        %tr
-          %th
-            = sort_link(@search_params, :user_padded_membership_number,
-                        t('shf_applications.index.membership_number'), {},
-                        { class: 'applications_pagination', remote: true })
-          %th
-            = sort_link(@search_params, :user_last_name,
-                        t('shf_applications.index.name'), {},
-                        { class: 'applications_pagination', remote: true })
-          %th
-            = sort_link(@search_params, :companies_company_number,
-                        t('shf_applications.index.org_nr'), {},
-                        { class: 'applications_pagination', remote: true })
-          %th
-            = sort_link(@search_params, :state,
-                        t('shf_applications.index.state'), {},
-                        { class: 'applications_pagination', remote: true })
+.table-responsive
+  %table.table.table-hover.table-sm
+    %thead
+      %tr
+        %th
+          = sort_link(@search_params, :user_padded_membership_number,
+                      t('shf_applications.index.membership_number'), {},
+                      { class: 'applications_pagination', remote: true })
+        %th
+          = sort_link(@search_params, :user_last_name,
+                      t('shf_applications.index.name'), {},
+                      { class: 'applications_pagination', remote: true })
+        %th
+          = sort_link(@search_params, :companies_company_number,
+                      t('shf_applications.index.org_nr'), {},
+                      { class: 'applications_pagination', remote: true })
+        %th
+          = sort_link(@search_params, :state,
+                      t('shf_applications.index.state'), {},
+                      { class: 'applications_pagination', remote: true })
 
-          %th= t('shf_applications.index.files')
-          %th
+        %th= t('shf_applications.index.files')
+        %th
 
-      %tbody
-        - @shf_applications.each do |shf_application|
-          %tr.applicant
-            %td.membership_number= shf_application.user.membership_number
-            %td.name= link_to "#{shf_application.user.last_name + ', ' + shf_application.user.first_name}", user_path(shf_application.user)
-            - company = shf_application.companies&.first
-            %td.company_number= company == nil ? '' : link_to(company.company_number, company_path(company))
-            %td.state=  shf_application.aasm.human_state
+    %tbody
+      - @shf_applications.each do |shf_application|
+        %tr.applicant
+          %td.membership_number= shf_application.user.membership_number
+          %td.name= link_to "#{shf_application.user.last_name + ', ' + shf_application.user.first_name}", user_path(shf_application.user)
+          - company = shf_application.companies&.first
+          %td.company_number= company == nil ? '' : link_to(company.company_number, company_path(company))
+          %td.state=  shf_application.aasm.human_state
 
-            %td.number_of_files
-              - if shf_application.uploaded_files_count > 0
-                = shf_application.uploaded_files_count
-              - else
-                &mdash;
+          %td.number_of_files
+            - if shf_application.uploaded_files_count > 0
+              = shf_application.uploaded_files_count
+            - else
+              &mdash;
 
-            %td.action= link_to "#{t('manage')}", shf_application_path(shf_application.id)
+          %td.action= link_to "#{t('manage')}", shf_application_path(shf_application.id)
 
-  = render partial: 'application/paginate_footer',
-           locals: { entities: @shf_applications,
-                     paginate_class: 'applications_pagination',
-                     items_count: @items_count,
-                     url: shf_applications_path }
+= render partial: 'application/paginate_footer',
+         locals: { entities: @shf_applications,
+                   paginate_class: 'applications_pagination',
+                   items_count: @items_count,
+                   url: shf_applications_path }

--- a/app/views/shf_applications/index.html.haml
+++ b/app/views/shf_applications/index.html.haml
@@ -1,19 +1,30 @@
 %header.entry-header
   %h1.entry-title= t('.title')
 .entry-content
+
   .row.mb-4
     .col-6
+      .panel-group.m-2#accordion{ "aria-multiselectable" => "true", :role => "tablist" }
+      .panel.panel-default
+        .panel-heading#toggle-heading{ :role => "tab" }
+          %h4.panel-title.hide-toggler
+            %a{ "aria-controls" => "application_search_form", "aria-expanded" => "true",
+                "data-parent" => "#accordion", "data-toggle" => "collapse",
+                :href => "#application_search_form", :role => "button",
+                id: 'company_search_form' }
+
+              #{t('toggle.application_search_form.hide')}
+
+
+    .col-4.offset-2
       = render partial: 'administration_panel' if @current_user.admin?
 
-    .col-6
-      %button.btn.btn-outline-light.pull-right{ id: 'toggle_search_form',
-                                        href: '#application_search_form' }
-        #{t('toggle.application_search_form.hide')}
 
   .clearfix
 
-  .panel.panel-default.search-form#application_search_form
+  .panel.panel-default.search-form#application_search_form{ "aria-labelledby" => "toggle-heading", :role => "tabpanel" }
     = render 'search_form'
+
 
   - if @shf_applications.empty?
     %strong

--- a/app/views/shf_applications/index.html.haml
+++ b/app/views/shf_applications/index.html.haml
@@ -10,10 +10,10 @@
           %h4.panel-title.hide-toggler
             %a{ "aria-controls" => "application-search-form", "aria-expanded" => "true",
                 "data-parent" => "#accordion", "data-toggle" => "collapse",
-                :href => "#application_search_form", :role => "button",
-                id: 'company_search_form' }
+                :href => "#application-search-form", :role => "button",
+                id: 'application_search_form' }
 
-              #{t('toggle.application_search_form.hide')}
+              #{t('accordion_label.application_search_form.hide')}
 
 
     .col-4.offset-2

--- a/app/views/shf_applications/index.html.haml
+++ b/app/views/shf_applications/index.html.haml
@@ -8,7 +8,7 @@
       .panel.panel-default
         .panel-heading#toggle-heading{ :role => "tab" }
           %h4.panel-title.hide-toggler
-            %a{ "aria-controls" => "application_search_form", "aria-expanded" => "true",
+            %a{ "aria-controls" => "application-search-form", "aria-expanded" => "true",
                 "data-parent" => "#accordion", "data-toggle" => "collapse",
                 :href => "#application_search_form", :role => "button",
                 id: 'company_search_form' }
@@ -22,7 +22,7 @@
 
   .clearfix
 
-  .panel.panel-default.search-form#application_search_form{ "aria-labelledby" => "toggle-heading", :role => "tabpanel" }
+  .panel.panel-default.search-form#application-search-form{ "aria-labelledby" => "toggle-heading", :role => "tabpanel" }
     = render 'search_form'
 
 
@@ -30,4 +30,5 @@
     %strong
       #{t('.no_search_results')}
   - else
-    = render partial: 'shf_applications_list'
+    #shf_applications_list
+      = render partial: 'shf_applications_list'

--- a/app/views/shf_applications/index.html.haml
+++ b/app/views/shf_applications/index.html.haml
@@ -4,16 +4,18 @@
 
   .row.mb-4
     .col-6
-      .panel-group.m-2#accordion{ "aria-multiselectable" => "true", :role => "tablist" }
-      .panel.panel-default
-        .panel-heading#toggle-heading{ :role => "tab" }
-          %h4.panel-title.hide-toggler
-            %a{ "aria-controls" => "application-search-form", "aria-expanded" => "true",
-                "data-parent" => "#accordion", "data-toggle" => "collapse",
-                :href => "#application-search-form", :role => "button",
-                id: 'application_search_form' }
 
-              #{t('accordion_label.application_search_form.hide')}
+      - search_form_id = 'toggled_search_form'
+      .panel-group.m-2#accordion{ role: 'tablist' }
+      .panel.panel-default
+        .panel-heading#toggle-heading{ role: 'tab' }
+          %h4.panel-title.hide-toggler
+            %a{ 'aria-controls' => search_form_id, 'aria-expanded' => 'true',
+                'data-parent' => '#accordion', 'data-toggle' => 'collapse',
+                href: "##{search_form_id}", role: 'button',
+                id: 'application_search_form_toggler' }
+
+              #{t('accordion_label.application_search_form_toggler.hide')}
 
 
     .col-4.offset-2
@@ -22,7 +24,7 @@
 
   .clearfix
 
-  .panel.panel-default.search-form#application-search-form{ "aria-labelledby" => "toggle-heading", :role => "tabpanel" }
+  .panel.panel-default.search-form{id: search_form_id, 'aria-labelledby' => 'application_search_form_toggler', role: 'tabpanel' }
     = render 'search_form'
 
 

--- a/app/views/shf_applications/index.html.haml
+++ b/app/views/shf_applications/index.html.haml
@@ -4,19 +4,7 @@
 
   .row.mb-4
     .col-6
-
-      - search_form_id = 'toggled_search_form'
-      .panel-group.m-2#accordion{ role: 'tablist' }
-      .panel.panel-default
-        .panel-heading#toggle-heading{ role: 'tab' }
-          %h4.panel-title.hide-toggler
-            %a{ 'aria-controls' => search_form_id, 'aria-expanded' => 'true',
-                'data-parent' => '#accordion', 'data-toggle' => 'collapse',
-                href: "##{search_form_id}", role: 'button',
-                id: 'application_search_form_toggler' }
-
-              #{t('accordion_label.application_search_form_toggler.hide')}
-
+      = render 'application/accordion_showhide_toggle', toggler_id: 'application_search_form_toggler'
 
     .col-4.offset-2
       = render partial: 'administration_panel' if @current_user.admin?
@@ -24,7 +12,7 @@
 
   .clearfix
 
-  .panel.panel-default.search-form{id: search_form_id, 'aria-labelledby' => 'application_search_form_toggler', role: 'tabpanel' }
+  .panel.panel-default.search-form{id: 'toggled_search_form', 'aria-labelledby' => 'toggle-heading', role: 'tabpanel' }
     = render 'search_form'
 
 

--- a/app/views/shf_applications/index.html.haml
+++ b/app/views/shf_applications/index.html.haml
@@ -2,9 +2,10 @@
   %h1.entry-title= t('.title')
 .entry-content
 
-  .row.mb-4
+  .row
     .col-6
-      = render 'application/accordion_showhide_toggle', toggler_id: 'application_search_form_toggler'
+      = render 'application/accordion_showhide_toggle',
+        toggler_id: 'application_search_form_toggler', search_form_id: 'toggled_search_form'
 
     .col-4.offset-2
       = render partial: 'administration_panel' if @current_user.admin?
@@ -12,8 +13,9 @@
 
   .clearfix
 
-  .panel.panel-default.search-form{id: 'toggled_search_form', 'aria-labelledby' => 'toggle-heading', role: 'tabpanel' }
-    = render 'search_form'
+  .panel-collapse.collapse.show#toggled_search_form{ 'aria-labelledby' => 'toggle-heading', role: 'tabpanel' }
+    .panel-body
+      = render 'search_form'
 
 
   - if @shf_applications.empty?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,9 @@ en:
     company_search_form:
       hide: &hide_search Hide search form
       show: &show_search Show search form
+    application_search_form:
+      hide: *hide_search
+      show: *show_search
 
   toggle:
     application_search_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,7 +82,7 @@ en:
     company_search_form:
       hide: &hide_search Hide search form
       show: &show_search Show search form
-    application_search_form:
+    application_search_form_toggler:
       hide: *hide_search
       show: *show_search
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -82,6 +82,9 @@ sv:
     company_search_form:
       hide: &hide_search Dölj Sökfunktionen
       show: &show_search Visa Sökfunktionen
+    application_search_form:
+      hide: *hide_search
+      show: *show_search
 
   toggle:
     application_search_form:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -82,7 +82,7 @@ sv:
     company_search_form:
       hide: &hide_search Dölj Sökfunktionen
       show: &show_search Visa Sökfunktionen
-    application_search_form:
+    application_search_form_toggler:
       hide: *hide_search
       show: *show_search
 

--- a/features/search_companies.feature
+++ b/features/search_companies.feature
@@ -95,7 +95,7 @@ Scenario: Search by category
   And I should see "We Luv Dogs"
   Then I select "Groomer" in select list t("activerecord.models.business_category.one")
   And I click on t("search")
-  Then I click on t("accordion_label.company_search_form.hide")
+  Then I hide the companies search form
   And I should see "Barky Boys"
   And I should see "We Luv Dogs"
   And I should not see "HappyMutts"
@@ -110,7 +110,7 @@ Scenario: Search by region
   And I am on the "landing" page
   Then I select "Västerbotten" in select list t("activerecord.attributes.company.region")
   And I click on t("search")
-  Then I click on t("accordion_label.company_search_form.hide")
+  Then I hide the companies search form
   Then I should see "HappyMutts"
   And I should not see "Barky Boys"
   And I should not see "Dogs R Us"
@@ -124,7 +124,7 @@ Scenario: Search by company (and confirm non-admin cannot search with non-search
   And I cannot select "NoMember" in select list t("activerecord.models.company.one")
   Then I select "We Luv Dogs" in select list t("activerecord.models.company.one")
   And I click on t("search")
-  Then I click on t("accordion_label.company_search_form.hide")
+  Then I hide the companies search form
   And I should see "We Luv Dogs"
   And I should not see "HappyMutts"
   And I should not see "Barky Boys"
@@ -246,7 +246,7 @@ Scenario: Toggle Hide/Show search form
   And I am on the "landing" page
   And I should see t("accordion_label.company_search_form.hide")
   And t("activerecord.models.company.one") should be visible
-  Then I click on t("accordion_label.company_search_form.hide")
+  Then I hide the companies search form
   Then I wait 2 seconds
   And I should see t("accordion_label.company_search_form.show")
   Then t("activerecord.models.company.one") should not be visible

--- a/features/show_all_shf_applications.feature
+++ b/features/show_all_shf_applications.feature
@@ -66,11 +66,11 @@ Feature: Admin can see all SHF applications so they can be managed
 
     Then I should see "8" applications
     And I should see t("shf_applications.under_review") 1 time in the list of applications
-    #And I should see 1 t("activerecord.attributes.shf_application.state/under_review")
-    And I should see 1 t("activerecord.attributes.shf_application.state/accepted")
-    And I should see 3 t("activerecord.attributes.shf_application.state/waiting_for_applicant")
-    And I should see 1 t("activerecord.attributes.shf_application.state/rejected")
-    And I click the t("shf_applications.index.manage") action for the row with "Lastname, Emma"
+    And I should see t("activerecord.attributes.shf_application.state/accepted") 1 time in the list of applications
+    And I should see t("activerecord.attributes.shf_application.state/waiting_for_applicant") 3 times in the list of applications
+    And I should see t("activerecord.attributes.shf_application.state/rejected") 1 time in the list of applications
+
+    When I click the t("shf_applications.index.manage") action for the row with "Lastname, Emma"
     Then I should be on the "application" page for "emma_waits@waiting.se"
     And I should see "Emma Lastname"
     And I should see "5562252998"

--- a/features/show_all_shf_applications.feature
+++ b/features/show_all_shf_applications.feature
@@ -61,10 +61,12 @@ Feature: Admin can see all SHF applications so they can be managed
     Given I am logged in as "admin@shf.se"
     And I set the locale to "sv"
     And I am on the "membership applications" page
-    And I hide the search form
+
+    And I hide the membership applications search form
 
     Then I should see "8" applications
-    And I should see 1 t("activerecord.attributes.shf_application.state/under_review")
+    And I should see t("shf_applications.under_review") 1 time in the list of applications
+    #And I should see 1 t("activerecord.attributes.shf_application.state/under_review")
     And I should see 1 t("activerecord.attributes.shf_application.state/accepted")
     And I should see 3 t("activerecord.attributes.shf_application.state/waiting_for_applicant")
     And I should see 1 t("activerecord.attributes.shf_application.state/rejected")

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -140,6 +140,18 @@ Then "I should{negate} see {capture_string} in the row for {capture_string}" do 
 end
 
 
+Then "I should{negate} see {capture_string} in the div with id {capture_string}" do | negate, expected_text, div_id |
+  div = page.find(:id, div_id)
+  expect(div).send (negate ? :not_to : :to), have_content(expected_text)
+end
+
+
+Then "I should{negate} see {capture_string} {digits} time(?:s) in the div with id {capture_string}" do | negate, expected_text, num_times, div_id |
+  div = page.find(:id, div_id)
+  expect(div).send (negate ? :not_to : :to), have_content(expected_text, count: num_times)
+end
+
+
 Then(/^I should see "([^"]*)" applications$/) do |number|
   expect(page).to have_selector('tr.applicant', count: number)
 end

--- a/features/step_definitions/company_steps.rb
+++ b/features/step_definitions/company_steps.rb
@@ -84,3 +84,13 @@ end
 And(/I scroll so the top of the list of companies is visible/) do
   step %{I scroll so element with id "shf_applications_list" is visible}
 end
+
+
+And "I hide the companies search form" do
+  step %{I click on t("accordion_label.company_search_form.hide")}
+end
+
+
+And "I show the companies search form" do
+  step %{I click on t("accordion_label.company_search_form.hide")}
+end

--- a/features/step_definitions/company_steps.rb
+++ b/features/step_definitions/company_steps.rb
@@ -94,3 +94,20 @@ end
 And "I show the companies search form" do
   step %{I click on t("accordion_label.company_search_form.hide")}
 end
+
+
+COMPANIES_LIST_ID = 'companies_list'
+
+# Find a string or not in the #companies_list
+# (= the list of companies on the #index page
+And "I should{negate} see {capture_string} in the list of companies" do | negated, expected_string |
+  step %{I should#{negated ? ' not' : ''} see "#{expected_string}" in the div with id "#{COMPANIES_LIST_ID}"}
+end
+
+
+# Find a string [x] times in the #companies_list table
+# (= the list of companies on the #index page
+And "I should see {capture_string} {digits} time(s) in the list of companies" do | expected_string, num_times|
+  step %{I should see "#{expected_string}" #{num_times} time in the div with id "#{COMPANIES_LIST_ID}"}
+end
+

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -130,10 +130,10 @@ end
 
 
 And "I hide the membership applications search form" do
-  step %{I click on t("toggle.application_search_form.hide")}
+  step %{I click on t("accordion_label.application_search_form.hide")}
 end
 
 
 And "I show the membership applications search form" do
-  step %{I click on t("toggle.application_search_form.show")}
+  step %{I click on t("accordion_label.application_search_form.show")}
 end

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -113,3 +113,27 @@ And "I should see {capture_string} files for the {capture_string} listed applica
 
   expect(ele.text).to eq count
 end
+
+
+# Find a string or not in the #shf_applications table
+# (= the list of shf membership applications on the #index page
+And "I should{negate} see {capture_string} in the list of applications" do | negated, expected_string |
+  step %{I should#{negated ? ' not' : ''} see "#{expected_string}" in the div with id "shf_applications_list"}
+end
+
+
+# Find a string [x] times in the #shf_applications table
+# (= the list of shf membership applications on the #index page
+And "I should see {capture_string} {digits} time(s) in the list of applications" do | expected_string, num_times|
+  step %{I should see "#{expected_string}" #{num_times} time in the div with id "shf_applications_list"}
+end
+
+
+And "I hide the membership applications search form" do
+  step %{I click on t("toggle.application_search_form.hide")}
+end
+
+
+And "I show the membership applications search form" do
+  step %{I click on t("toggle.application_search_form.show")}
+end

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -130,10 +130,10 @@ end
 
 
 And "I hide the membership applications search form" do
-  step %{I click on t("accordion_label.application_search_form.hide")}
+  step %{I click on t("accordion_label.application_search_form_toggler.hide")}
 end
 
 
 And "I show the membership applications search form" do
-  step %{I click on t("accordion_label.application_search_form.show")}
+  step %{I click on t("accordion_label.application_search_form_toggler.show")}
 end

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -71,16 +71,16 @@ Feature: SHF Application status is changed
     And I should see status line with status t("shf_applications.under_review")
     And I should not see t("shf_applications.update.enter_member_number")
     And I should see "dog grooming"
+
     When I am on the "landing" page
-    And I hide the search form
+    And I hide the companies search form
 
-    Then I should see 1 t("shf_applications.waiting_for_applicant")
-    And I should see 3 t("shf_applications.under_review")
-    And I should see 1 t("shf_applications.accepted")
-    And I should see 1 t("shf_applications.rejected")
+    Then I should see t("shf_applications.waiting_for_applicant") 1 time in the list of applications
+    Then I should see t("shf_applications.under_review") 3 times in the list of applications
+    Then I should see t("shf_applications.accepted") 1 time in the list of applications
+    Then I should see t("shf_applications.rejected") 1 time in the list of applications
 
-
-
+    
 
   # From under_review to...
 
@@ -94,12 +94,12 @@ Feature: SHF Application status is changed
     And I should not see t("shf_applications.update.enter_member_number")
     And I should see "rehab"
     When I am on the "landing" page
-    And I hide the search form
+    And I hide the companies search form
 
-    Then I should see 2 t("shf_applications.waiting_for_applicant")
-    And I should see 1 t("shf_applications.under_review")
-    And I should see 1 t("shf_applications.accepted")
-    And I should see 1 t("shf_applications.rejected")
+    Then  I should see t("shf_applications.waiting_for_applicant") 2 times in the list of applications
+    And  I should see t("shf_applications.under_review") 1 time in the list of applications
+    And  I should see t("shf_applications.accepted") 1 time in the list of applications
+    And  I should see t("shf_applications.rejected") 1 time in the list of applications
     And I am Logged out
     And I am logged in as "emma_under_review@happymutts.se"
     And I am on the "edit my application" page
@@ -113,12 +113,12 @@ Feature: SHF Application status is changed
     Then I should see t("shf_applications.accept.success")
     And I should see "rehab"
     When I am on the "landing" page
-    And I hide the search form
+    And I hide the companies search form
 
-    Then I should see 1 t("shf_applications.waiting_for_applicant")
-    And I should see 1 t("shf_applications.under_review")
-    And I should see 2 t("shf_applications.accepted")
-    And I should see 1 t("shf_applications.rejected")
+    Then  I should see t("shf_applications.waiting_for_applicant") 1 time in the list of applications
+    And  I should see t("shf_applications.under_review") 1 time in the list of applications
+    And  I should see t("shf_applications.accepted") 2 times in the list of applications
+    And  I should see t("shf_applications.rejected") 1 time in the list of applications
 
   @selenium @admin
   Scenario: Admin changed from under_review to rejected
@@ -130,12 +130,12 @@ Feature: SHF Application status is changed
     And I should not see t("shf_applications.update.enter_member_number")
     And I should see "rehab"
     When I am on the "landing" page
-    And I hide the search form
+    And I hide the companies search form
 
-    Then I should see 1 t("shf_applications.waiting_for_applicant")
-    And I should see 1 t("shf_applications.under_review")
-    And I should see 2 t("shf_applications.rejected")
-    And I should see 1 t("shf_applications.accepted")
+    Then  I should see t("shf_applications.waiting_for_applicant") 1 time in the list of applications
+    And  I should see t("shf_applications.under_review") 1 time in the list of applications
+    And  I should see t("shf_applications.rejected") 2 times in the list of applications
+    And  I should see t("shf_applications.accepted") 1 time in the list of applications
 
   @admin
   Scenario: Admin cannot change from under_review to 'cancel waiting for applicant'
@@ -152,12 +152,12 @@ Feature: SHF Application status is changed
     And I should not see t("shf_applications.update.enter_member_number")
     And I should see "rehab"
     When I am on the "landing" page
-    And I hide the search form
+    And I hide the companies search form
 
-    Then I should see 2 t("shf_applications.rejected")
-    And I should see 1 t("shf_applications.under_review")
-    And I should see 1 t("shf_applications.waiting_for_applicant")
-    And I should see 1 t("shf_applications.accepted")
+    Then  I should see t("shf_applications.rejected") 2 times in the list of applications
+    And  I should see t("shf_applications.under_review") 1 time in the list of applications
+    And  I should see t("shf_applications.waiting_for_applicant") 1 time in the list of applications
+    And  I should see t("shf_applications.accepted") 1 time in the list of applications
 
   @admin @user @selenium
   Scenario: Admin rejects an application that had uploaded files (under_review to rejected)
@@ -217,12 +217,12 @@ Feature: SHF Application status is changed
     Then I should see status line with status t("shf_applications.ready_for_review")
     And I should see "rehab"
     And I am on the "landing" page
-    And I hide the search form
+    And I hide the companies search form
 
-    And I should see 1 t("shf_applications.ready_for_review")
-    And I should see 1 t("shf_applications.accepted")
-    And I should see 2 t("shf_applications.under_review")
-    And I should see 1 t("shf_applications.rejected")
+    And  I should see t("shf_applications.ready_for_review") 1 time in the list of applications
+    And  I should see t("shf_applications.accepted") 1 time in the list of applications
+    And  I should see t("shf_applications.under_review") 2 times in the list of applications
+    And  I should see t("shf_applications.rejected") 1 time in the list of applications
 
   @selenium @admin
   Scenario: Admin changed from 'waiting for applicant' to 'under review'
@@ -235,12 +235,12 @@ Feature: SHF Application status is changed
     And I should not see t("shf_applications.update.enter_member_number")
     And I should see "rehab"
     When I am on the "landing" page
-    And I hide the search form
+    And I hide the companies search form
 
-    And I should see 3 t("shf_applications.under_review")
-    And I should see 0 t("shf_applications.waiting_for_applicant")
-    And I should see 1 t("shf_applications.accepted")
-    And I should see 1 t("shf_applications.rejected")
+    And  I should see t("shf_applications.under_review") 3 times in the list of applications
+    And  I should see t("shf_applications.waiting_for_applicant") 0 times in the list of applications
+    And  I should see t("shf_applications.accepted") 1 time in the list of applications
+    And  I should see t("shf_applications.rejected") 1 time in the list of applications
 
   @admin
   Scenario: Admin cannot change from 'waiting for applicant' to rejected
@@ -277,12 +277,12 @@ Feature: SHF Application status is changed
     And I should see status line with status t("shf_applications.rejected")
     And I should see "dog crooning"
     When I am on the "landing" page
-    And I hide the search form
+    And I hide the companies search form
 
-    And I should see 2 t("shf_applications.under_review")
-    And I should see 1 t("shf_applications.waiting_for_applicant")
-    And I should see 0 t("shf_applications.accepted")
-    And I should see 2 t("shf_applications.rejected")
+    And  I should see t("shf_applications.under_review") 2 times in the list of applications
+    And  I should see t("shf_applications.waiting_for_applicant") 1 time in the list of applications
+    And  I should see t("shf_applications.accepted") 0 times in the list of applications
+    And  I should see t("shf_applications.rejected") 2 times in the list of applications
 
   @admin
   Scenario: Admin cannot change from accepted to accepted
@@ -326,12 +326,12 @@ Feature: SHF Application status is changed
     And I should see status line with status t("shf_applications.rejected")
     And I should see "rehab"
     When I am on the "landing" page
-    And I hide the search form
+    And I hide the companies search form
 
-    And I should see 2 t("shf_applications.under_review")
-    And I should see 1 t("shf_applications.waiting_for_applicant")
-    And I should see 1 t("shf_applications.accepted")
-    And I should see 1 t("shf_applications.rejected")
+    And  I should see t("shf_applications.under_review") 2 times in the list of applications
+    And  I should see t("shf_applications.waiting_for_applicant") 1 time in the list of applications
+    And  I should see t("shf_applications.accepted") 1 time in the list of applications
+    And  I should see t("shf_applications.rejected") 1 time in the list of applications
 
   @admin
   Scenario: Admin cannot change from rejected to 'waiting for applicant'
@@ -346,12 +346,12 @@ Feature: SHF Application status is changed
     Then I should see t("shf_applications.accept.success")
     And I should see "rehab"
     When I am on the "landing" page
-    And I hide the search form
+    And I hide the companies search form
 
-    Then I should see 1 t("shf_applications.waiting_for_applicant")
-    And I should see 2 t("shf_applications.under_review")
-    And I should see 2 t("shf_applications.accepted")
-    And I should see 0 t("shf_applications.rejected")
+    Then  I should see t("shf_applications.waiting_for_applicant") 1 time in the list of applications
+    And  I should see t("shf_applications.under_review") 2 times in the list of applications
+    And  I should see t("shf_applications.accepted") 2 times in the list of applications
+    And  I should see t("shf_applications.rejected") 0 times in the list of applications
 
   @admin
   Scenario: Admin cannot change from rejected to rejected

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -201,7 +201,7 @@ Feature: Visitor sees all companies
     Given the date is set to "2017-10-01"
     Given I am Logged out
     And I am on the "landing" page
-    And I click on t("accordion_label.company_search_form.hide")
+    And I hide the companies search form
     # Ensure the list is sorted by name so we will see Company02
     And I click on t("activerecord.attributes.company.name")
     And I should see "Company02"
@@ -240,7 +240,7 @@ Feature: Visitor sees all companies
     Given the date is set to "2017-10-01"
     Given I am Logged out
     And I am on the "landing" page
-    And I click on t("accordion_label.company_search_form.hide")
+    And I hide the companies search form
     And "items_count" should have "10" selected
     And I should see "10" companies
     # Ensure the list is sorted by name so we will see Company02
@@ -265,7 +265,7 @@ Feature: Visitor sees all companies
     Given the date is set to "2017-10-01"
     Given I am Logged out
     And I am on the "landing" page
-    And I click on t("accordion_label.company_search_form.hide")
+    And I hide the companies search form
     And "items_count" should have "10" selected
     Then I select "All" in select list "items_count"
     And I should see "27" companies

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -38,22 +38,22 @@ Feature: Visitor sees all companies
       | Company11 | 2965790286     | cmpy11@mail.com | Stockholm    | Alingsås |
       | Company12 | 4268582063     | cmpy12@mail.com | Stockholm    | Alingsås |
       | Company13 | 8028973322     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company14 | 8356502446     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company15 | 8394317054     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company16 | 8423893877     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company17 | 8589182768     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company18 | 8616006592     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company19 | 8764985894     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company20 | 8822107739     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company21 | 5569767808     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company22 | 8909248752     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company23 | 9074668568     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company24 | 9243957975     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company25 | 9267816362     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company26 | 9360289459     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company27 | 9475077674     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company28 | 8728875504     | cmpy13@mail.com | Stockholm    | Alingsås |
-      | Company29 | 5872150379     | cmpy13@mail.com | Stockholm    | Alingsås |
+      | Company14 | 8356502446     | cmpy14@mail.com | Stockholm    | Alingsås |
+      | Company15 | 8394317054     | cmpy15@mail.com | Stockholm    | Alingsås |
+      | Company16 | 8423893877     | cmpy16@mail.com | Stockholm    | Alingsås |
+      | Company17 | 8589182768     | cmpy17@mail.com | Stockholm    | Alingsås |
+      | Company18 | 8616006592     | cmpy18@mail.com | Stockholm    | Alingsås |
+      | Company19 | 8764985894     | cmpy19@mail.com | Stockholm    | Alingsås |
+      | Company20 | 8822107739     | cmpy20@mail.com | Stockholm    | Alingsås |
+      | Company21 | 5569767808     | cmpy21@mail.com | Stockholm    | Alingsås |
+      | Company22 | 8909248752     | cmpy22@mail.com | Stockholm    | Alingsås |
+      | Company23 | 9074668568     | cmpy23@mail.com | Stockholm    | Alingsås |
+      | Company24 | 9243957975     | cmpy24@mail.com | Stockholm    | Alingsås |
+      | Company25 | 9267816362     | cmpy25@mail.com | Stockholm    | Alingsås |
+      | Company26 | 9360289459     | cmpy26@mail.com | Stockholm    | Alingsås |
+      | Company27 | 9475077674     | cmpy27@mail.com | Stockholm    | Alingsås |
+      | Company28 | 8728875504     | cmpy28@mail.com | Stockholm    | Alingsås |
+      | Company29 | 5872150379     | cmpy29@mail.com | Stockholm    | Alingsås |
 
     And the following company addresses exist:
       | company_name | region     | kommun  |
@@ -162,10 +162,10 @@ Feature: Visitor sees all companies
     Given the date is set to "2017-10-01"
     Given I am Logged out
     And I am on the "landing" page
-    Then I should see "Company02"
-    And I should not see "2120000142"
-    And I should see "Company01"
-    And I should not see "5560360793"
+    Then I should see "Company02" in the list of companies
+    And I should not see "2120000142" in the list of companies
+    And I should see "Company01" in the list of companies
+    And I should not see "5560360793" in the list of companies
     And I should not see t("companies.new_company")
 
   @selenium @time_adjust
@@ -175,7 +175,7 @@ Feature: Visitor sees all companies
     And I am on the "landing" page
     # Ensure the list is sorted by name so we will see Company02
     And I click on t("activerecord.attributes.company.name")
-    And I should see "Company02"
+    And I should see "Company02" in the list of companies
     And I should see "Västerbotten" in the row for "Company02"
     And I should see "Norrbotten" in the row for "Company02"
     And I should see "Uppsala" in the row for "Company02"
@@ -190,10 +190,10 @@ Feature: Visitor sees all companies
     Given I am logged in as "u1@mutts.com"
     And I am on the "landing" page
     Then I should see t("companies.index.title")
-    And I should see "Company02"
-    And I should not see "2120000142"
-    And I should see "Company01"
-    And I should not see "5560360793"
+    And I should see "Company02" in the list of companies
+    And I should not see "2120000142" in the list of companies
+    And I should see "Company01" in the list of companies
+    And I should not see "5560360793" in the list of companies
     And I should not see t("companies.new_company")
 
   @selenium @time_adjust
@@ -204,16 +204,16 @@ Feature: Visitor sees all companies
     And I hide the companies search form
     # Ensure the list is sorted by name so we will see Company02
     And I click on t("activerecord.attributes.company.name")
-    And I should see "Company02"
-    And I should not see "2120000142"
-    And I should see "Company01"
-    And I should not see "5560360793"
-    And I should see "Company10"
-    And I should not see "3609340140"
-    And I should not see "Company11"
+    And I should see "Company02" in the list of companies
+    And I should not see "2120000142" in the list of companies
+    And I should see "Company01" in the list of companies
+    And I should not see "5560360793" in the list of companies
+    And I should see "Company10" in the list of companies
+    And I should not see "3609340140" in the list of companies
+    And I should not see "Company11" in the list of companies
     Then I click on t("will_paginate.next_label") link
-    And I should see "Company11"
-    And I should not see "Company10"
+    And I should see "Company11" in the list of companies
+    And I should not see "Company10" in the list of companies
 
   @selenium @time_adjust
   Scenario: I18n translations
@@ -221,14 +221,14 @@ Feature: Visitor sees all companies
     Given I am Logged out
     And I set the locale to "sv"
     And I am on the "landing" page
-    Then I click on t("accordion_label.company_search_form.hide")
+    Then I hide the companies search form
     And I should see "Verksamhetslän"
     And I should see "Kategori"
     And I should not see "Region"
     And I should not see "Category"
     Then I click on "change-lang-to-english"
     And I set the locale to "en"
-    Then I click on t("accordion_label.company_search_form.hide")
+    Then I hide the companies search form
     And I wait 1 second
     And I should see "Region"
     And I should see "Category"
@@ -245,20 +245,21 @@ Feature: Visitor sees all companies
     And I should see "10" companies
     # Ensure the list is sorted by name so we will see Company02
     And I click on t("activerecord.attributes.company.name")
-    And I should see "Company10"
-    And I should not see "Company11"
-    And I should not see "Company26"
+    And I should see "Company10" in the list of companies
+    And I should not see "Company11" in the list of companies
+    And I should not see "Company26" in the list of companies
     Then I select "25" in select list "items_count"
     And I wait for all ajax requests to complete
     Then I should see "25" companies
     And "items_count" should have "25" selected
-    And I should see "Company01"
-    And I should see "Company02"
-    And I should see "Company11"
-    And I should see "Company12"
-    And I should see "Company24"
-    And I should see "Company25"
-    And I should not see "Company26"
+    And I should see "Company01" in the list of companies
+    And I should see "Company02" in the list of companies
+    And I should see "Company11" in the list of companies
+    And I should see "Company12" in the list of companies
+    And I should see "Company24" in the list of companies
+    And I should see "Company25" in the list of companies
+    And I should not see "Company26" in the list of companies
+    And I should not see "Company27" in the list of companies
 
   @selenium @time_adjust
   Scenario: Companies lacking branding payment or members not shown
@@ -269,10 +270,10 @@ Feature: Visitor sees all companies
     And "items_count" should have "10" selected
     Then I select "All" in select list "items_count"
     And I should see "27" companies
-    And I should see "Company10"
-    And I should see "Company27"
-    And I should not see "Company28"
-    And I should not see "Company29"
+    And I should see "Company10" in the list of companies
+    And I should see "Company27" in the list of companies
+    And I should not see "Company28" in the list of companies
+    And I should not see "Company29" in the list of companies
 
   @selenium @time_adjust
   Scenario: Admin can see all companies even if lacking branding payment or members
@@ -283,7 +284,7 @@ Feature: Visitor sees all companies
     Then I select "All" in select list "items_count"
     And I wait for all ajax requests to complete
     And I should see "29" companies
-    And I should see "Company10"
-    And I should see "Company27"
-    And I should see "Company28"
-    And I should see "Company29"
+    And I should see "Company10" in the list of companies
+    And I should see "Company27" in the list of companies
+    And I should see "Company28" in the list of companies
+    And I should see "Company29" in the list of companies

--- a/features/view_shf_applications.feature
+++ b/features/view_shf_applications.feature
@@ -74,39 +74,57 @@ Feature: Admin sees as many or few SHF Applications as they want (pagination)
   Scenario: Pagination: default is All, can set to just 10 items
     Given I am logged in as "admin@shf.se"
     And I am on the "membership applications" page
-    And I hide the search form
+    And I hide the membership applications search form
     Then "items_count" should have "All" selected
     And I select "10" in select list "items_count"
     Then "items_count" should have "10" selected
     # prevents getting the element not clickable at that position error in Chrome
+
     And I scroll so the top of the list of companies is visible
     When I click on t("shf_applications.index.org_nr")
+
     And I should see "6222279082" before "6613265393"
     And I should see "6613265393" before "6914762726"
+
+    # Capybara seems to be viewing the search form select lists (options) as 'visible',
+    #  so it pics those up with the simple "And I should see ..." steps.
+    # I am ensuring that we are checking in the actual list of shf applications
+    # (search select options are not within the div#shf_applications_list, so they'll be ignored)
+    And I should see "6222279082" in the list of applications
+    And I should see "6613265393" in the list of applications
+    And I should see "6914762726" in the list of applications
+
+    When I click on t("will_paginate.next_label") link
+    Then I should see "7661057765" in the list of applications
+    And I should see "8728875504" in the list of applications
+    And I should not see "6914762726" in the list of applications
+    And I should not see "8764985894" in the list of applications
+
     Then I click on t("will_paginate.next_label") link
-    And I should see "7661057765"
-    And I should see "8728875504"
-    And I should not see "6914762726"
-    And I should not see "8764985894"
-    Then I click on t("will_paginate.next_label") link
-    And I should see "8764985894"
-    And I should not see "8728875504"
+    And I should see "8764985894" in the list of applications
+    And I should not see "8728875504" in the list of applications
 
   @selenium
   Scenario: Pagination: Set number of items per page to various choices
     Given I am logged in as "admin@shf.se"
     And I am on the "membership applications" page
-    And I hide the search form
+    And I hide the membership applications search form
     Then "items_count" should have "All" selected
     And I should see "28" applications
-    And I should see "2120000142"
-    And I should see "9475077674"
+
+    # Capybara seems to be viewing the search form select lists (options) as 'visible',
+    #  so it pics those up with the simple "And I should see ..." steps.
+    # I am ensuring that we are checking in the actual list of shf applications
+    # (search select options are not within the div#shf_applications_list, so they'll be ignored)
+    And I should see "2120000142" in the list of applications
+    And I should see "9475077674" in the list of applications
     Then I select "25" in select list "items_count"
     And I should see "25" applications
     And "items_count" should have "25" selected
-    And I should see "9243957975"
-    And I should not see "9267816362"
+    And I should see "9243957975" in the list of applications
+    And I should not see "9267816362" in the list of applications
+
     Then I select "10" in select list "items_count"
     And I should see "10" applications
-    And I should see "6914762726"
-    And I should not see "7661057765"
+    And I should see "6914762726" in the list of applications
+    And I should not see "7661057765" in the list of applications


### PR DESCRIPTION
### PT Story: NewLook: Admin manage applications: Show/Hide Button 


### Changes proposed in this pull request:
1. Admin: Manage SHF Applications (index) :  
   - use toggle text instead of a show/hide button (use same accordion panel as the Company indes page)
   - put the Export button on the left so that the toggle Text can be on the left

**Note: The export button needs to be aligned**

 
### Screenshots (Optional):
#### Here's how it looks:  the search options are _shown_ by default:

<img width="962" alt="admin-apps-show-hide-default" src="https://user-images.githubusercontent.com/673794/55281870-6b2cab00-52f7-11e9-8aa4-4579cd2d6782.png">

---
#### Search options hidden:


<img width="916" alt="admin-apps-show-hide-hidden" src="https://user-images.githubusercontent.com/673794/55281869-6a941480-52f7-11e9-8ad2-3abc87c84b82.png">

---
#### Variation 1:  the toggle text is lighter (gray: #808080)

<img width="935" alt="admin-apps-show-hide--grayed-toggle-text" src="https://user-images.githubusercontent.com/673794/55281868-6a941480-52f7-11e9-8b23-9109a50b70f3.png">

---

#### Variation 2: the toggle text is lighter _and_ the Export button text is smaller

<img width="931" alt="admin-apps-show-hide-lt-btn-smallerFont" src="https://user-images.githubusercontent.com/673794/55281939-4553d600-52f8-11e9-860a-f60904420b7f.png">



### Ready for review:
@thesuss @patmbolger 




