### PR TITLE
fix exception handling in shorten URL service

### DIFF
--- a/app/services/shorten_url.rb
+++ b/app/services/shorten_url.rb
@@ -1,30 +1,32 @@
 class ShortenUrl
 
-  SHORTEN_URL_LOG = 'log/tinyurl.log'
+  SHORTEN_URL_LOG = LogfileNamer.name_for(ShortenUrl)
   SUCCESS_CODES = [200, 201, 202].freeze
 
   def self.short(url)
+    response = nil
     response = HTTParty.get("http://tinyurl.com/api-create.php?url=#{url}")
     raise HTTParty::Error if response.match?(/error/i) || !SUCCESS_CODES.include?(response.code)
     response
-  rescue HTTParty::Error => error
-    log_error(error)
+  rescue HTTParty::UnsupportedURIScheme, HTTParty::UnsupportedFormat, HTTParty::Error => error
+    log_error(error, url, response)
     nil
   end
 
   private_class_method
 
-  def self.log_error(error)
+  def self.log_error(error, url, response)
+
     ActivityLogger.open(SHORTEN_URL_LOG, 'TINYURL_API', 'shortening url', false) do |log|
-      log.record('error', "Exception: #{error.message}")
+
+      log.error("Exception: #{error.message}")
+      log.error("Attempted URL: #{url}")
       if response
-        log.record('error', "Attempted URL: #{url}")
-        log.record('error', "Response body: #{response.body}")
-        log.record('error', "HTTP code: #{response.code}")
+        log.error("Response body: #{response.body}")
+        log.error("HTTP code: #{response.code}")
       else
-        log.record('error', "Exception raised by HTTParty")
+        log.error("Exception raised by HTTParty")
       end
     end
   end
 end
-


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/165896555


Changes proposed in this pull request:
1. Fix errors in exception handling in `ShortenUrl`
2. Use `LogfileNamer` to derive log file path


Ready for review:
@AgileVentures/shf-project-team 