### PR TITLE
Validate dinkurs company key does not contain invalid (for URL) characters

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -126,6 +126,9 @@ class Company < ApplicationRecord
   rescue Dinkurs::Errors::InvalidKey
     errors.add(:dinkurs_company_id, :invalid)
     return false
+  rescue URI::InvalidURIError
+    errors.add(:dinkurs_company_id, :invalid)
+    return false
   end
 
 

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -17,6 +17,8 @@ class Company < ApplicationRecord
   validates_format_of :email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: [:create, :update]
   validate :swedish_organisationsnummer
 
+  validates :dinkurs_company_id, dinkurs_id: true
+
   before_save :sanitize_website, :sanitize_description
 
   has_many :company_applications
@@ -127,7 +129,7 @@ class Company < ApplicationRecord
     errors.add(:dinkurs_company_id, :invalid)
     return false
   rescue URI::InvalidURIError
-    errors.add(:dinkurs_company_id, :invalid)
+    errors.add(:dinkurs_company_id, :invalid_chars)
     return false
   end
 

--- a/app/validators/dinkurs_id_validator.rb
+++ b/app/validators/dinkurs_id_validator.rb
@@ -1,0 +1,9 @@
+class DinkursIdValidator < ActiveModel::EachValidator
+  KEY = 'activerecord.errors.models.company.attributes.dinkurs_company_id.invalid_chars'
+
+  def validate_each(object, attribute, value)
+    if value.to_s =~ /å|ä|ö|Å|Ä|Ö/
+      object.errors[attribute] << I18n.t(KEY)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -261,7 +261,7 @@ en:
               taken: This company (organization number) already exists in the system.
             dinkurs_company_id:
               invalid: is not recognized as a company key by Dinkurs
-              invalid_chars: contains invalid characters (possibly å, ä, ö, Å, Ä, or Ö)
+              invalid_chars: contains invalid characters (characters such as Å, Ä, Ö are not allowed)
             company_has_active_memberships: "The company has active (accepted) membership applications."
 
         user:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -261,6 +261,7 @@ en:
               taken: This company (organization number) already exists in the system.
             dinkurs_company_id:
               invalid: is not recognized as a company key by Dinkurs
+              invalid_chars: contains invalid characters (possibly å, ä, ö, Å, Ä, or Ö)
             company_has_active_memberships: "The company has active (accepted) membership applications."
 
         user:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -260,7 +260,7 @@ sv:
               taken: Detta företag (org nr) finns redan i systemet.
             dinkurs_company_id:
               invalid: erkänns inte som en företagsnyckel av Dinkurs
-              invalid_chars: innehåller ogiltiga tecken (eventuellt å, ä, ö, Å, Ä eller Ö)
+              invalid_chars: innehåller ogiltiga tecken (tecken som Å, Ä, Ö är inte tillåtna)
             company_has_active_memberships: "Företaget har aktiva (godkända) medlemskap."
 
         user:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -260,6 +260,7 @@ sv:
               taken: Detta företag (org nr) finns redan i systemet.
             dinkurs_company_id:
               invalid: erkänns inte som en företagsnyckel av Dinkurs
+              invalid_chars: innehåller ogiltiga tecken (eventuellt å, ä, ö, Å, Ä eller Ö)
             company_has_active_memberships: "Företaget har aktiva (godkända) medlemskap."
 
         user:

--- a/features/events_management/dinkurs_events.feature
+++ b/features/events_management/dinkurs_events.feature
@@ -100,6 +100,15 @@ Feature: As a member of a company
     And I click on t("submit")
     Then I should see t("activerecord.errors.models.company.attributes.dinkurs_company_id.invalid")
 
+  @time_adjust @dinkurs_invalid_key
+  Scenario: Member edits company, enters Dinkurs ID with invalid chars, sees validation error
+    Given the date is set to "2017-10-01"
+    And I am logged in as "member@mutts.com"
+    And I am on the edit company page for "5560360793"
+    And I fill in t("companies.show.dinkurs_key") with "Åö"
+    And I click on t("submit")
+    Then I should see t("activerecord.errors.models.company.attributes.dinkurs_company_id.invalid_chars")
+
   @time_adjust @selenium @dinkurs_fetch
   Scenario: Member fetches Dinkurs events
     Given the date is set to "2017-10-01"

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -50,6 +50,9 @@ RSpec.describe Company, type: :model, focus: true do
     it { is_expected.to allow_value('user@example.com').for(:email) }
     it { is_expected.not_to allow_value('userexample.com').for(:email) }
 
+    it { is_expected.to allow_value('abcdef').for(:dinkurs_company_id) }
+    it { is_expected.not_to allow_value('åäöÅÄÖ').for(:dinkurs_company_id) }
+
     describe 'uniqueness of company_number' do
       let(:msg) { I18n.t('activerecord.errors.models.company.attributes.company_number.taken') }
       subject { FactoryBot.build(:company) }

--- a/spec/support/validator_helper.rb
+++ b/spec/support/validator_helper.rb
@@ -1,0 +1,9 @@
+module ValidatorHelper
+  def test_model_class
+    Class.new do
+      include ActiveModel::Validations
+
+      attr_accessor :test_attr
+    end
+  end
+end

--- a/spec/validators/dinkurs_id_validator_spec.rb
+++ b/spec/validators/dinkurs_id_validator_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require 'support/validator_helper'
+include ValidatorHelper
+
+RSpec.describe DinkursIdValidator do
+  let(:model) { ValidatorHelper.test_model_class }
+  let(:record) { model.new }
+
+  let(:error_msg) { I18n.t('activerecord.errors.models.company.attributes.dinkurs_company_id.invalid_chars') }
+
+  before(:each) do
+    record.class_eval do
+      validates :test_attr, dinkurs_id: true
+    end
+  end
+
+  it 'adds error message when key contains invalid characters' do
+    record.test_attr = 'abcDEä'
+    expect { record.valid? }
+      .to change(record.errors, :messages).from({})
+      .to a_hash_including(test_attr: [error_msg])
+    # reference: http://rspec.info/blog/2014/01/new-in-rspec-3-composable-matchers/
+  end
+
+  it 'does not add error message if no special characters' do
+    record.test_attr = 'abcDEF'
+    expect { record.valid? }.not_to change(record.errors.messages, :count).from(0)
+  end
+end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/165052117


Changes proposed in this pull request:
1. Add validator to Dinkurs company ID (aka Dinkurs company key)
2. Rescue _URI::InvalidURIError_ exception when trying to access Dinkurs

Screenshots (Optional):

<img width="1006" alt="Screen Shot 2019-04-22 at 6 10 56 PM" src="https://user-images.githubusercontent.com/9968213/56535567-fe898280-6529-11e9-92f1-459615e4a74d.png">


Ready for review:
@AgileVentures/shf-project-team 
