### PR TITLE
Format city name on Address save

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -5,6 +5,8 @@ class Address < ApplicationRecord
   # Thus the model behavior is consistent with the business rules of the
   # Company model.  This is manifest in some of the Address controller actions.
 
+  before_save :format_city_name
+
   belongs_to :addressable, polymorphic: true
 
   # When an address is initially created, it may not have a kommun or region assigned,
@@ -145,6 +147,20 @@ class Address < ApplicationRecord
 
   end
 
+  # TODO: Make this a private method after a one-time rake task - which updates
+  #       non-conforming city names in addresses - has been run.
+  def format_city_name
+    # Capitalize first letter of each word
+    # Convert remaining letters of each word to lower case
+    # Remove leading and trailing white space
+    # Reduce internal string of multiple white spaces to single white space
+    # Preserve non-whitespace, non-word characters as-is (e.g. dashes)
+
+    self.city = city.strip.gsub(/\s\s+/, ' ').gsub(/(\w|å|ä|ö|Å|Ä|Ö)+/) do |word|
+      word.mb_chars.capitalize.to_s
+    end
+  end
+
 
   private
 
@@ -156,8 +172,6 @@ class Address < ApplicationRecord
       (!latitude.nil? && !longitude.nil?)  &&
       (self.new_record? || !((self.changed & GEO_FIELDS).any?) )
   end
-
-
 
   def sverige_if_nil
     country = 'Sverige' if country.nil?

--- a/features/search_companies.feature
+++ b/features/search_companies.feature
@@ -247,7 +247,7 @@ Scenario: Search by category and region 2
   Then I select "Sweden" in select list t("activerecord.attributes.company.region")
   And I click on t("search")
   And I should see "We Luv Dogs"
-  And I should see "city4" in the list of companies
+  And I should see "City4" in the list of companies
 
 @selenium @time_adjust
 Scenario: Toggle Hide/Show search form
@@ -264,13 +264,13 @@ Scenario: Toggle Hide/Show search form
   Scenario: Search by city
     Given I am Logged out
     And I am on the "landing" page
-    Then I select "city1" in select list t("activerecord.attributes.company.city")
+    Then I select "City1" in select list t("activerecord.attributes.company.city")
     And I click on t("search")
     And I should see "Barky Boys"
     And I should not see "HappyMutts" in the list of companies
     And I should not see "We Luv Dogs" in the list of companies
     And I should not see "Dogs R Us" in the list of companies
-    Then I select "city2" in select list t("activerecord.attributes.company.city")
+    Then I select "City2" in select list t("activerecord.attributes.company.city")
     And I click on t("search")
     And I should see "HappyMutts"
     And I should see "Barky Boys"
@@ -280,17 +280,16 @@ Scenario: Toggle Hide/Show search form
   Scenario: Search by city ignores case, and leading and trailing whitespace in city name
     Given I am Logged out
     And I am on the "landing" page
-    Then I select "space city" in select list t("activerecord.attributes.company.city")
+    Then I select "Space City" in select list t("activerecord.attributes.company.city")
     And I click on t("search")
     And I should see "New Company"
     And I should not see "HappyMutts" in the list of companies
     And I should not see "We Luv Dogs" in the list of companies
     And I should not see "Dogs R Us" in the list of companies
 
-    Then I select "city1" in select list t("activerecord.attributes.company.city")
+    Then I select "City1" in select list t("activerecord.attributes.company.city")
     And I click on t("search")
     And I should see "Barky Boys"
     And I should see "DogCo_01"
     And I should see "DogCo_02"
-    And I should see "city1" in the list of companies
-    And I should see "CITY1" 2 times in the list of companies
+    And I should see "City1" 3 times in the list of companies

--- a/lib/tasks/one_time/2019_Q2/format_city_names.rake
+++ b/lib/tasks/one_time/2019_Q2/format_city_names.rake
@@ -1,0 +1,34 @@
+# Format city names, as needed, as described in Address#format_city_name
+namespace :shf do
+  namespace :one_time do
+
+    desc "Format all city names"
+    task format_city_names: :environment do
+
+      log_file = 'log/format_city_names.log'
+
+      ActivityLogger.open(log_file, 'OneTimeRakeTask', 'format_city_names') do |log|
+
+        log.info("Checking #{Address.count} addresses.")
+
+        formatted_count = 0
+
+        Address.order(:city).each do | address |
+          city_name = address.city
+          formatted_name = address.format_city_name
+
+          if city_name != formatted_name
+            
+            address.update_column(:city, formatted_name)
+
+            log.info("#{city_name} >> #{formatted_name}")
+            formatted_count += 1
+          end
+        end
+
+        log.info("Formatted #{formatted_count} addresses.")
+      end
+    end
+  end
+
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -341,6 +341,31 @@ RSpec.describe Address, type: :model do
     it { is_expected.to belong_to(:addressable) }
   end
 
+  describe 'Calls #format_city_name before save' do
+    let(:address) { build(:address, addressable: build(:company)) }
+
+    it 'removes unneeded white space' do
+      address.city = '   lots  of   white   space   '
+      address.save
+      expect(address.city).to eq 'Lots Of White Space'
+    end
+
+    it 'converts city to Title Case' do
+      address.city = 'trollhättan'
+      address.save
+      expect(address.city).to eq 'Trollhättan'
+
+      address.city = 'ÄLMHULT'
+      address.save
+      expect(address.city).to eq 'Älmhult'
+
+      address.city = 'saltsjö-boo'
+      address.save
+      expect(address.city).to eq 'Saltsjö-Boo'
+    end
+
+  end
+
 
   describe 'scopes' do
     let!(:has_regions) { [addr_has_region] }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/165347812

Changes proposed in this pull request:
1. Add `before_save` filter to Address that calls method to format `city` appropriately.
2. Added one-time rake task to convert (as needed) existing city names in DB

*NOTE*: The task `she:one_time:format_city_names` should be run upon deployment.

Running the rake task in my local environment (with a DB only slightly out of sync with production) resulted in 45 `city` conversions:
```
[OneTimeRakeTask] [format_city_names] [info] Started at 2019-05-09 21:07:12 UTC
[OneTimeRakeTask] [format_city_names] [info] Checking 280 addresses.
[OneTimeRakeTask] [format_city_names] [info] BANDHAGEN >> Bandhagen
[OneTimeRakeTask] [format_city_names] [info] BROMMA                 >> Bromma
[OneTimeRakeTask] [format_city_names] [info] FARSTA >> Farsta
[OneTimeRakeTask] [format_city_names] [info] Gnesta  >> Gnesta
[OneTimeRakeTask] [format_city_names] [info] GÖTEBORG >> Göteborg
[OneTimeRakeTask] [format_city_names] [info] HALMSTAD >> Halmstad
[OneTimeRakeTask] [format_city_names] [info] HELSINGBORG >> Helsingborg
[OneTimeRakeTask] [format_city_names] [info] HENÅN >> Henån
[OneTimeRakeTask] [format_city_names] [info] Hallstahammar  >> Hallstahammar
[OneTimeRakeTask] [format_city_names] [info] Hallstahammar  >> Hallstahammar
[OneTimeRakeTask] [format_city_names] [info] Hindås  >> Hindås
[OneTimeRakeTask] [format_city_names] [info] HÄLLINGSJÖ >> Hällingsjö
[OneTimeRakeTask] [format_city_names] [info] JÖNKÖPING >> Jönköping
[OneTimeRakeTask] [format_city_names] [info] KINNA >> Kinna
[OneTimeRakeTask] [format_city_names] [info] KOLBÄCK >> Kolbäck
[OneTimeRakeTask] [format_city_names] [info] Kolbäck  >> Kolbäck
[OneTimeRakeTask] [format_city_names] [info] KÖPING >> Köping
[OneTimeRakeTask] [format_city_names] [info] Kävlinge  >> Kävlinge
[OneTimeRakeTask] [format_city_names] [info] LINDESBERG >> Lindesberg
[OneTimeRakeTask] [format_city_names] [info] LUND >> Lund
[OneTimeRakeTask] [format_city_names] [info] LYCKEBY >> Lyckeby
[OneTimeRakeTask] [format_city_names] [info] Lomma  >> Lomma
[OneTimeRakeTask] [format_city_names] [info] Munkedal  >> Munkedal
[OneTimeRakeTask] [format_city_names] [info] OXIE >> Oxie
[OneTimeRakeTask] [format_city_names] [info] SIMRISHAMN >> Simrishamn
[OneTimeRakeTask] [format_city_names] [info] SKARA >> Skara
[OneTimeRakeTask] [format_city_names] [info] SKULTUNA >> Skultuna
[OneTimeRakeTask] [format_city_names] [info] SOLLENTUNA >> Sollentuna
[OneTimeRakeTask] [format_city_names] [info] STOCKHOILM >> Stockhoilm
[OneTimeRakeTask] [format_city_names] [info] STOCKHOLM >> Stockholm
[OneTimeRakeTask] [format_city_names] [info] STOCKHOLM >> Stockholm
[OneTimeRakeTask] [format_city_names] [info] Saltsjö-Boo  >> Saltsjö-Boo
[OneTimeRakeTask] [format_city_names] [info] Simrishamn  >> Simrishamn
[OneTimeRakeTask] [format_city_names] [info] Sollentuna  >> Sollentuna
[OneTimeRakeTask] [format_city_names] [info] Sorunda  >> Sorunda
[OneTimeRakeTask] [format_city_names] [info] Stockholm  >> Stockholm
[OneTimeRakeTask] [format_city_names] [info] Stockholm  >> Stockholm
[OneTimeRakeTask] [format_city_names] [info] Svensbyn  >> Svensbyn
[OneTimeRakeTask] [format_city_names] [info] TYRESÖ >> Tyresö
[OneTimeRakeTask] [format_city_names] [info] UPPSALA >> Uppsala
[OneTimeRakeTask] [format_city_names] [info] Vallentuna  >> Vallentuna
[OneTimeRakeTask] [format_city_names] [info] trollhättan >> Trollhättan
[OneTimeRakeTask] [format_city_names] [info] ÄLMHULT >> Älmhult
[OneTimeRakeTask] [format_city_names] [info] ÄNGELHOLM >> Ängelholm
[OneTimeRakeTask] [format_city_names] [info] Åkers Styckebruk  >> Åkers Styckebruk
[OneTimeRakeTask] [format_city_names] [info] Formatted 45 addresses.
[OneTimeRakeTask] [format_city_names] [info] Finished at 2019-05-09 21:07:12 UTC.
[OneTimeRakeTask] [format_city_names] [info] Duration: 0.36 seconds.
[OneTimeRakeTask] [format_city_names] [info] Information was logged to: log/format_city_names.log
```
Also, note that some of these conversions represent stripping trailing white space, so:
```
Saltsjö-Boo  >> Saltsjö-Boo
```
represents changing "Saltsjö-Boo " to "Saltsjö-Boo".

Ready for review:
@AgileVentures/shf-project-team 