### PR TITLE
Fix city search

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -18,6 +18,7 @@ class CompaniesController < ApplicationController
 
     self.params = fix_FB_changed_q_params(self.params)
     self.params = remove_sort_by_business_categories(self.params)
+    self.params = adjust_city_match_names(self.params)
 
     action_params, @items_count, items_per_page = process_pagination_params('company')
 
@@ -34,9 +35,24 @@ class CompaniesController < ApplicationController
     # allowing sorting on an associated table column ("region" in this case)
     # https://github.com/activerecord-hackery/ransack#problem-with-distinct-selects
 
-    @all_companies = @all_companies.searchable unless current_user.admin?
+    if current_user.admin?
+      @all_visible_companies = @all_companies
+      @addresses_select_list = Address.select(:city).distinct
+                                 .sort { |a,b| a.city.downcase.strip <=> b.city.downcase.strip }
+    else
+      @all_companies = @all_companies.searchable
+      @all_visible_companies = @all_companies.address_visible
 
-    @all_visible_companies = @all_companies.address_visible
+      addresses = []
+      @all_visible_companies.each do |company|
+        company.addresses.where.not(visibility: 'none').select(:city).each do |address|
+          addresses << address
+        end
+      end
+
+      @addresses_select_list = addresses.uniq { |a| a.city }
+                                .sort { |a,b| a.city.downcase.strip <=> b.city.downcase.strip }
+    end
 
     @all_visible_companies.each { |co| geocode_if_needed co }
 
@@ -49,7 +65,7 @@ class CompaniesController < ApplicationController
 
     respond_to do |format|
       format.html
-      
+
       format.js do
         list_html = render_to_string(partial: 'companies_list',
                                      locals: { companies: @companies,
@@ -316,6 +332,21 @@ class CompaniesController < ApplicationController
       params['q'] = params['q'].except('s')
     end
 
+    params
+  end
+
+  def adjust_city_match_names(params)
+    # Remove leading and trailing whitespace for city names
+
+    return unless city_matches = params[:q]&.[]('addresses_city_matches_any')
+
+    params[:q]['addresses_city_matches_any'] = city_matches.map do |v|
+      if v.empty?
+        v
+      else
+        '%' + v.strip + '%'
+      end
+    end
     params
   end
 

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -338,7 +338,7 @@ class CompaniesController < ApplicationController
   def adjust_city_match_names(params)
     # Remove leading and trailing whitespace for city names and set up "LIKE" match
 
-    return unless (city_matches = params[:q]&.[]('addresses_city_matches_any'))
+    return params unless (city_matches = params[:q]&.[]('addresses_city_matches_any'))
 
     params[:q]['addresses_city_matches_any'] = city_matches.map do |v|
       if v.empty?

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -50,7 +50,7 @@ class CompaniesController < ApplicationController
         end
       end
 
-      @addresses_select_list = addresses.uniq { |a| a.city }
+      @addresses_select_list = addresses.uniq { |a| a.city.downcase.strip }
                                 .sort { |a,b| a.city.downcase.strip <=> b.city.downcase.strip }
     end
 
@@ -336,7 +336,7 @@ class CompaniesController < ApplicationController
   end
 
   def adjust_city_match_names(params)
-    # Remove leading and trailing whitespace for city names
+    # Remove leading and trailing whitespace for city names and set up "LIKE" match
 
     return unless city_matches = params[:q]&.[]('addresses_city_matches_any')
 

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -338,7 +338,7 @@ class CompaniesController < ApplicationController
   def adjust_city_match_names(params)
     # Remove leading and trailing whitespace for city names and set up "LIKE" match
 
-    return unless city_matches = params[:q]&.[]('addresses_city_matches_any')
+    return unless (city_matches = params[:q]&.[]('addresses_city_matches_any'))
 
     params[:q]['addresses_city_matches_any'] = city_matches.map do |v|
       if v.empty?

--- a/app/views/companies/_search_form.html.haml
+++ b/app/views/companies/_search_form.html.haml
@@ -40,11 +40,11 @@
                        class: 'form-control search_field',
                        data: {language: language } }
     .col-sm.form-group
-      = f.label :addresses_id_in,
+      = f.label :addresses_city_matches_any,
                 "#{t('activerecord.attributes.address.city')}"
-      = f.collection_select :addresses_id_in,
-                     Address.visible.order(:city).select(:id, :city).uniq {|a| a.city},
-                     :id, :city, { include_blank: false },
+      = f.collection_select :addresses_city_matches_any,
+                     addresses_select_list, :city, :city,
+                     { include_blank: false },
                      { multiple: true, size: 5, style: 'width: 100%;',
                        class: 'form-control search_field',
                        data: {language: language } }

--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -20,6 +20,7 @@
             .panel-body
               = render 'search_form', all_companies: @all_companies,
                                       search_params: @search__params,
+                                      addresses_select_list: @addresses_select_list,
                                       language: @locale
 
   - if @companies.empty?
@@ -27,4 +28,7 @@
       #{t('.no_search_results')}
   - else
     #companies_list
-      = render 'companies_list', companies: @companies, search_params: @search_params
+      = render 'companies_list', companies: @companies,
+                                 search_params: @search_params,
+                                 addresses_select_list: @addresses_select_list,
+                                 language: @locale

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -31,15 +31,15 @@ SET default_with_oids = false;
 --
 
 CREATE TABLE public.addresses (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     street_address character varying,
     post_code character varying,
     city character varying,
     country character varying DEFAULT 'Sverige'::character varying NOT NULL,
-    region_id bigint,
+    region_id integer,
     addressable_type character varying,
-    addressable_id bigint,
-    kommun_id bigint,
+    addressable_id integer,
+    kommun_id integer,
     latitude double precision,
     longitude double precision,
     visibility character varying DEFAULT 'street_address'::character varying,
@@ -130,7 +130,7 @@ CREATE TABLE public.ar_internal_metadata (
 --
 
 CREATE TABLE public.business_categories (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     name character varying,
     description character varying,
     created_at timestamp without time zone NOT NULL,
@@ -162,9 +162,9 @@ ALTER SEQUENCE public.business_categories_id_seq OWNED BY public.business_catego
 --
 
 CREATE TABLE public.business_categories_shf_applications (
-    id bigint NOT NULL,
-    shf_application_id bigint,
-    business_category_id bigint
+    id integer NOT NULL,
+    shf_application_id integer,
+    business_category_id integer
 );
 
 
@@ -192,7 +192,7 @@ ALTER SEQUENCE public.business_categories_shf_applications_id_seq OWNED BY publi
 --
 
 CREATE TABLE public.ckeditor_assets (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     data_file_name character varying NOT NULL,
     data_content_type character varying,
     data_file_size integer,
@@ -202,7 +202,7 @@ CREATE TABLE public.ckeditor_assets (
     height integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    company_id bigint
+    company_id integer
 );
 
 
@@ -230,7 +230,7 @@ ALTER SEQUENCE public.ckeditor_assets_id_seq OWNED BY public.ckeditor_assets.id;
 --
 
 CREATE TABLE public.companies (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     name character varying,
     company_number character varying,
     phone_number character varying,
@@ -437,7 +437,7 @@ ALTER SEQUENCE public.file_delivery_methods_id_seq OWNED BY public.file_delivery
 --
 
 CREATE TABLE public.kommuns (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     name character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
@@ -468,7 +468,7 @@ ALTER SEQUENCE public.kommuns_id_seq OWNED BY public.kommuns.id;
 --
 
 CREATE TABLE public.member_app_waiting_reasons (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     name_sv character varying,
     description_sv character varying,
     name_en character varying,
@@ -545,7 +545,7 @@ ALTER SEQUENCE public.member_app_waiting_reasons_id_seq OWNED BY public.member_a
 --
 
 CREATE TABLE public.member_pages (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     filename character varying NOT NULL,
     title character varying,
     created_at timestamp without time zone NOT NULL,
@@ -627,7 +627,7 @@ ALTER SEQUENCE public.payments_id_seq OWNED BY public.payments.id;
 --
 
 CREATE TABLE public.regions (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     name character varying,
     code character varying,
     created_at timestamp without time zone NOT NULL,
@@ -668,11 +668,11 @@ CREATE TABLE public.schema_migrations (
 --
 
 CREATE TABLE public.shf_applications (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     phone_number character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    user_id bigint,
+    user_id integer,
     contact_email character varying,
     state character varying DEFAULT 'new'::character varying,
     member_app_waiting_reasons_id integer,
@@ -708,8 +708,8 @@ ALTER SEQUENCE public.shf_applications_id_seq OWNED BY public.shf_applications.i
 --
 
 CREATE TABLE public.shf_documents (
-    id bigint NOT NULL,
-    uploader_id bigint NOT NULL,
+    id integer NOT NULL,
+    uploader_id integer NOT NULL,
     title character varying,
     description text,
     created_at timestamp without time zone NOT NULL,
@@ -745,14 +745,14 @@ ALTER SEQUENCE public.shf_documents_id_seq OWNED BY public.shf_documents.id;
 --
 
 CREATE TABLE public.uploaded_files (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     actual_file_file_name character varying,
     actual_file_content_type character varying,
     actual_file_file_size integer,
     actual_file_updated_at timestamp without time zone,
-    shf_application_id bigint
+    shf_application_id integer
 );
 
 
@@ -780,7 +780,7 @@ ALTER SEQUENCE public.uploaded_files_id_seq OWNED BY public.uploaded_files.id;
 --
 
 CREATE TABLE public.users (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     email character varying DEFAULT ''::character varying NOT NULL,
     encrypted_password character varying DEFAULT ''::character varying NOT NULL,
     reset_password_token character varying,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -31,15 +31,15 @@ SET default_with_oids = false;
 --
 
 CREATE TABLE public.addresses (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     street_address character varying,
     post_code character varying,
     city character varying,
     country character varying DEFAULT 'Sverige'::character varying NOT NULL,
-    region_id integer,
+    region_id bigint,
     addressable_type character varying,
-    addressable_id integer,
-    kommun_id integer,
+    addressable_id bigint,
+    kommun_id bigint,
     latitude double precision,
     longitude double precision,
     visibility character varying DEFAULT 'street_address'::character varying,
@@ -130,7 +130,7 @@ CREATE TABLE public.ar_internal_metadata (
 --
 
 CREATE TABLE public.business_categories (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     name character varying,
     description character varying,
     created_at timestamp without time zone NOT NULL,
@@ -162,9 +162,9 @@ ALTER SEQUENCE public.business_categories_id_seq OWNED BY public.business_catego
 --
 
 CREATE TABLE public.business_categories_shf_applications (
-    id integer NOT NULL,
-    shf_application_id integer,
-    business_category_id integer
+    id bigint NOT NULL,
+    shf_application_id bigint,
+    business_category_id bigint
 );
 
 
@@ -192,7 +192,7 @@ ALTER SEQUENCE public.business_categories_shf_applications_id_seq OWNED BY publi
 --
 
 CREATE TABLE public.ckeditor_assets (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     data_file_name character varying NOT NULL,
     data_content_type character varying,
     data_file_size integer,
@@ -202,7 +202,7 @@ CREATE TABLE public.ckeditor_assets (
     height integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    company_id integer
+    company_id bigint
 );
 
 
@@ -230,7 +230,7 @@ ALTER SEQUENCE public.ckeditor_assets_id_seq OWNED BY public.ckeditor_assets.id;
 --
 
 CREATE TABLE public.companies (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     name character varying,
     company_number character varying,
     phone_number character varying,
@@ -437,7 +437,7 @@ ALTER SEQUENCE public.file_delivery_methods_id_seq OWNED BY public.file_delivery
 --
 
 CREATE TABLE public.kommuns (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     name character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
@@ -468,7 +468,7 @@ ALTER SEQUENCE public.kommuns_id_seq OWNED BY public.kommuns.id;
 --
 
 CREATE TABLE public.member_app_waiting_reasons (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     name_sv character varying,
     description_sv character varying,
     name_en character varying,
@@ -545,7 +545,7 @@ ALTER SEQUENCE public.member_app_waiting_reasons_id_seq OWNED BY public.member_a
 --
 
 CREATE TABLE public.member_pages (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     filename character varying NOT NULL,
     title character varying,
     created_at timestamp without time zone NOT NULL,
@@ -627,7 +627,7 @@ ALTER SEQUENCE public.payments_id_seq OWNED BY public.payments.id;
 --
 
 CREATE TABLE public.regions (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     name character varying,
     code character varying,
     created_at timestamp without time zone NOT NULL,
@@ -668,11 +668,11 @@ CREATE TABLE public.schema_migrations (
 --
 
 CREATE TABLE public.shf_applications (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     phone_number character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    user_id integer,
+    user_id bigint,
     contact_email character varying,
     state character varying DEFAULT 'new'::character varying,
     member_app_waiting_reasons_id integer,
@@ -708,8 +708,8 @@ ALTER SEQUENCE public.shf_applications_id_seq OWNED BY public.shf_applications.i
 --
 
 CREATE TABLE public.shf_documents (
-    id integer NOT NULL,
-    uploader_id integer NOT NULL,
+    id bigint NOT NULL,
+    uploader_id bigint NOT NULL,
     title character varying,
     description text,
     created_at timestamp without time zone NOT NULL,
@@ -745,14 +745,14 @@ ALTER SEQUENCE public.shf_documents_id_seq OWNED BY public.shf_documents.id;
 --
 
 CREATE TABLE public.uploaded_files (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     actual_file_file_name character varying,
     actual_file_content_type character varying,
     actual_file_file_size integer,
     actual_file_updated_at timestamp without time zone,
-    shf_application_id integer
+    shf_application_id bigint
 );
 
 
@@ -780,7 +780,7 @@ ALTER SEQUENCE public.uploaded_files_id_seq OWNED BY public.uploaded_files.id;
 --
 
 CREATE TABLE public.users (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     email character varying DEFAULT ''::character varying NOT NULL,
     encrypted_password character varying DEFAULT ''::character varying NOT NULL,
     reset_password_token character varying,

--- a/features/search_companies.feature
+++ b/features/search_companies.feature
@@ -38,6 +38,8 @@ Background:
   And the following companies exist:
     | name        | company_number | email                | region       | kommun    | city  |
     | Barky Boys  | 5560360793     | barky@barkyboys.com  | Stockholm    | Alingsås  | city1 |
+    | DogCo_01    | 5634016009     | dogco_01@mail.com    | Stockholm    | Alingsås  | CITY1 |
+    | DogCo_02    | 8471950124     | dogco_02@mail.com    | Stockholm    | Alingsås  | 'CITY1   ' |
     | HappyMutts  | 2120000142     | woof@happymutts.com  | Västerbotten | Bromölla  | city2 |
     | Dogs R Us   | 5562252998     | chief@dogsrus.com    | Norrbotten   | Östersund | city3 |
     | We Luv Dogs | 5569467466     | alpha@weluvdogs.com  | Sweden       | Laxå      | city4 |
@@ -48,15 +50,17 @@ Background:
   And the following payments exist
     | user_email          | start_date | expire_date | payment_type | status | hips_id | company_number |
     | fred@barkyboys.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 5560360793     |
+    | fred@barkyboys.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 5634016009     |
     | john@happymutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 2120000142     |
+    | john@happymutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 8471950124     |
     | anna@dogsrus.com    | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 5562252998     |
     | emma@weluvdogs.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 5569467466     |
     | emma@weluvdogs.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 8248600598     |
 
   And the following applications exist:
     | user_email          | company_number | state    | categories      |
-    | fred@barkyboys.com  | 5560360793     | accepted | Groomer, Trainer|
-    | john@happymutts.com | 2120000142     | accepted | Psychologist    |
+    | fred@barkyboys.com  | 5560360793, 5634016009     | accepted | Groomer, Trainer|
+    | john@happymutts.com | 2120000142, 8471950124     | accepted | Psychologist    |
     | anna@dogsrus.com    | 5562252998     | accepted | Trainer         |
     | emma@weluvdogs.com  | 5569467466, 8248600598 | accepted | Groomer, Walker |
     | lars@nopayment.se   | 8028973322     | accepted | Groomer, Trainer|
@@ -272,7 +276,7 @@ Scenario: Toggle Hide/Show search form
     And I should not see "We Luv Dogs" in the list of companies
 
   @selenium @time_adjust
-  Scenario: Search by city ignores leading and trailing whitespace in city name
+  Scenario: Search by city ignores case, and leading and trailing whitespace in city name
     Given I am Logged out
     And I am on the "landing" page
     Then I select "space city" in select list t("activerecord.attributes.company.city")
@@ -281,3 +285,11 @@ Scenario: Toggle Hide/Show search form
     And I should not see "HappyMutts" in the list of companies
     And I should not see "We Luv Dogs" in the list of companies
     And I should not see "Dogs R Us" in the list of companies
+
+    Then I select "city1" in select list t("activerecord.attributes.company.city")
+    And I click on t("search")
+    And I should see "Barky Boys"
+    And I should see "DogCo_01"
+    And I should see "DogCo_02"
+    And I should see "city1" in the list of companies
+    And I should see "CITY1" 2 times in the list of companies

--- a/features/search_companies.feature
+++ b/features/search_companies.feature
@@ -43,6 +43,7 @@ Background:
     | We Luv Dogs | 5569467466     | alpha@weluvdogs.com  | Sweden       | Laxå      | city4 |
     | NoPayment   | 8028973322     | hello@nopayment.se   | Stockholm    | Alingsås  | city5 |
     | NoMember    | 9697222900     | hello@nomember.se    | Stockholm    | Alingsås  | city6 |
+    | New Company | 8248600598     | newco@newco.com      | Stockholm    | Alingsås  | ' space city ' |
 
   And the following payments exist
     | user_email          | start_date | expire_date | payment_type | status | hips_id | company_number |
@@ -50,13 +51,14 @@ Background:
     | john@happymutts.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 2120000142     |
     | anna@dogsrus.com    | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 5562252998     |
     | emma@weluvdogs.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 5569467466     |
+    | emma@weluvdogs.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 8248600598     |
 
   And the following applications exist:
     | user_email          | company_number | state    | categories      |
     | fred@barkyboys.com  | 5560360793     | accepted | Groomer, Trainer|
     | john@happymutts.com | 2120000142     | accepted | Psychologist    |
     | anna@dogsrus.com    | 5562252998     | accepted | Trainer         |
-    | emma@weluvdogs.com  | 5569467466     | accepted | Groomer, Walker |
+    | emma@weluvdogs.com  | 5569467466, 8248600598 | accepted | Groomer, Walker |
     | lars@nopayment.se   | 8028973322     | accepted | Groomer, Trainer|
 
   Given the date is set to "2017-10-01"
@@ -268,3 +270,14 @@ Scenario: Toggle Hide/Show search form
     And I should see "HappyMutts"
     And I should see "Barky Boys"
     And I should not see "We Luv Dogs" in the list of companies
+
+  @selenium @time_adjust
+  Scenario: Search by city ignores leading and trailing whitespace in city name
+    Given I am Logged out
+    And I am on the "landing" page
+    Then I select "space city" in select list t("activerecord.attributes.company.city")
+    And I click on t("search")
+    And I should see "New Company"
+    And I should not see "HappyMutts" in the list of companies
+    And I should not see "We Luv Dogs" in the list of companies
+    And I should not see "Dogs R Us" in the list of companies

--- a/features/step_definitions/company_steps.rb
+++ b/features/step_definitions/company_steps.rb
@@ -2,7 +2,7 @@ And(/^the following companies exist:$/) do |table|
   table.hashes.each do |company|
     region = company.delete('region') || 'Stockholm'
     kommun = company.delete('kommun') || 'Stockholm'
-    city = company.delete('city') || 'Stockholm'
+    city = (company.delete('city') || 'Stockholm').gsub("'","")
     visibility = company.delete('visibility') || 'street_address'
 
     cmpy = FactoryBot.create(:company, company)
@@ -11,7 +11,6 @@ And(/^the following companies exist:$/) do |table|
                                 kommun: Kommun.find_or_create_by(name: kommun),
                                 city: city,
                                 visibility: visibility)
-
   end
 end
 

--- a/features/step_definitions/company_steps.rb
+++ b/features/step_definitions/company_steps.rb
@@ -2,7 +2,7 @@ And(/^the following companies exist:$/) do |table|
   table.hashes.each do |company|
     region = company.delete('region') || 'Stockholm'
     kommun = company.delete('kommun') || 'Stockholm'
-    city = (company.delete('city') || 'Stockholm').gsub("'","")
+    city = (company.delete('city') || 'Stockholm').delete("'")
     visibility = company.delete('visibility') || 'street_address'
 
     cmpy = FactoryBot.create(:company, company)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/165772206


Changes proposed in this pull request:
1. Search for companies using "city" was using incorrect matching logic.  This has been changed to match city name (in DB) against the list of city names selected by the user in the form.
2. In the controller, adjust the search params - as needed - to strip leading and trailing whitespace from city names (from the select list), and then arrange for the city search to use MATCH LIKE logic (that is, add wildcard in front and back of city name).

This means that:

1. City names containing leading and/or trailing whitespace will match the same as the same city name without the whitespace, and,
2. City name search will be case insensitive.

Screenshots (these are for a **non-admin user** - admin will see more unfiltered detail):

---

### City names have lower-case, upper-case _and_ trailing whitespace:

<img width="674" alt="Screen Shot 2019-05-06 at 6 17 53 AM" src="https://user-images.githubusercontent.com/9968213/57219737-0e43a500-6fc7-11e9-8b21-26c4083d3b74.png">

In the DB, two "Bromma" city names have the same (correct) spelling, and differ only by case and whitespace occurrence.  These are consolidated into one selectable city name for search.

---

### Result of executing search on above city name selection:

<img width="721" alt="Screen Shot 2019-05-06 at 6 18 09 AM" src="https://user-images.githubusercontent.com/9968213/57219812-4b0f9c00-6fc7-11e9-872f-32d83f57c854.png">

All matching records are found - regardless of case / whitespace.

---

### City names have lower-case, upper-case _and_ trailing whitespace; also, name is misspelled:

<img width="720" alt="Screen Shot 2019-05-06 at 6 18 37 AM" src="https://user-images.githubusercontent.com/9968213/57219921-8e6a0a80-6fc7-11e9-95f5-bddec27baec9.png">

Note that 3 occurrences of the (correctly-spelled) city name have been collapsed into one selectable name. (the 3 occurrences include "Stockholm", "STOCKHOLM", and "Stockholm ").

The 4th name for the city is misspelled and no attempt is made to correct that.


Ready for review:
@AgileVentures/shf-project-team 