### PR TITLE
Application file delete does not submit application form

### DIFF
--- a/app/assets/javascripts/companies.js
+++ b/app/assets/javascripts/companies.js
@@ -3,7 +3,7 @@ $(function() {
 
   $('body').on('ajax:complete', '.companies_pagination', function (e, response) {
 
-    if (companyFunctions.handleError(e, response) === false) {
+    if (Utility.handleError(e, response) === false) {
       var data = JSON.parse(response.responseText);
 
       $('#companies_list').html(data.list_html);
@@ -13,7 +13,7 @@ $(function() {
 
   $('body').on('ajax:complete', '#companies_search', function (e, response) {
 
-    if (companyFunctions.handleError(e, response) === false) {
+    if (Utility.handleError(e, response) === false) {
       var data = JSON.parse(response.responseText);
 
       $('#companies_list').html(data.list_html);
@@ -59,14 +59,3 @@ $(function() {
     }
   });
 });
-
-companyFunctions = {
-  handleError: function(event, response) {
-    if (response.status !== 200) {
-      event.stopPropagation();
-      alert('Something went wrong - please reload page and try again.');
-      return true;
-    }
-    return false;
-  }
-}

--- a/app/assets/javascripts/shf_application.js
+++ b/app/assets/javascripts/shf_application.js
@@ -3,11 +3,10 @@ $(function() {
 
   // Successful delete of file attached to application
   $('body').on('ajax:complete', 'a[class="action-delete"]', function (e, response) {
-    var data = JSON.parse(response.responseText);
 
-    if (data.status !== 'ok') {
-      alert('Something went wrong. Please reload page and try again.');
-    } else {
+    if (Utility.handleError(e, response) === false) {
+      var data = JSON.parse(response.responseText);
+
       $('#uploaded-files').html(data.uploaded_html);
       $('[data-toggle="tooltip"]').tooltip();
     }

--- a/app/assets/javascripts/shf_application.js
+++ b/app/assets/javascripts/shf_application.js
@@ -1,6 +1,18 @@
 $(function() {
   'use strict';
 
+  // Successful delete of file attached to application
+  $('body').on('ajax:complete', 'a[class="action-delete"]', function (e, response) {
+    var data = JSON.parse(response.responseText);
+
+    if (data.status !== 'ok') {
+      alert('Something went wrong. Please reload page and try again.');
+    } else {
+      $('#uploaded-files').html(data.uploaded_html);
+      $('[data-toggle="tooltip"]').tooltip();
+    }
+  });
+
   // Check to see if any file delivery radio button is selected -
   // if so, remove "disable" from submit button, hide explain text
   // if not, set callback function, on button change, to perform above actions

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -47,6 +47,21 @@ var Utility = {
       var hideStr = 'accordion_label.' + toggleId + '.hide';
       $(this).text(I18n.t(hideStr));
     }
+  },
+
+  handleError: function(event, response) {
+    console.log(response);
+    console.log(response.responseText);
+    console.log(response.statusText);
+
+    if (response.status !== 200 || (response.statusText !== 'OK')) {
+      // HTTP error or Action cannot be completed
+      event.stopPropagation();
+      alert(I18n.t('errors.something_wrong'));
+      return true;
+    }
+
+    return false;
   }
 
 };

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -50,9 +50,6 @@ var Utility = {
   },
 
   handleError: function(event, response) {
-    console.log(response);
-    console.log(response.responseText);
-    console.log(response.statusText);
 
     if (response.status !== 200 || (response.statusText !== 'OK')) {
       // HTTP error or Action cannot be completed

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -171,7 +171,7 @@ class CompaniesController < ApplicationController
 
     # XHR request from modal in ShfApplication create view (to create company)
     if saved
-      status = 'success'
+      status = 'ok'
       id = 'shf_application_company_number'
       value = @company.company_number
     else

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -113,22 +113,10 @@ class ShfApplicationsController < ApplicationController
         helpers.flash_message(:notice, t('.success'))
       end
 
-      respond_to do |format|
-        format.html { redirect_to define_path(evaluate_update(params)) }
-        format.js do
-          uploaded_html = render_to_string(partial: 'uploaded_files_list',
-                                           locals: { shf_application: @shf_application })
-          render json: { uploaded_html: uploaded_html, status: :ok }
-        end
-      end
-      # redirect_to define_path(evaluate_update(params))
+      redirect_to define_path(evaluate_update(params))
     else
-      respond_to do |format|
-        format.html { create_or_update_error(t('.error'), companies_and_numbers, numbers_str, :edit) }
-        format.js { render json: { status: :unprocessable_entity } }
-      end
 
-      # create_or_update_error(t('.error'), companies_and_numbers, numbers_str, :edit)
+      create_or_update_error(t('.error'), companies_and_numbers, numbers_str, :edit)
     end
   end
 
@@ -142,7 +130,6 @@ class ShfApplicationsController < ApplicationController
           render json: { uploaded_html: uploaded_html, status: :ok }
         end
       end
-      # redirect_to define_path(evaluate_update(params))
     else
       respond_to do |format|
         format.js { render json: { status: :unprocessable_entity } }

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -113,10 +113,24 @@ class ShfApplicationsController < ApplicationController
         helpers.flash_message(:notice, t('.success'))
       end
 
-      redirect_to define_path(evaluate_update(params))
+      respond_to do |format|
+        format.html { redirect_to define_path(evaluate_update(params)) }
+        format.js do
+          uploaded_html = render_to_string(partial: 'uploaded_files_list',
+                                           locals: { shf_application: @shf_application })
+
+          render json: { uploaded_html: uploaded_html, status: :ok }
+        end
+      end
     else
 
-      create_or_update_error(t('.error'), companies_and_numbers, numbers_str, :edit)
+      respond_to do |format|
+        format.html { create_or_update_error(t('.error'),
+                                             companies_and_numbers,
+                                             numbers_str, :edit) }
+
+        format.js { render json: { status: :internal_server_error } }
+      end
     end
   end
 

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -118,18 +118,34 @@ class ShfApplicationsController < ApplicationController
         format.js do
           uploaded_html = render_to_string(partial: 'uploaded_files_list',
                                            locals: { shf_application: @shf_application })
-
           render json: { uploaded_html: uploaded_html, status: :ok }
         end
       end
+      # redirect_to define_path(evaluate_update(params))
     else
+      respond_to do |format|
+        format.html { create_or_update_error(t('.error'), companies_and_numbers, numbers_str, :edit) }
+        format.js { render json: { status: :unprocessable_entity } }
+      end
+
+      # create_or_update_error(t('.error'), companies_and_numbers, numbers_str, :edit)
+    end
+  end
+
+  def remove_attachment
+    if @shf_application.update(shf_application_params)
 
       respond_to do |format|
-        format.html { create_or_update_error(t('.error'),
-                                             companies_and_numbers,
-                                             numbers_str, :edit) }
-
-        format.js { render json: { status: :internal_server_error } }
+        format.js do
+          uploaded_html = render_to_string(partial: 'uploaded_files_list',
+                                           locals: { shf_application: @shf_application })
+          render json: { uploaded_html: uploaded_html, status: :ok }
+        end
+      end
+      # redirect_to define_path(evaluate_update(params))
+    else
+      respond_to do |format|
+        format.js { render json: { status: :unprocessable_entity } }
       end
     end
   end

--- a/app/policies/shf_application_policy.rb
+++ b/app/policies/shf_application_policy.rb
@@ -67,6 +67,10 @@ class ShfApplicationPolicy < ApplicationPolicy
     user == record.user && EDITABLE_STATES_FOR_APPLICATION.include?(record.state.to_sym)
   end
 
+  def remove_attachment?
+    admin_or_owner?
+  end
+
   def update_reason_waiting?
     update?
   end

--- a/app/views/shf_applications/_uploaded_files_list.html.haml
+++ b/app/views/shf_applications/_uploaded_files_list.html.haml
@@ -1,6 +1,4 @@
 .uploaded-files#uploaded-files
-  - warning = content_tag(:p, icon('far', 'warning') + t('shf_applications.uploads.no_files'))
-
 
   - if shf_application.uploaded_files.count < 1
 
@@ -29,4 +27,10 @@
             - if show_delete
               %td{ class: "delete-uploaded-file-#{uploaded_file.id}" }
                 - trash_icon = icon('fas', 'trash')
-                = link_to trash_icon, shf_application_path(shf_application.id, shf_application: { uploaded_files_attributes: { id: uploaded_file.id,  '_destroy' => true }}), method: :put, id: "uploaded-file-#{uploaded_file.id}", class: "action-delete", data: { confirm: "#{t('shf_applications.uploads.confirm_delete', filename: uploaded_file.actual_file_file_name)}" }
+                = link_to trash_icon,
+                          shf_application_path(shf_application.id,
+                                               shf_application: { uploaded_files_attributes: { id: uploaded_file.id,  '_destroy' => true }}),
+                          method: :put, remote: true,
+                          id: "uploaded-file-#{uploaded_file.id}",
+                          class: "action-delete",
+                          data: { confirm: "#{t('shf_applications.uploads.confirm_delete', filename: uploaded_file.actual_file_file_name)}" }

--- a/app/views/shf_applications/_uploaded_files_list.html.haml
+++ b/app/views/shf_applications/_uploaded_files_list.html.haml
@@ -28,8 +28,8 @@
               %td{ class: "delete-uploaded-file-#{uploaded_file.id}" }
                 - trash_icon = icon('fas', 'trash')
                 = link_to trash_icon,
-                          shf_application_path(shf_application.id,
-                                               shf_application: { uploaded_files_attributes: { id: uploaded_file.id,  '_destroy' => true }}),
+                          remove_attachment_shf_application_path(shf_application.id,
+                            shf_application: { uploaded_files_attributes: { id: uploaded_file.id,  '_destroy' => true }}),
                           method: :put, remote: true,
                           id: "uploaded-file-#{uploaded_file.id}",
                           class: "action-delete",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1359,6 +1359,7 @@ en:
     not_permitted: You are not authorized to access that page.
     try_login: Login first and then retry accessing that page.
     bad_search_params: "Sorry.  We could not search for %{search_item} with those critera.  Please try again."
+    something_wrong: 'Something went wrong - please reload page and try again.'
     format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1358,6 +1358,7 @@ sv:
     try_login: Logga in först och försök igen med den sidan.
     format: "%{attribute} %{message}"
     bad_search_params: "Förlåt. Vi kunde inte söka efter %{search_item} med dessa kriterier. Var god försök igen."
+    something_wrong: 'Något gick fel - vänligen ladda om sidan och försök igen.'
     messages:
       accepted: måste accepteras
       blank: måste anges

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,8 @@ Rails.application.routes.draw do
 
     resources :shf_applications, path: 'ansokan' do
       member do
+        put 'remove_attachment'
+
         put 'update-reason-waiting', to: 'shf_applications#update_reason_waiting',
             as: 'reason_waiting'
 

--- a/features/edit_shf_application.feature
+++ b/features/edit_shf_application.feature
@@ -94,14 +94,14 @@ Feature: Edit SHF Application
     And I should not see t("shf_applications.update.success_with_app_files_missing")
 
     @selenium
-    Scenario: User deletes uploaded file
+    Scenario: User deletes uploaded files
       Given I am logged in as "emma@random.com"
       And I am on the "user instructions" page
       And I click on first t("menus.nav.users.my_application") link
       Then I should be on "Edit My Application" page
 
       And I select files delivery radio button "upload_now"
-      And I choose a file named "diploma.pdf" to upload
+      And I choose files named "diploma.pdf, image.jpg" to upload
 
       And I click on t("shf_applications.edit.submit_button_label")
       Then I should be on the "show my application" page for "emma@random.com"
@@ -112,9 +112,16 @@ Feature: Edit SHF Application
       And I click on first t("menus.nav.users.my_application") link
       Then I should be on "Edit My Application" page
 
-      And I delete the first uploaded file
+      And I delete the second uploaded file
+      And I should not see "image.jpg"
 
+      And I should be on "Edit My Application" page
+
+      And I should see "diploma.pdf"
+
+      And I delete the first uploaded file
       And I should not see "diploma.pdf"
+
       And I should see t("shf_applications.uploads.no_files")
 
 

--- a/features/edit_shf_application.feature
+++ b/features/edit_shf_application.feature
@@ -78,7 +78,7 @@ Feature: Edit SHF Application
     And I should see "5560360793, 2120000142"
 
   @selenium
-  Scenario: Files uploaded, user sees success and does not deliver-files prompt
+  Scenario: Files uploaded, user sees success and does not see deliver-files prompt
     Given I am logged in as "emma@random.com"
     And I am on the "user instructions" page
     And I click on first t("menus.nav.users.my_application") link
@@ -92,6 +92,31 @@ Feature: Edit SHF Application
 
     And I should see t("shf_applications.update.success")
     And I should not see t("shf_applications.update.success_with_app_files_missing")
+
+    @selenium
+    Scenario: User deletes uploaded file
+      Given I am logged in as "emma@random.com"
+      And I am on the "user instructions" page
+      And I click on first t("menus.nav.users.my_application") link
+      Then I should be on "Edit My Application" page
+
+      And I select files delivery radio button "upload_now"
+      And I choose a file named "diploma.pdf" to upload
+
+      And I click on t("shf_applications.edit.submit_button_label")
+      Then I should be on the "show my application" page for "emma@random.com"
+
+      And I should see t("shf_applications.update.success")
+      And I should not see t("shf_applications.update.success_with_app_files_missing")
+
+      And I click on first t("menus.nav.users.my_application") link
+      Then I should be on "Edit My Application" page
+
+      And I delete the first uploaded file
+
+      And I should not see "diploma.pdf"
+      And I should see t("shf_applications.uploads.no_files")
+
 
   @selenium @skip_ci_test
   Scenario: Create 2nd company, file delivery via email, user sees success and deliver-files reminder

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -100,14 +100,6 @@ When "I select files delivery radio button {capture_string}" do |option|
 
 end
 
-When "I delete the{optional_string} uploaded file" do |ordinal|
-  index = ordinal ? [0, 1, 2, 3, 4].send(ordinal.lstrip) : 0
-
-  page.driver.accept_modal(:confirm, wait: 4) do
-    all("a[class='action-delete']")[index].click
-  end
-end
-
 And "I should see {capture_string} files for the {capture_string} listed application" do |count, ordinal|
   # Use to confirm uploaded files count in ShfApplication index view
   # If more than one app then make sure the sort order supports the test step.

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -100,6 +100,14 @@ When "I select files delivery radio button {capture_string}" do |option|
 
 end
 
+When "I delete the{optional_string} uploaded file" do |ordinal|
+  index = ordinal ? [0, 1, 2, 3, 4].send(ordinal.lstrip) : 0
+
+  page.driver.accept_modal(:confirm, wait: 4) do
+    all("a[class='action-delete']")[index].click
+  end
+end
+
 And "I should see {capture_string} files for the {capture_string} listed application" do |count, ordinal|
   # Use to confirm uploaded files count in ShfApplication index view
   # If more than one app then make sure the sort order supports the test step.

--- a/features/step_definitions/upload_steps.rb
+++ b/features/step_definitions/upload_steps.rb
@@ -4,8 +4,8 @@ When(/^I choose (?:a file|files) named "([^"]*)" to upload$/) do | filename |
   filenames.each do |file|
     filepaths << File.join(Rails.root, 'spec', 'fixtures','uploaded_files', file)
   end
-  # page.attach_file "uploaded_file[actual_files][]", File.join(Rails.root, 'spec', 'fixtures','uploaded_files', filename), visible: false #selenium won't find the upload button without visible: false
-  page.attach_file "uploaded_file[actual_files][]", filepaths, visible: false #selenium won't find the upload button without visible: false
+  page.attach_file "uploaded_file[actual_files][]", filepaths, visible: false
+  # ^^ selenium won't find the upload button without visible: false
 end
 
 And(/^I should( not)? see "([^"]*)" uploaded for this membership application$/) do |negate, filename|

--- a/features/step_definitions/upload_steps.rb
+++ b/features/step_definitions/upload_steps.rb
@@ -1,5 +1,11 @@
-When(/^I choose a file named "([^"]*)" to upload$/) do | filename |
-  page.attach_file "uploaded_file[actual_files][]", File.join(Rails.root, 'spec', 'fixtures','uploaded_files', filename), visible: false #selenium won't find the upload button without visible: false
+When(/^I choose (?:a file|files) named "([^"]*)" to upload$/) do | filename |
+  filenames = filename.split(/\s*,\s*/)
+  filepaths = []
+  filenames.each do |file|
+    filepaths << File.join(Rails.root, 'spec', 'fixtures','uploaded_files', file)
+  end
+  # page.attach_file "uploaded_file[actual_files][]", File.join(Rails.root, 'spec', 'fixtures','uploaded_files', filename), visible: false #selenium won't find the upload button without visible: false
+  page.attach_file "uploaded_file[actual_files][]", filepaths, visible: false #selenium won't find the upload button without visible: false
 end
 
 And(/^I should( not)? see "([^"]*)" uploaded for this membership application$/) do |negate, filename|
@@ -23,4 +29,12 @@ end
 
 Then(/^I should( not)? see the file delete action$/) do | negate |
   expect(page).send (negate ? :not_to : :to), have_xpath("//th[contains(., #{I18n.t('delete')})][@class='action']")
+end
+
+When "I delete the{optional_string} uploaded file" do |ordinal|
+  index = ordinal ? [0, 1, 2, 3, 4].send(ordinal.lstrip) : 0
+
+  page.driver.accept_modal(:confirm, wait: 4) do
+    all("a[class='action-delete']")[index].click
+  end
 end

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -79,7 +79,7 @@ Feature: Applicant uploads a file for their application
   Scenario: Upload multiple files at one time (multiple select)
     Given I am logged in as "applicant_1@random.com"
     And I am on the "edit my application" page
-    When I choose the files named ["picture.jpg", "picture.png", "diploma.pdf"] to upload
+    When I choose files named "picture.jpg, picture.png, diploma.pdf" to upload
     And I click on t("shf_applications.edit.submit_button_label")
     Then I should see t("shf_applications.uploads.files_uploaded")
     And I should see "diploma.pdf" uploaded for this membership application
@@ -122,12 +122,14 @@ Feature: Applicant uploads a file for their application
     And I am logged in as "admin@shf.com"
     And I am on the "application" page for "applicant_1@random.com"
     Then I click on t("shf_applications.ask_applicant_for_info_btn")
-    And  I am logged in as "applicant_1@random.com"
+    And I am logged in as "applicant_1@random.com"
     And I am on the "edit my application" page
+
     And I click on trash icon for "diploma.pdf"
     And I confirm popup
+
     Then I should not see "diploma.pdf" uploaded for this membership application
-    And I should see t("shf_applications.update.success_with_app_files_missing")
+    And I should see t("shf_applications.uploads.no_files")
 
   @selenium
   Scenario: User uploads a file to an existing membership application

--- a/spec/models/conditions_response/company_email_alert_spec.rb
+++ b/spec/models/conditions_response/company_email_alert_spec.rb
@@ -86,6 +86,12 @@ RSpec.describe CompanyEmailAlert do
       subject.create_alert_logger(log)
     end
 
+    around(:each) do |example|
+      Timecop.freeze(jan1)
+      example.run
+      Timecop.return
+    end
+
 
     context 'successful' do
 
@@ -165,12 +171,16 @@ RSpec.describe CompanyEmailAlert do
 
 
   it '.company_recipients returns all current_members' do
+    Timecop.freeze(jan1)
+
     member1_c2_exp_jun6
     member2_c2_exp_jun1
     expect(subject.company_recipients(c2_2_members)).to match_array([member1_c2_exp_jun6, member2_c2_exp_jun1])
+
+    Timecop.return
   end
 
-  
+
   it '.success_str returns a string with member and company info' do
     expect(subject.success_str(c1_all_paid, member1_c1_exp_jun6))
         .to eq "to user id: #{member1_c1_exp_jun6.id} email: #{member1_c1_exp_jun6.email} company id: #{c1_all_paid.id} name: company1"


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/166328362


Changes proposed in this pull request:
1. File delete action is handled as an AJAX request
2. The app form is not submitted, and the user stays in the form
3. The "uploaded file" section of the page is updated

Update June 1:
4. Fixed unit tests that were failing due to time-dependent logic that started to fail _today_.  Fixed with Timecop.

Update June 3 - made changes prompted by @weedySeaDragon (spot-on) review comments:

5. Create a separate controller action for the removal of an attached file
6. Refactored JS error handling for callbacks used for applications and companies controllers


Ready for review:
@AgileVentures/shf-project-team 