### PR TITLE
change production log_level to :warn

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :info
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
### PT Story:  change Production log level to WARN
https://www.pivotaltracker.com/story/show/165980031


### Changes proposed in this pull request:
1.  change log level in config/environments/production.rb 

Ready for review:
@patmbolger @thesuss 
