### PR TITLE
Condition processing continues after condition exception

### DIFF
--- a/lib/tasks/conditions/process_conditions.rake
+++ b/lib/tasks/conditions/process_conditions.rake
@@ -51,6 +51,7 @@ namespace :shf do
       #      log the error and continue with condition processing.
       #      (If Slack connection is up, we'll have already notified via that).
       rescue StandardError => e
+        log.error("Class: #{class_name}")
         log.error("Exception: #{e}:  #{e.inspect}")
         next
       end

--- a/lib/tasks/conditions/process_conditions.rake
+++ b/lib/tasks/conditions/process_conditions.rake
@@ -38,7 +38,7 @@ namespace :shf do
           process_klass(klass, condition, log)
         end
 
-      # If the problem is because of Slack Notification, log it and continue.
+      # If the problem is because of Slack Notification .... log it and continue.
       # Do not let it stop the processing.
       rescue Slack::Notifier::APIError => slack_error
         use_slack_notification = false
@@ -47,9 +47,12 @@ namespace :shf do
         log.error('Retrying the previous condition...')
         retry
 
+      # .... Otherwise, an exception was raised during condition processing -
+      #      log the error and continue with condition processing.
+      #      (If Slack connection is up, we'll have already notified via that).
       rescue StandardError => e
         log.error("Exception: #{e}:  #{e.inspect}")
-        raise
+        next
       end
     end
   end

--- a/spec/tasks/conditions/process_conditions_rake_spec.rb
+++ b/spec/tasks/conditions/process_conditions_rake_spec.rb
@@ -6,34 +6,79 @@ RSpec.describe 'conditions/process_conditions shf:process_conditions', type: :ta
 
   include_context 'rake'
 
+  EXPECTED_PROCESSING_EXCEPTION_LOG_ENTRY = 'Exception: uninitialized constant ' +
+                                            'AnInvalidClass:  #<NameError: ' +
+                                            'uninitialized constant AnInvalidClass>'
+
+  EXPECTED_SLACK_EXCEPTION_LOG_ENTRIES =
+      [
+        'Slack::Notifier::APIError Exception:',
+        'Slack Notifications turned off! Condition processing continuing without it.',
+        'Retrying the previous condition...'
+      ]
+
   let(:filepath) { LogfileNamer.name_for(Condition) }
 
   before(:each) do
     File.delete(filepath) if File.file?(filepath)
   end
 
-  let(:test_conditions) do
-    [{ class_name: 'MembershipLapsedAlert',
+  let(:valid_conditions) do
+    [{ class_name: 'HBrandingFeeDueAlert',
+       timing:     :after,
+       config:     { days: [2, 9, 14, 30, 60] } },
+     { class_name: 'HBrandingFeeWillExpireAlert',
+        timing:     :before,
+        config:     { days: [2, 9, 14, 30, 60] } }
+    ]
+  end
+
+  let(:invalid_condition) do
+    [{ class_name: 'AnInvalidClass', # must sort _before_ other (valid) condition class names
        timing:     :after,
        config:     { days: [2, 9, 14, 30, 60] } },
     ]
   end
 
+  describe 'normal processing' do
 
-  describe 'failures' do
+    before(:each) { Condition.create!(valid_conditions) }
 
-    before(:each) do
+    it 'logs all conditions processed and indicates no errors' do
+      output_loaded_condition_info
 
-      # load the condition(s)
-      if Condition.create(test_conditions)
-        puts "  #{test_conditions.size} Conditions were loaded into the db: #{test_conditions.map { |h_cond| h_cond[:class_name] }.join(', ')}"
+      # stub out the Slack notification methods
+      allow(SHFNotifySlack).to receive(:notification)
+                                   .and_return(true)
+
+      # should never create a SlackNotifier during this test
+      expect(Slack::Notifier).not_to receive(:new)
+
+      # precondition: log file should not exist
+      expect(File.exist?(filepath)).to be false
+
+      expect { subject.invoke }.not_to raise_error
+
+      # post-conditions:
+      # 1) Log file indicates all conditions were processed successfully
+      valid_conditions.each do |condition|
+        expect(File.read(filepath)).to include("[info] #{condition[:class_name]}")
       end
-    end
 
+      # 1) Log file does not contain error message(s)
+      expect(File.read(filepath)).not_to include('[error]')
+    end
+  end
+
+  describe 'exception handling' do
+
+    before(:each) { Condition.create!(valid_conditions) }
 
     describe 'Slack Notification failure' do
 
-      it 'logs the error but keeps going' do
+      it 'logs the notification error but keeps processing all conditions' do
+
+        output_loaded_condition_info
 
         # Slack notification error will be raised:
         allow(SHFNotifySlack).to receive(:notification)
@@ -42,39 +87,32 @@ RSpec.describe 'conditions/process_conditions shf:process_conditions', type: :ta
         # should never create a SlackNotifier during this test
         expect(Slack::Notifier).not_to receive(:new)
 
-        # precondition:
-        # log should not have the Exception info
-        if File.exist?(filepath)
-          expect(File.read(filepath))
-              .not_to include 'Slack::Notifier::APIError Exception:'
-          expect(File.read(filepath))
-              .not_to include 'Slack Notifications turned off! Condition processing continuing without it.'
-          expect(File.read(filepath))
-              .not_to include 'Retrying the previous condition...'
-        end
+        # precondition: log file should not exist
+        expect(File.exist?(filepath)).to be false
 
-        # the error will not percolate up and be rasied; processing continues
+        # the error will not percolate up and be raised; processing continues
         expect { subject.invoke }.not_to raise_error
 
-        # post-condition:
-        # log should have the Exception info
-        expect(File.read(filepath))
-            .to include 'Slack::Notifier::APIError Exception:'
-        expect(File.read(filepath))
-            .to include 'Slack Notifications turned off! Condition processing continuing without it.'
-        expect(File.read(filepath))
-            .to include 'Retrying the previous condition...'
+        # post-conditions:
+        # 1) log should have the Slack Notification Exception info
+        EXPECTED_SLACK_EXCEPTION_LOG_ENTRIES.each do |msg|
+          expect(File.read(filepath)).to include msg
+        end
+
+        # 2) All conditions were processed successfully
+        valid_conditions.each do |condition|
+          expect(File.read(filepath)).to include("[info] #{condition[:class_name]}")
+        end
       end
 
     end
 
-    describe 'any other failure will stop processing' do
+    describe 'processing failure does not stop other condition processing' do
 
-      it 'logs the error and raises the error' do
+      it 'logs the processing error and continues with other conditions' do
 
-        # error that will be raised:
-        allow_any_instance_of(MembershipLapsedAlert).to receive(:condition_response)
-                                                            .and_raise(EOFError)
+        Condition.create!(invalid_condition)
+        output_loaded_condition_info
 
         # stub out the Slack notification methods
         allow(SHFNotifySlack).to receive(:notification)
@@ -83,24 +121,66 @@ RSpec.describe 'conditions/process_conditions shf:process_conditions', type: :ta
         # should never create a SlackNotifier during this test
         expect(Slack::Notifier).not_to receive(:new)
 
-        expected_exception_log_entry = 'Exception: EOFError:  #<EOFError: EOFError>'
+        # precondition: log file should not exist
+        expect(File.exist?(filepath)).to be false
 
-        # precondition:
-        # log should not have the Exception
-        if File.exist?(filepath)
-          expect(File.read(filepath))
-              .not_to include expected_exception_log_entry
-        end
+        expect { subject.invoke }.not_to raise_error
 
-        expect { subject.invoke }.to raise_error EOFError
-
-        # post-condition:
-        # log should have the Exception
+        # post-conditions:
+        # 1) Log should have the processing Exception info
         expect(File.read(filepath))
-            .to include expected_exception_log_entry
+            .to include EXPECTED_PROCESSING_EXCEPTION_LOG_ENTRY
+
+        # 2) Log file indicates other conditions were processed successfully
+        valid_conditions.each do |condition|
+          expect(File.read(filepath)).to include("[info] #{condition[:class_name]}")
+        end
       end
 
     end
+
+    describe 'processing AND slack notification failures does not stop condition processing' do
+
+      it 'retries condition after Slack error, logs condition error and continues with remaining conditions' do
+
+        Condition.create!(invalid_condition)
+        output_loaded_condition_info
+
+        # Slack notification error that will be raised:
+        allow(SHFNotifySlack).to receive(:notification)
+                             .and_raise(Slack::Notifier::APIError)
+
+        # should never create a SlackNotifier during this test
+        expect(Slack::Notifier).not_to receive(:new)
+
+        # precondition: log file should not exist
+        expect(File.exist?(filepath)).to be false
+
+        expect { subject.invoke }.not_to raise_error
+
+        # post-conditions:
+        # 1) Log should have the processing Exception info
+        expect(File.read(filepath))
+            .to include EXPECTED_PROCESSING_EXCEPTION_LOG_ENTRY
+
+        # 2) Log should have the Slack Notification Exception info
+        EXPECTED_SLACK_EXCEPTION_LOG_ENTRIES.each do |msg|
+          expect(File.read(filepath)).to include msg
+        end
+
+        # 3) Log file indicates other conditions were processed successfully
+        valid_conditions.each do |condition|
+          expect(File.read(filepath)).to include("[info] #{condition[:class_name]}")
+        end
+
+      end
+
+    end
+
+  end
+
+  def output_loaded_condition_info
+    puts "      #{Condition.count} conditions were loaded into the db: #{Condition.order(:class_name).map { |h_cond| h_cond[:class_name] }.join(', ')}"
   end
 
 end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/165559677

Changes proposed in this pull request:
1. In condition processing, continue to `next` condition from rescue clause for condition exception
2. Expanded tests for various scenarios.

Screenshots (Optional):


Ready for review:
@AgileVentures/shf-project-team 