### PR TITLE
[WIP] Session will timeout after 1 hour (will need to log in again)

### DIFF
--- a/app/controllers/concerns/custom_devise_fail_app.rb
+++ b/app/controllers/concerns/custom_devise_fail_app.rb
@@ -19,14 +19,4 @@ class CustomDeviseFailApp < Devise::FailureApp
     new_user_session_path
   end
 
-
-  # Need to override this so that warden recall is not involved
-  def respond
-    if http_auth?
-      http_auth
-    else
-      redirect
-    end
-  end
-
 end

--- a/app/controllers/concerns/custom_devise_fail_app.rb
+++ b/app/controllers/concerns/custom_devise_fail_app.rb
@@ -1,11 +1,10 @@
-
 #--------------------------
 #
 # @class CustomDeviseFailApp
 #
-# @desc Responsibility: Redirects users to the login page on a Warden auth failure
-#
-#
+# @desc Responsibility: Redirects users to the login page on Warden authorization failures
+# See
+# https://github.com/plataformatec/devise/wiki/How-To:-Redirect-to-a-specific-page-when-the-user-can-not-be-authenticated)
 #
 # @author Ashley Engelund (ashley.engelund@gmail.com  weedySeaDragon @ github)
 # @date   2019-05-11
@@ -15,16 +14,13 @@
 #--------------------------
 class CustomDeviseFailApp < Devise::FailureApp
 
-  # Where users will be redirected on any Warden failure
-  # = login path
+  # Redirect users to the login path on a Warden authorization failure
   def redirect_url
     new_user_session_path
   end
 
 
-  # Need to override this so that warden recall is not involved (per Devise
-  # FailuraApp instructions:
-  # https://github.com/plataformatec/devise/wiki/How-To:-Redirect-to-a-specific-page-when-the-user-can-not-be-authenticated)
+  # Need to override this so that warden recall is not involved
   def respond
     if http_auth?
       http_auth

--- a/app/controllers/concerns/custom_devise_fail_app.rb
+++ b/app/controllers/concerns/custom_devise_fail_app.rb
@@ -1,0 +1,36 @@
+
+#--------------------------
+#
+# @class CustomDeviseFailApp
+#
+# @desc Responsibility: Redirects users to the login page on a Warden auth failure
+#
+#
+#
+# @author Ashley Engelund (ashley.engelund@gmail.com  weedySeaDragon @ github)
+# @date   2019-05-11
+#
+# @file custom_devise_fail_app.rb
+#
+#--------------------------
+class CustomDeviseFailApp < Devise::FailureApp
+
+  # Where users will be redirected on any Warden failure
+  # = login path
+  def redirect_url
+    new_user_session_path
+  end
+
+
+  # Need to override this so that warden recall is not involved (per Devise
+  # FailuraApp instructions:
+  # https://github.com/plataformatec/devise/wiki/How-To:-Redirect-to-a-specific-page-when-the-user-can-not-be-authenticated)
+  def respond
+    if http_auth?
+      http_auth
+    else
+      redirect
+    end
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable,
+         :timeoutable
 
   before_destroy { self.member_photo = nil } # remove photo file from file system
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -166,6 +166,8 @@ Devise.setup do |config|
   # time the user will be asked for credentials again. Default is 30 minutes.
   # config.timeout_in = 30.minutes
 
+  config.timeout_in = 1.hour
+
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
@@ -253,10 +255,11 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
+   config.warden do |manager|
+     manager.failure_app = CustomDeviseFailApp
   #   manager.intercept_401 = false
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+   end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -1,4 +1,5 @@
-Feature: As a registered user
+Feature: Logging in
+  As a registered user
   in order to access the functions of the site
   I need to be able to login
 

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -151,6 +151,16 @@ Given(/^the date is set to "([^"]*)"$/) do |date|
   Timecop.freeze( Time.find_zone("UTC").parse(date))
 end
 
+
+# Note: the 'time_unit' must be a method (string) that is implemented
+# by a Duration (see active_support/time_with_zone.rb)
+#
+And("time advances by {digits} {capture_string}") do | amount, time_unit |
+  new_time = Time.zone.now + (amount.send(time_unit.to_sym))
+  Timecop.freeze(new_time)
+end
+
+
 # Hide (or show) the search form by clicking on the button
 #  This is frequently used to hide the search form on a page so that
 #  items in the select lists are not included in counts.

--- a/features/user_session_timeout.feature
+++ b/features/user_session_timeout.feature
@@ -1,0 +1,47 @@
+Feature: User is automatically logged out after timeout time exceeded
+
+  As a user, if I have been inactive more than the timeout time configured,
+  I am automatically logged out
+  So that the system does not have lots of open, inactive sessions in use
+
+
+  Background:
+    Given the following users exists
+      | email                | password | admin | member |
+      | emma@random.com      | password | false | true   |
+      | lars-user@random.com | password | false | false  |
+      | anne@random.com      | password | false | false  |
+      | arne@random.com      | password | true  | true   |
+
+    And the following applications exist:
+      | user_email           | company_number | state        |
+      | emma@random.com      | 5562252998     | accepted     |
+      | lars-user@random.com | 2120000142     | under_review |
+
+
+  # assumes the timeout time is configured to < 3 hours
+  @time_adjust
+  Scenario: I am logged out because I have been inactive longer than the timeout time
+    Given the date is set to "2019-05-01"
+    And I am on the "login" page
+    When I fill in t("activerecord.attributes.user.email") with "emma@random.com"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I click on t("devise.sessions.new.log_in") button
+    Then I should see t("devise.sessions.signed_in")
+    And time advances by 3 "hours"
+    And I am on the "user profile" page for "emma@random.com"
+    Then I should see t("devise.failure.timeout")
+
+
+  # assumes the timeout time is configured to 1 hour or more
+  @time_adjust
+  Scenario: I am not loggged out when I do something before the timeout time
+    Given the date is set to "2019-05-01"
+    And I am on the "login" page
+    When I fill in t("activerecord.attributes.user.email") with "emma@random.com"
+    And I fill in t("activerecord.attributes.user.password") with "password"
+    And I click on t("devise.sessions.new.log_in") button
+    Then I should see t("devise.sessions.signed_in")
+    And time advances by 59 "minutes"
+    And I am on the "user profile" page for "emma@random.com"
+    Then I should not see t("devise.failure.timeout")


### PR DESCRIPTION
### PT Story

We do need to redirect folks to the login page if they need to log in (= PT https://www.pivotaltracker.com/story/show/153527174 )  
but it's not clear that we need to use "timeoutable" since we're already using "rememberable"


I set the **timeout to 1 hour** : users will have to log in again after 1 hour of inactivity.  (This is set in `config/initializers/devise.rb`

**_Should the timeout setting be longer?  Shorter?  (the default is 30 minutes)_**

### Changes proposed in this pull request:
1.  Added 'timeoutable' to User
2. Added the `CustomDeviseFailApp` class that will redirect users to the sign-in page if there is an authentication error (e.g. if they have been automatically signed out and try to do something)
3. added a cucumber step to advance the time by a Duration (e.g. `3.minutes` or `2.hours` etc).


Ready for review:
@AgileVentures/shf-project-team 
