### PR TITLE
HOTFIX: Backups: need to provide the full target name for the backup (e.g. <....>.tar.<date>.gz)

### DIFF
--- a/app/models/conditions_response/backup.rb
+++ b/app/models/conditions_response/backup.rb
@@ -325,7 +325,7 @@ class Backup < ConditionResponder
   #
   def self.log_and_notify(error, log, additional_info = '')
 
-    log_string = additional_info&.empty? ? error.to_s : "#{error} #{additional_info}"
+    log_string = additional_info.blank? ? error.to_s : "#{error} #{additional_info}"
 
     log.error(log_string)
     SHFNotifySlack.failure_notification(self.name, text: log_string)

--- a/app/models/shf_notify_slack.rb
+++ b/app/models/shf_notify_slack.rb
@@ -26,6 +26,7 @@ class SHFNotifySlack
   SLACK_FAIL_EMOJI    = ':x:'
   SUCCESS_TEXT        = 'Successful'
   FAILURE_TEXT        = 'Failure!'
+  UNKNOWN_FAILURE     = 'Some unknown failure!'
 
   FOOTER_PREFIX = 'SHF'
 
@@ -66,10 +67,10 @@ class SHFNotifySlack
   end
 
 
-  def self.failure_notification(notification_source, text: FAILURE_TEXT,
+  def self.failure_notification(notification_source, text: UNKNOWN_FAILURE,
       emoji: SLACK_FAIL_EMOJI)
 
-    self.notification(notification_source, text,
+    self.notification(notification_source, "#{failure_word} #{text}",
                       emoji: emoji,
                       color: SLACK_FAIL_COLOR)
   end

--- a/app/models/shf_notify_slack.rb
+++ b/app/models/shf_notify_slack.rb
@@ -132,5 +132,15 @@ class SHFNotifySlack
     "#{FOOTER_PREFIX}: #{f_text}"
   end
 
+
+  def self.failure_word
+    FAILURE_TEXT
+  end
+
+
+  def self.successful_word
+    SUCCESS_TEXT
+  end
+
 end # SHFNotifySlack
 

--- a/spec/models/conditions_response/backup_makers_spec.rb
+++ b/spec/models/conditions_response/backup_makers_spec.rb
@@ -16,9 +16,11 @@ RSpec.describe AbstractBackupMaker do
       expect(subject.backup_sources).to eq []
     end
 
-    it 'default backup target base filename = backup-<class name>-<DateTime.current>.tar' do
-      expect(subject.target_filename).to match(/backup-AbstractBackupMaker\.tar/)
+    it 'base_filename = backup-<class name>-<DateTime.current>.tar' do
+      expect(subject.base_filename).to match(/backup-AbstractBackupMaker\.tar/)
     end
+
+
 
     describe 'shell_cmd' do
 
@@ -49,8 +51,8 @@ RSpec.describe FilesBackupMaker do
 
     let(:backup_using_defaults) { FilesBackupMaker.new }
 
-    it 'default backup target base filename = backup-FilesBackupMaker.tar' do
-      expect(subject.target_filename).to eq 'backup-FilesBackupMaker.tar'
+    it 'base_filename = backup-FilesBackupMaker.tar' do
+      expect(subject.base_filename).to eq 'backup-FilesBackupMaker.tar'
     end
 
 
@@ -145,8 +147,8 @@ RSpec.describe CodeBackupMaker do
 
   describe 'Unit tests' do
 
-    it 'default backup target base filename = current.tar' do
-      expect(subject.target_filename).to eq 'current.tar'
+    it 'base_filename = current.tar' do
+      expect(subject.base_filename).to eq 'current.tar'
     end
 
     it 'default sources = [/var/www/shf/current/]' do
@@ -183,8 +185,8 @@ RSpec.describe DBBackupMaker do
 
     let(:backup_using_defaults) { DBBackupMaker.new }
 
-    it 'default backup target base filename = db_backup.sql' do
-      expect(subject.target_filename).to eq 'db_backup.sql'
+    it 'base_filename = db_backup.sql' do
+      expect(subject.base_filename).to eq 'db_backup.sql'
     end
 
     it 'default sources = [DB_NAME]' do

--- a/spec/models/conditions_response/backup_makers_spec.rb
+++ b/spec/models/conditions_response/backup_makers_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe FilesBackupMaker do
       end
 
       it 'will fail unless sources are provided (tar will fail with an empty list)' do
-        expect{subject.backup}.to raise_error(ShfConditionError::BackupCommandNotSuccessfulError, /tar: no files or directories specified/)
+        expect{subject.backup}.to raise_error(ShfConditionError::BackupCommandNotSuccessfulError, /tar/)
       end
     end
 

--- a/spec/models/conditions_response/backup_makers_spec.rb
+++ b/spec/models/conditions_response/backup_makers_spec.rb
@@ -1,49 +1,12 @@
 # Specs for AbstractBackupMaker and subclasses
+# TODO break this up into separate files; break up the models/conditions_response/backup file, too
 
 require 'rails_helper'
-
 require_relative File.join(Rails.root, 'app/models/conditions_response/backup')
 
+require 'shared_examples/backup_maker_target_filename_with_default_spec'
 
-# =========================================================================
-# Shared examples
 
-RSpec.shared_examples 'it takes a backup target filename, with default =' do |default_filename|
-
-  before(:each) do
-    @temp_backup_sourcedir = Dir.mktmpdir('faux-code-dir')
-    @temp_backup_sourcefn1 = File.open(File.join(@temp_backup_sourcedir, 'some-sourcefile.txt'), 'w').path
-  end
-
-  describe 'target filename (the name of the backup file created)' do
-
-    it "default target backup file is '#{default_filename}'" do
-      files_backup = described_class.new(backup_sources: [@temp_backup_sourcefn1])
-      backup_created_fn = files_backup.backup
-
-      expect(backup_created_fn).to eq default_filename
-      expect(File.exist?(default_filename)).to be_truthy
-      File.delete(default_filename)
-    end
-
-    it 'can provide the name of the file' do
-      files_backup = described_class.new(backup_sources: [@temp_backup_sourcefn1])
-
-      target_dir = Dir.mktmpdir('backup-target-dir')
-      given_backup_target_fn = File.join(target_dir, 'some_filename.tar.zzzx')
-
-      files_backup.backup(target: given_backup_target_fn)
-
-      expect(File.exist?(given_backup_target_fn)).to be_truthy
-      File.delete(given_backup_target_fn)
-    end
-
-  end
-
-end
-
-# =========================================================================
-# =========================================================================
 
 RSpec.describe AbstractBackupMaker do
 
@@ -76,9 +39,7 @@ RSpec.describe AbstractBackupMaker do
       expect { subject.backup }.to raise_error(NoMethodError, 'Subclass must define the backup method')
     end
 
-
   end
-
 end
 
 

--- a/spec/models/conditions_response/backup_spec.rb
+++ b/spec/models/conditions_response/backup_spec.rb
@@ -1,427 +1,639 @@
 require 'rails_helper'
 
 require 'shared_examples/shared_condition_specs'
-
+require 'shared_context/activity_logger'
 
 
 RSpec.describe Backup, type: :model do
 
-  let(:condition) { build(:condition, timing: Backup::TIMING_EVERY_DAY) }
-  let(:today) { Time.now.strftime '%Y-%m-%d' }
 
+  describe 'Acceptance tests' do
 
-  let(:today_timestamp) { Backup.today_timestamp }
-  let(:expected_bucket) { ENV['SHF_AWS_S3_BACKUP_BUCKET'] }
-  let(:expected_bucket_folder) { "production_backup/#{today_timestamp}/" }
-
-
-  def create_faux_backup_file(backups_dir, file_prefix)
-    File.open(File.join(backups_dir, "#{file_prefix}-faux-backup.bak"), 'w').path
-  end
-
-
-  describe '.backup_dir' do
-
-    it 'uses the backup_directory in the config' do
-      backup = build(:condition, :every_day, config: { backup_directory: 'blorf-dir' })
-      expect(described_class.backup_dir(backup.config)).to eq 'blorf-dir'
-    end
-
-    it 'if the dir in the config is not found, uses /home/deploy/SHF_BACKUPS/' do
-      backup = build(:condition, :every_day)
-      expect(described_class.backup_dir(backup.config)).to eq '/home/deploy/SHF_BACKUPS/'
-    end
-
-  end
-
-
-  describe '.backup_target_fn' do
-
-    it 'joins the given directory with the given filename, appends a timestamp and .gz to the base filename' do
-      timestamp = Time.now.strftime Backup::TIMESTAMP_FMT
-      expect(described_class.backup_target_fn('blorf-dir', 'blorf')).to eq(File.join('blorf-dir', "blorf#{timestamp}.gz"))
-    end
-
-  end
-
-
-  describe '.get_s3_objects' do
-
-    it 'requires ENV variables for the AWS credentials and region' do
-      expect(ENV.fetch('SHF_AWS_S3_BACKUP_BUCKET', nil)).not_to be_nil
-      expect(ENV.fetch('SHF_AWS_S3_BACKUP_REGION', nil)).not_to be_nil
-      expect(ENV.fetch('SHF_AWS_S3_BACKUP_KEY_ID', nil)).not_to be_nil
-      expect(ENV.fetch('SHF_AWS_S3_BACKUP_SECRET_ACCESS_KEY', nil)).not_to be_nil
-    end
-
-    it 'uses the argument as part of the bucket folder name' do
-      result = Backup.get_s3_objects('blorfo')
-      expect(result[2]).to eq "production_backup/blorfo/"
-    end
-
-    it 'uses Bucket.today_timestamp is no argument is given' do
-      result = Backup.get_s3_objects
-      expect(result[1]).to eq expected_bucket
-      expect(result[2]).to eq expected_bucket_folder
-    end
-
-    it 'returns array of [AWS S3 credentials, bucket, bucket_folder' do
-      result = Backup.get_s3_objects(today_timestamp)
-      expect(result[1]).to eq expected_bucket
-      expect(result[2]).to eq expected_bucket_folder
-    end
-
-  end
-
-
-  it '.upload_file_to_s3 calls .upload_file for the bucket, folder, and file to upload' do
-
-    temp_backups_dir = Dir.mktmpdir('faux-backups-dir')
-    faux_backup_fn = create_faux_backup_file(temp_backups_dir, 'faux_backup.bak')
-
-    expect_any_instance_of(Aws::S3::Object).to receive(:upload_file).with(faux_backup_fn).and_return(true)
-
-    aws_s3_resource, bucket, bucket_folder = Backup.get_s3_objects(today_timestamp)
-
-    Backup.upload_file_to_s3(aws_s3_resource, bucket, bucket_folder, faux_backup_fn)
-
-    FileUtils.remove_entry(temp_backups_dir, true)
-  end
-
-
-  it '.delete_excess_backup_files sorts based on filename, deleting those that come first' do
-
-    # create some faux backup files
-    temp_backups_dir = Dir.mktmpdir('faux-backups-dir')
-    backup_a0 = create_faux_backup_file(temp_backups_dir, 'a0')
-    backup_a1 = create_faux_backup_file(temp_backups_dir, 'a1')
-    backup_a2 = create_faux_backup_file(temp_backups_dir, 'a2')
-    backup_a3 = create_faux_backup_file(temp_backups_dir, 'a3')
-
-    expect(File.exist?(backup_a0)).to be_truthy
-    expect(File.exist?(backup_a1)).to be_truthy
-    expect(File.exist?(backup_a2)).to be_truthy
-    expect(File.exist?(backup_a3)).to be_truthy
-
-    Backup.delete_excess_backup_files("#{temp_backups_dir}/*.bak", 2)
-
-    expect(File.exist?(backup_a0)).to be_falsey
-    expect(File.exist?(backup_a1)).to be_falsey
-    expect(File.exist?(backup_a2)).to be_truthy
-    expect(File.exist?(backup_a3)).to be_truthy
-
-    FileUtils.remove_entry(temp_backups_dir, true)
-  end
-
-
-  describe '.condition_response' do
-
-    class FakeLogger
-      def self.record(*args)
-      end
-    end
-
-    let(:backup_config) { { class_name: 'Backup',
-                            timing: Backup::TIMING_EVERY_DAY,
-                            days_to_keep: { code_backup: 4,
-                                            db_backup: 15,
-                                            files_backup: 31 },
-                            backup_directory: nil,
-                            files: ['file1.txt', '/some/dir'] } }
-
-    let(:backup_condition) { build(:condition, config: backup_config, timing: Backup::TIMING_EVERY_DAY) }
-
+    include_context 'create logger'
 
     before(:each) do
-      @code_backup_maker = CodeBackupMaker.new(backup_target_filebase: 'code_backup_maker_target_file.tar')
-      @db_backup_maker1 = DBBackupMaker.new(backup_target_filebase: 'db_backup_maker_target_file.sql')
-      @db_backup_maker2 = DBBackupMaker.new(backup_target_filebase: 'another_db_backup_maker_target_file.flurb')
-      @file_backup_maker = FilesBackupMaker.new(backup_target_filebase: 'files_maker_target_file.tar',
-                                                backup_sources: ['file1.txt', 'file2.zip'])
-      @created_backup_makers = [
-          { backup_maker: @code_backup_maker, keep_num: 3 },
-          { backup_maker: @db_backup_maker1, keep_num: 2 },
-          { backup_maker: @db_backup_maker2, keep_num: 1 },
-          { backup_maker: @file_backup_maker, keep_num: 99 }
-      ]
 
-      # Individual tests below might change or set an expectation
-      allow_any_instance_of(AbstractBackupMaker).to receive(:shell_cmd)
-      allow(described_class).to receive(:validate_timing)
+      @logfilename = LogfileNamer.name_for(Condition)
+      File.delete(@logfilename) if File.exist?(@logfilename)
 
-      allow(described_class).to receive(:backup_dir)
-                                    .and_return('BACKUP_DIR')
-      allow(described_class).to receive(:create_backup_makers)
-                                    .and_return(@created_backup_makers)
-      allow(described_class).to receive(:backup_target_fn)
-                                    .and_return(%w(BACKUP_DIR/code_backup_maker_target_file.zzz BACKUP_DIR/db_backup_maker_target_file.sql BACKUP_DIR/another_db_backup_maker_target_file.flurb BACKUP_DIR/files_maker_target_file.tar))
 
-      allow(described_class).to receive(:get_s3_objects)
+      @faux_app_dir = Dir.mktmpdir('faux-app-dir')
+
+      # set up files to be backed up: make 2 notes files:
+      @notes_filenames = []
+      2.times do |i|
+        @notes_filenames[i] = File.join(@faux_app_dir, "notes-#{i}.txt")
+        File.open(@notes_filenames[i], 'w') do |f|
+          f.puts "notes #{i}"
+        end
+      end
+      @notes_sources = [@notes_filenames]
+
+      # create a faux code directory to be backed up
+      @code_dir = Dir.mktmpdir('faux-code')
+      @code_filenames = []
+      3.times do |i|
+        @code_filenames[i] = "faux_code#{i}.rb"
+        File.open(File.join(@code_dir, @code_filenames[i]), 'w') do |f|
+          f.puts "class FauxCode-#{i};  end"
+        end
+      end
+      @code_sources = [@code_dir]
+
+      # db to be backed up
+      @db_to_backup = 'shf_project_test'
+      @db_sources = [@db_to_backup]
+
+      allow_any_instance_of(CodeBackupMaker).to receive(:default_sources)
+                                                    .and_return(@code_sources)
+      allow_any_instance_of(DBBackupMaker).to receive(:default_sources)
+                                                  .and_return(@db_sources)
+      allow_any_instance_of(FilesBackupMaker).to receive(:default_sources)
+                                                     .and_return(@notes_sources)
+      # destination for the backup files
+      @backup_dir = Dir.mktmpdir('backup-dir')
+
+      # stub trying to actually do the AWS backup.
       allow(described_class).to receive(:upload_file_to_s3)
-      allow(described_class).to receive(:get_backup_files_pattern)
-      allow(described_class).to receive(:delete_excess_backup_files)
-    end
-
-    let(:expected_num_makers) { @created_backup_makers.size }
-
-
-    it_behaves_like 'it validates timings in .condition_response', [:every_day] do
-      let(:tested_condition) { condition }
     end
 
 
-    it 'gets the backup_dir from the configuration' do
-      expect(described_class).to receive(:backup_dir).with(backup_config).and_call_original
-      described_class.condition_response(backup_condition, FakeLogger)
+    after(:each) do
+      File.delete(@logfilename) if File.exist?(@logfilename)
     end
 
-    it 'creates backup makers given a configuration' do
-      expect(described_class).to receive(:create_backup_makers)
-                                     .with(backup_config).and_call_original
-      described_class.condition_response(backup_condition, FakeLogger)
+
+    let(:backup_condition) do
+      condition_info = { class_name: 'Backup',
+                         timing: :every_day,
+                         config: { days_to_keep: { code_backup: 2,
+                                                   db_backup: 5,
+                                                   files_backup: 31 },
+                                   backup_directory: @backup_dir,
+                                   files: @notes_sources } }
+
+      Condition.new(condition_info)
     end
 
-    describe 'with each backup maker, it:' do
+    let(:yy_mm_dd_timestr) { Time.now.strftime '%Y-%m-%d' }
+    let(:expected_aws_bucketname) { "production_backup/#{yy_mm_dd_timestr}/" }
 
-      it 'gets the maker backup file name and adds it to the list of backup files created' do
+    let(:code_backup_basefn) { 'current.tar' }
+    let(:code_backup_fname) { "#{code_backup_basefn}.#{yy_mm_dd_timestr}.gz" }
 
-        expect(described_class).to receive(:backup_target_fn)
-                                       .with('BACKUP_DIR', 'code_backup_maker_target_file.tar')
-        expect(described_class).to receive(:backup_target_fn)
-                                       .with('BACKUP_DIR', 'db_backup_maker_target_file.sql')
-        expect(described_class).to receive(:backup_target_fn)
-                                       .with('BACKUP_DIR', 'another_db_backup_maker_target_file.flurb')
-        expect(described_class).to receive(:backup_target_fn)
-                                       .with('BACKUP_DIR', 'files_maker_target_file.tar')
+    let(:db_backup_basefn) { 'db_backup.sql' }
+    let(:db_backup_fname) { "#{db_backup_basefn}.#{yy_mm_dd_timestr}.gz" }
 
+    let(:files_backup_basefn) { 'backup-FilesBackupMaker.tar' }
+    let(:files_backup_fname) { "#{files_backup_basefn}.#{yy_mm_dd_timestr}.gz" }
+
+
+    it 'does the backup - everything works (HAPPY PATH)' do
+
+      expect(described_class).to receive(:upload_file_to_s3)
+                                     .with(anything, anything, expected_aws_bucketname, File.join(@backup_dir, code_backup_fname))
+      expect(described_class).to receive(:upload_file_to_s3)
+                                     .with(anything, anything, expected_aws_bucketname, File.join(@backup_dir, db_backup_fname))
+      expect(described_class).to receive(:upload_file_to_s3)
+                                     .with(anything, anything, expected_aws_bucketname, File.join(@backup_dir, files_backup_fname))
+
+      expect(described_class).to receive(:delete_excess_backup_files)
+                                     .with("#{File.join(@backup_dir, code_backup_basefn)}.*", 2)
+      expect(described_class).to receive(:delete_excess_backup_files)
+                                     .with("#{File.join(@backup_dir, db_backup_basefn)}.*", 5)
+      expect(described_class).to receive(:delete_excess_backup_files)
+                                     .with("#{File.join(@backup_dir, files_backup_basefn)}.*", 31)
+
+      class_name = backup_condition.class_name
+      klass = class_name.constantize
+
+      ActivityLogger.open(@logfilename, 'SHF_TASK', 'Conditions') do |log|
+        log.info("#{class_name} ...")
+        klass.condition_response(backup_condition, log)
+      end
+
+      # no errors in the log file
+      expect(File.read(@logfilename)).not_to include('error')
+
+      # expect the backup files to be in the backup directory
+      expect(File.exist?(File.join(@backup_dir, code_backup_fname))).to be_truthy
+      expect(File.exist?(File.join(@backup_dir, db_backup_fname))).to be_truthy
+      expect(File.exist?(File.join(@backup_dir, files_backup_fname))).to be_truthy
+    end
+
+
+    describe 'errors happen - 1 error should not stop the entire backup' do
+
+      it 'one of the shell commands for the DBBackupMaker fails' do
+
+        allow_any_instance_of(DBBackupMaker).to receive(:shell_cmd)
+                                                    .with(/touch/)
+                                                    .and_raise(Errno::ENOENT, 'blorfo')
+
+        expect(described_class).to receive(:upload_file_to_s3)
+                                       .with(anything, anything, expected_aws_bucketname, File.join(@backup_dir, code_backup_fname))
+        expect(described_class).to receive(:upload_file_to_s3)
+                                       .with(anything, anything, expected_aws_bucketname, File.join(@backup_dir, db_backup_fname))
+        expect(described_class).to receive(:upload_file_to_s3)
+                                       .with(anything, anything, expected_aws_bucketname, File.join(@backup_dir, files_backup_fname))
+
+        expect(described_class).to receive(:delete_excess_backup_files)
+                                       .with("#{File.join(@backup_dir, code_backup_basefn)}.*", 2)
+        expect(described_class).to receive(:delete_excess_backup_files)
+                                       .with("#{File.join(@backup_dir, db_backup_basefn)}.*", 5)
+        expect(described_class).to receive(:delete_excess_backup_files)
+                                       .with("#{File.join(@backup_dir, files_backup_basefn)}.*", 31)
+
+        class_name = backup_condition.class_name
+        klass = class_name.constantize
+
+        ActivityLogger.open(@logfilename, 'SHF_TASK', 'Conditions') do |log|
+          log.info("#{class_name} ...")
+          klass.condition_response(backup_condition, log)
+        end
+
+        # There will be errors in the log file
+        expect(File.read(@logfilename)).to include('error')
+
+        # expect only the successful backup files to be in the backup directory
+        expect(File.exist?(File.join(@backup_dir, code_backup_fname))).to be_truthy
+        expect(File.exist?(File.join(@backup_dir, db_backup_fname))).to be_falsey
+        expect(File.exist?(File.join(@backup_dir, files_backup_fname))).to be_truthy
+      end
+
+
+      it 'writing to AWS fails for the code backup file' do
+        allow(described_class).to receive(:upload_file_to_s3)
+                                      .with(anything, anything, expected_aws_bucketname, File.join(@backup_dir, code_backup_fname))
+                                      .and_raise(NoMethodError)
+
+        expect(described_class).to receive(:upload_file_to_s3)
+                                       .with(anything, anything, expected_aws_bucketname, File.join(@backup_dir, db_backup_fname))
+        expect(described_class).to receive(:upload_file_to_s3)
+                                       .with(anything, anything, expected_aws_bucketname, File.join(@backup_dir, files_backup_fname))
+
+        expect(described_class).to receive(:delete_excess_backup_files)
+                                       .with("#{File.join(@backup_dir, code_backup_basefn)}.*", 2)
+        expect(described_class).to receive(:delete_excess_backup_files)
+                                       .with("#{File.join(@backup_dir, db_backup_basefn)}.*", 5)
+        expect(described_class).to receive(:delete_excess_backup_files)
+                                       .with("#{File.join(@backup_dir, files_backup_basefn)}.*", 31)
+
+        class_name = backup_condition.class_name
+        klass = class_name.constantize
+
+        ActivityLogger.open(@logfilename, 'SHF_TASK', 'Conditions') do |log|
+          log.info("#{class_name} ...")
+          klass.condition_response(backup_condition, log)
+        end
+
+        # There will be errors in the log file
+        expect(File.read(@logfilename)).to include('error')
+
+        # expect the backup files to be in the backup directory
+        expect(File.exist?(File.join(@backup_dir, code_backup_fname))).to be_truthy
+        expect(File.exist?(File.join(@backup_dir, db_backup_fname))).to be_truthy
+        expect(File.exist?(File.join(@backup_dir, files_backup_fname))).to be_truthy
+      end
+
+    end
+
+  end
+
+
+  describe 'Unit tests' do
+
+
+    let(:condition) { build(:condition, timing: Backup::TIMING_EVERY_DAY) }
+    let(:today) { Time.now.strftime '%Y-%m-%d' }
+
+
+    let(:today_timestamp) { Backup.today_timestamp }
+    let(:expected_bucket) { ENV['SHF_AWS_S3_BACKUP_BUCKET'] }
+    let(:expected_bucket_folder) { "production_backup/#{today_timestamp}/" }
+
+
+    def create_faux_backup_file(backups_dir, file_prefix)
+      File.open(File.join(backups_dir, "#{file_prefix}-faux-backup.bak"), 'w').path
+    end
+
+
+    describe '.backup_dir' do
+
+      it 'uses the backup_directory in the config' do
+        backup = build(:condition, :every_day, config: { backup_directory: 'blorf-dir' })
+        expect(described_class.backup_dir(backup.config)).to eq 'blorf-dir'
+      end
+
+      it 'if the dir in the config is not found, uses /home/deploy/SHF_BACKUPS/' do
+        backup = build(:condition, :every_day)
+        expect(described_class.backup_dir(backup.config)).to eq '/home/deploy/SHF_BACKUPS/'
+      end
+
+    end
+
+
+    describe '.backup_target_fn' do
+
+      it 'joins the given directory with the given filename, appends "." + a timestamp and .gz to the base filename' do
+        timestamp = Time.now.strftime Backup::TIMESTAMP_FMT
+        expect(described_class.backup_target_fn('blorf-dir', 'blorf')).to eq(File.join('blorf-dir', "blorf.#{timestamp}.gz"))
+      end
+
+    end
+
+
+    describe '.get_s3_objects' do
+
+      it 'requires ENV variables for the AWS credentials and region' do
+        expect(ENV.fetch('SHF_AWS_S3_BACKUP_BUCKET', nil)).not_to be_nil
+        expect(ENV.fetch('SHF_AWS_S3_BACKUP_REGION', nil)).not_to be_nil
+        expect(ENV.fetch('SHF_AWS_S3_BACKUP_KEY_ID', nil)).not_to be_nil
+        expect(ENV.fetch('SHF_AWS_S3_BACKUP_SECRET_ACCESS_KEY', nil)).not_to be_nil
+      end
+
+      it 'uses the argument as part of the bucket folder name' do
+        result = Backup.get_s3_objects('blorfo')
+        expect(result[2]).to eq "production_backup/blorfo/"
+      end
+
+      it 'uses Bucket.today_timestamp is no argument is given' do
+        result = Backup.get_s3_objects
+        expect(result[1]).to eq expected_bucket
+        expect(result[2]).to eq expected_bucket_folder
+      end
+
+      it 'returns array of [AWS S3 credentials, bucket, bucket_folder' do
+        result = Backup.get_s3_objects(today_timestamp)
+        expect(result[1]).to eq expected_bucket
+        expect(result[2]).to eq expected_bucket_folder
+      end
+
+    end
+
+
+    it '.upload_file_to_s3 calls .upload_file for the bucket, folder, and file to upload' do
+
+      temp_backups_dir = Dir.mktmpdir('faux-backups-dir')
+      faux_backup_fn = create_faux_backup_file(temp_backups_dir, 'faux_backup.bak')
+
+      expect_any_instance_of(Aws::S3::Object).to receive(:upload_file).with(faux_backup_fn).and_return(true)
+
+      aws_s3_resource, bucket, bucket_folder = Backup.get_s3_objects(today_timestamp)
+
+      Backup.upload_file_to_s3(aws_s3_resource, bucket, bucket_folder, faux_backup_fn)
+
+      FileUtils.remove_entry(temp_backups_dir, true)
+    end
+
+
+    it '.delete_excess_backup_files sorts based on filename, deleting those that come first' do
+
+      # create some faux backup files
+      temp_backups_dir = Dir.mktmpdir('faux-backups-dir')
+      backup_a0 = create_faux_backup_file(temp_backups_dir, 'a0')
+      backup_a1 = create_faux_backup_file(temp_backups_dir, 'a1')
+      backup_a2 = create_faux_backup_file(temp_backups_dir, 'a2')
+      backup_a3 = create_faux_backup_file(temp_backups_dir, 'a3')
+
+      expect(File.exist?(backup_a0)).to be_truthy
+      expect(File.exist?(backup_a1)).to be_truthy
+      expect(File.exist?(backup_a2)).to be_truthy
+      expect(File.exist?(backup_a3)).to be_truthy
+
+      Backup.delete_excess_backup_files("#{temp_backups_dir}/*.bak", 2)
+
+      expect(File.exist?(backup_a0)).to be_falsey
+      expect(File.exist?(backup_a1)).to be_falsey
+      expect(File.exist?(backup_a2)).to be_truthy
+      expect(File.exist?(backup_a3)).to be_truthy
+
+      FileUtils.remove_entry(temp_backups_dir, true)
+    end
+
+
+    describe '.condition_response' do
+
+      class FakeLogger
+        def self.record(*args)
+        end
+      end
+
+      let(:backup_config) { { class_name: 'Backup',
+                              timing: Backup::TIMING_EVERY_DAY,
+                              days_to_keep: { code_backup: 4,
+                                              db_backup: 15,
+                                              files_backup: 31 },
+                              backup_directory: nil,
+                              files: ['file1.txt', '/some/dir'] } }
+
+      let(:backup_condition) { build(:condition, config: backup_config, timing: Backup::TIMING_EVERY_DAY) }
+
+
+      before(:each) do
+        @code_backup_maker = CodeBackupMaker.new(backup_target_filebase: 'code_backup_maker_target_file.tar')
+        @db_backup_maker1 = DBBackupMaker.new(backup_target_filebase: 'db_backup_maker_target_file.sql')
+        @db_backup_maker2 = DBBackupMaker.new(backup_target_filebase: 'another_db_backup_maker_target_file.flurb')
+        @file_backup_maker = FilesBackupMaker.new(backup_target_filebase: 'files_maker_target_file.tar',
+                                                  backup_sources: ['file1.txt', 'file2.zip'])
+        @created_backup_makers = [
+            { backup_maker: @code_backup_maker, keep_num: 3 },
+            { backup_maker: @db_backup_maker1, keep_num: 2 },
+            { backup_maker: @db_backup_maker2, keep_num: 1 },
+            { backup_maker: @file_backup_maker, keep_num: 99 }
+        ]
+
+        # Individual tests below might change or set an expectation
+        allow_any_instance_of(AbstractBackupMaker).to receive(:shell_cmd)
+        allow(described_class).to receive(:validate_timing)
+
+        allow(described_class).to receive(:backup_dir)
+                                      .and_return('BACKUP_DIR')
+        allow(described_class).to receive(:create_backup_makers)
+                                      .and_return(@created_backup_makers)
+        allow(described_class).to receive(:backup_target_fn)
+                                      .and_return(%w(BACKUP_DIR/code_backup_maker_target_file.zzz BACKUP_DIR/db_backup_maker_target_file.sql BACKUP_DIR/another_db_backup_maker_target_file.flurb BACKUP_DIR/files_maker_target_file.tar))
+
+        allow(described_class).to receive(:get_s3_objects)
+        allow(described_class).to receive(:upload_file_to_s3)
+        allow(described_class).to receive(:get_backup_files_pattern)
+        allow(described_class).to receive(:delete_excess_backup_files)
+      end
+
+      let(:expected_num_makers) { @created_backup_makers.size }
+
+
+      it_behaves_like 'it validates timings in .condition_response', [:every_day] do
+        let(:tested_condition) { condition }
+      end
+
+
+      it 'gets the backup_dir from the configuration' do
+        expect(described_class).to receive(:backup_dir).with(backup_config).and_call_original
         described_class.condition_response(backup_condition, FakeLogger)
       end
 
-      it "logs a message that it is 'Backing up to: <the backup file>'" do
-        allow(FakeLogger).to receive(:record).with('info', /Moving (.*)/)
-        allow(FakeLogger).to receive(:record).with('info', /Pruning (.*)/)
-
-        expect(FakeLogger).to receive(:record).with('info', /Backing up to: (.*)/)
-                                  .exactly(expected_num_makers).times
-
+      it 'creates backup makers given a configuration' do
+        expect(described_class).to receive(:create_backup_makers)
+                                       .with(backup_config).and_call_original
         described_class.condition_response(backup_condition, FakeLogger)
       end
 
-      it 'sends the backup method to each backup maker, which creates the backup file for the maker' do
-        expect(@code_backup_maker).to receive(:backup)
-        expect(@db_backup_maker1).to receive(:backup)
-        expect(@db_backup_maker2).to receive(:backup)
-        expect(@file_backup_maker).to receive(:backup)
+      describe 'with each backup maker, it:' do
 
-        described_class.condition_response(backup_condition, FakeLogger)
-      end
-    end
+        it 'gets the maker backup file name and adds it to the list of backup files created' do
 
-    it "logs a message that it is 'Moving backup files to AWS S3'" do
-      allow(FakeLogger).to receive(:record).with('info', /Backing up to: (.*)/)
-      allow(FakeLogger).to receive(:record).with('info', /Pruning (.*)/)
-
-      expect(FakeLogger).to receive(:record).with('info', /Moving (.*)/)
-      described_class.condition_response(backup_condition, FakeLogger)
-    end
-
-    it 'calls S3 credentials once' do
-      expect(described_class).to receive(:get_s3_objects)
-                                     .with(today).exactly(1).times
-
-      described_class.condition_response(condition, FakeLogger)
-    end
-
-    it 'calls upload to S3 once for each Backup maker ' do
-      # if no files are in the config, there are only 2 backup makers
-      expect(described_class).to receive(:upload_file_to_s3).exactly(expected_num_makers).times
-
-      described_class.condition_response(condition, FakeLogger)
-    end
-
-
-    describe 'finally it prunes older backups on local storage' do
-
-      it "logs a message that it is 'Pruning older backups on local storage'" do
-        allow(FakeLogger).to receive(:record).with('info', /Backing up to: (.*)/)
-        allow(FakeLogger).to receive(:record).with('info', /Moving (.*)/)
-
-        expect(FakeLogger).to receive(:record).with('info', /Pruning (.*)/)
-        described_class.condition_response(backup_condition, FakeLogger)
-      end
-
-
-      describe 'for each backup_maker it:' do
-
-        it 'gets the file pattern to use to prune older backup files for the backup_maker' do
-          expect(described_class).to receive(:get_backup_files_pattern)
+          expect(described_class).to receive(:backup_target_fn)
                                          .with('BACKUP_DIR', 'code_backup_maker_target_file.tar')
-          expect(described_class).to receive(:get_backup_files_pattern)
+          expect(described_class).to receive(:backup_target_fn)
                                          .with('BACKUP_DIR', 'db_backup_maker_target_file.sql')
-          expect(described_class).to receive(:get_backup_files_pattern)
+          expect(described_class).to receive(:backup_target_fn)
                                          .with('BACKUP_DIR', 'another_db_backup_maker_target_file.flurb')
-          expect(described_class).to receive(:get_backup_files_pattern)
+          expect(described_class).to receive(:backup_target_fn)
                                          .with('BACKUP_DIR', 'files_maker_target_file.tar')
 
           described_class.condition_response(backup_condition, FakeLogger)
         end
 
-        it 'deletes excess backup files that were created by this backup_maker, keeping the number given in the configuration' do
-          allow(described_class).to receive(:get_backup_files_pattern)
-                                        .with('BACKUP_DIR', 'code_backup_maker_target_file.tar')
-                                        .and_return('code_backup_maker_target_file.tar.*')
-          allow(described_class).to receive(:get_backup_files_pattern)
-                                        .with('BACKUP_DIR', 'db_backup_maker_target_file.sql')
-                                        .and_return('db_backup_maker_target_file.sql.*')
-          allow(described_class).to receive(:get_backup_files_pattern)
-                                        .with('BACKUP_DIR', 'another_db_backup_maker_target_file.flurb')
-                                        .and_return('another_db_backup_maker_target_file.flurb.*')
-          allow(described_class).to receive(:get_backup_files_pattern)
-                                        .with('BACKUP_DIR', 'files_maker_target_file.tar')
-                                        .and_return('files_maker_target_file.tar.*')
+        it "logs a message that it is 'Backing up to: <the backup file>'" do
+          allow(FakeLogger).to receive(:record).with('info', /Moving (.*)/)
+          allow(FakeLogger).to receive(:record).with('info', /Pruning (.*)/)
 
-          expect(described_class).to receive(:delete_excess_backup_files)
-                                         .with('code_backup_maker_target_file.tar.*', 3)
-          expect(described_class).to receive(:delete_excess_backup_files)
-                                         .with('db_backup_maker_target_file.sql.*', 2)
-          expect(described_class).to receive(:delete_excess_backup_files)
-                                         .with('another_db_backup_maker_target_file.flurb.*', 1)
-          expect(described_class).to receive(:delete_excess_backup_files)
-                                         .with('files_maker_target_file.tar.*', 99)
+          expect(FakeLogger).to receive(:record).with('info', /Backing up to: (.*)/)
+                                    .exactly(expected_num_makers).times
 
           described_class.condition_response(backup_condition, FakeLogger)
+        end
+
+        it 'sends the backup method to each backup maker, which creates the backup file for the maker' do
+          expect(@code_backup_maker).to receive(:backup)
+          expect(@db_backup_maker1).to receive(:backup)
+          expect(@db_backup_maker2).to receive(:backup)
+          expect(@file_backup_maker).to receive(:backup)
+
+          described_class.condition_response(backup_condition, FakeLogger)
+        end
+      end
+
+      it "logs a message that it is 'Moving backup files to AWS S3'" do
+        allow(FakeLogger).to receive(:record).with('info', /Backing up to: (.*)/)
+        allow(FakeLogger).to receive(:record).with('info', /Pruning (.*)/)
+
+        expect(FakeLogger).to receive(:record).with('info', /Moving (.*)/)
+        described_class.condition_response(backup_condition, FakeLogger)
+      end
+
+      it 'calls S3 credentials once' do
+        expect(described_class).to receive(:get_s3_objects)
+                                       .with(today).exactly(1).times
+
+        described_class.condition_response(condition, FakeLogger)
+      end
+
+      it 'calls upload to S3 once for each Backup maker ' do
+        # if no files are in the config, there are only 2 backup makers
+        expect(described_class).to receive(:upload_file_to_s3).exactly(expected_num_makers).times
+
+        described_class.condition_response(condition, FakeLogger)
+      end
+
+
+      describe 'finally it prunes older backups on local storage' do
+
+        it "logs a message that it is 'Pruning older backups on local storage'" do
+          allow(FakeLogger).to receive(:record).with('info', /Backing up to: (.*)/)
+          allow(FakeLogger).to receive(:record).with('info', /Moving (.*)/)
+
+          expect(FakeLogger).to receive(:record).with('info', /Pruning (.*)/)
+          described_class.condition_response(backup_condition, FakeLogger)
+        end
+
+
+        describe 'for each backup_maker it:' do
+
+          it 'gets the file pattern to use to prune older backup files for the backup_maker' do
+            expect(described_class).to receive(:get_backup_files_pattern)
+                                           .with('BACKUP_DIR', 'code_backup_maker_target_file.tar')
+            expect(described_class).to receive(:get_backup_files_pattern)
+                                           .with('BACKUP_DIR', 'db_backup_maker_target_file.sql')
+            expect(described_class).to receive(:get_backup_files_pattern)
+                                           .with('BACKUP_DIR', 'another_db_backup_maker_target_file.flurb')
+            expect(described_class).to receive(:get_backup_files_pattern)
+                                           .with('BACKUP_DIR', 'files_maker_target_file.tar')
+
+            described_class.condition_response(backup_condition, FakeLogger)
+          end
+
+          it 'deletes excess backup files that were created by this backup_maker, keeping the number given in the configuration' do
+            allow(described_class).to receive(:get_backup_files_pattern)
+                                          .with('BACKUP_DIR', 'code_backup_maker_target_file.tar')
+                                          .and_return('code_backup_maker_target_file.tar.*')
+            allow(described_class).to receive(:get_backup_files_pattern)
+                                          .with('BACKUP_DIR', 'db_backup_maker_target_file.sql')
+                                          .and_return('db_backup_maker_target_file.sql.*')
+            allow(described_class).to receive(:get_backup_files_pattern)
+                                          .with('BACKUP_DIR', 'another_db_backup_maker_target_file.flurb')
+                                          .and_return('another_db_backup_maker_target_file.flurb.*')
+            allow(described_class).to receive(:get_backup_files_pattern)
+                                          .with('BACKUP_DIR', 'files_maker_target_file.tar')
+                                          .and_return('files_maker_target_file.tar.*')
+
+            expect(described_class).to receive(:delete_excess_backup_files)
+                                           .with('code_backup_maker_target_file.tar.*', 3)
+            expect(described_class).to receive(:delete_excess_backup_files)
+                                           .with('db_backup_maker_target_file.sql.*', 2)
+            expect(described_class).to receive(:delete_excess_backup_files)
+                                           .with('another_db_backup_maker_target_file.flurb.*', 1)
+            expect(described_class).to receive(:delete_excess_backup_files)
+                                           .with('files_maker_target_file.tar.*', 99)
+
+            described_class.condition_response(backup_condition, FakeLogger)
+          end
+
         end
 
       end
 
     end
 
+
+    describe '.create_backup_makers' do
+
+      describe 'number of code backups to keep' do
+
+        it 'CodeBackupMaker number to keep is from config if days_to_keep: {code_backup: N} exists' do
+          makers = described_class.create_backup_makers({ days_to_keep: { code_backup: 12 } })
+          code_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].is_a? CodeBackupMaker }.first
+          expect(code_backupmaker[:keep_num]).to eq 12
+        end
+
+        it 'CodeBackupMaker number to keep is 4 (default) if not in config' do
+          makers = described_class.create_backup_makers({})
+          code_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].is_a? CodeBackupMaker }.first
+          expect(code_backupmaker[:keep_num]).to eq 4
+        end
+      end
+
+      describe 'number of database backups to keep' do
+
+        it 'DBBackupMaker number to keep is from config if days_to_keep: {db_backup: N} exists' do
+          makers = described_class.create_backup_makers({ days_to_keep: { db_backup: 12 } })
+          db_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].is_a? DBBackupMaker }.first
+          expect(db_backupmaker[:keep_num]).to eq 12
+        end
+
+        it 'DBBackupMaker number to keep is 15 (default) if not in config' do
+          makers = described_class.create_backup_makers({})
+          db_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].is_a? DBBackupMaker }.first
+          expect(db_backupmaker[:keep_num]).to eq 15
+        end
+      end
+
+
+      describe 'number of file backups to keep' do
+        it 'FilesBackupMaker number to keep is from config if days_to_keep: {files_backup: N} exists' do
+          makers = described_class.create_backup_makers({ files: ['thisfile'], days_to_keep: { files_backup: 12 } })
+          code_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].class.name == 'FilesBackupMaker' }.first
+          expect(code_backupmaker[:keep_num]).to eq 12
+        end
+
+        it 'FilesBackupMaker number to keep is 31 (default) if not in config' do
+          makers = described_class.create_backup_makers({ files: ['thisfile'] })
+          code_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].class.name == 'FilesBackupMaker' }.first
+          expect(code_backupmaker[:keep_num]).to eq 31
+        end
+      end
+
+
+      describe 'adds a CodeBackupMaker and a DBBackupMaker' do
+
+        it 'creates a CodeBackupMaker with the number to keep, backup dir,default target filename and source' do
+          allow(described_class).to receive(:create_files_backup_maker).and_return(nil)
+
+          makers = described_class.create_backup_makers({ files: ['thisfile'],
+                                                          days_to_keep: { files_backup: 12 },
+                                                          backup_directory: 'backup/destination/dir' })
+
+          code_backup_makers = makers.select { |maker_entry| maker_entry[:backup_maker].is_a? CodeBackupMaker }
+          expect(code_backup_makers.size).to eq 1
+        end
+
+
+        it 'creates a DBBackupMaker with the number to keep, backup dir, default target filename and source' do
+          allow(described_class).to receive(:create_files_backup_maker).and_return(nil)
+
+          makers = described_class.create_backup_makers({ files: ['thisfile'],
+                                                          days_to_keep: { files_backup: 12 },
+                                                          backup_directory: 'backup/destination/dir' })
+
+          db_backup_makers = makers.select { |maker_entry| maker_entry[:backup_maker].is_a? DBBackupMaker }
+          expect(db_backup_makers.size).to eq 1
+        end
+      end
+
+
+      describe 'only adds a FileBackupMaker if needed' do
+
+        it 'no FileBackupMaker created after reading the config' do
+          allow(described_class).to receive(:create_files_backup_maker).and_return(nil)
+
+          makers = described_class.create_backup_makers({ files: ['thisfile'], days_to_keep: { files_backup: 12 } })
+          files_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].class.name == 'FilesBackupMaker' }
+
+          expect(files_backupmaker).to be_empty
+        end
+
+        it 'a FileBackupMaker is created from config info' do
+
+          allow(described_class).to receive(:create_files_backup_maker).and_return(FilesBackupMaker.new)
+
+          makers = described_class.create_backup_makers({ files: ['thisfile'],
+                                                          days_to_keep: { files_backup: 12 },
+                                                          backup_directory: 'backup/destination/dir' })
+
+          files_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].class.name == 'FilesBackupMaker' }
+          expect(files_backupmaker.size).to eq 1
+        end
+
+      end
+
+    end
+
+
+    describe '.create_files_backup_maker' do
+
+      it 'nil if there is no files: entry in config' do
+        expect(described_class.create_files_backup_maker({})).to be_nil
+      end
+
+      it 'raises ShfConditionError::BackupConfigFilesBadFormatError if not an array' do
+        expect { described_class.create_files_backup_maker({ files: 'blorf' }) }.to raise_exception(ShfConditionError::BackupConfigFilesBadFormatError)
+      end
+
+      it 'nil if the list is empty: []' do
+        expect(described_class.create_files_backup_maker({ files: [] })).to be_nil
+      end
+
+      it 'creates a FileBackupMaker with the list as the source files for the backup, and destination dir set' do
+        created_maker = described_class.create_files_backup_maker({ files: ['~/NOTES_RUNNING_LOG.txt', '/var/log/nginx'],
+                                                                    backup_directory: 'backup/destination/dir' })
+
+        expect(created_maker.backup_sources).to match_array(['~/NOTES_RUNNING_LOG.txt', '/var/log/nginx'])
+      end
+
+    end
+
+
+    describe 'get_backup_files_pattern' do
+
+      it 'appends ".*" to the end of the File.join(backup directory, backup file)' do
+        expect(described_class.get_backup_files_pattern('dir', 'filename.zzk')).to eq('dir/filename.zzk.*')
+      end
+
+      it 'uses File.join so redundant/repeated slashes are not a problem' do
+        expect(described_class.get_backup_files_pattern('dir/with/ending/slash/', 'filename.zzk')).to eq('dir/with/ending/slash/filename.zzk.*')
+      end
+    end
   end
 
-
-  describe '.create_backup_makers' do
-
-    describe 'number of code backups to keep' do
-
-      it 'CodeBackupMaker number to keep is from config if days_to_keep: {code_backup: N} exists' do
-        makers = described_class.create_backup_makers({ days_to_keep: { code_backup: 12 } })
-        code_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].is_a? CodeBackupMaker }.first
-        expect(code_backupmaker[:keep_num]).to eq 12
-      end
-
-      it 'CodeBackupMaker number to keep is 4 (default) if not in config' do
-        makers = described_class.create_backup_makers({})
-        code_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].is_a? CodeBackupMaker }.first
-        expect(code_backupmaker[:keep_num]).to eq 4
-      end
-    end
-
-    describe 'number of database backups to keep' do
-
-      it 'DBBackupMaker number to keep is from config if days_to_keep: {db_backup: N} exists' do
-        makers = described_class.create_backup_makers({ days_to_keep: { db_backup: 12 } })
-        db_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].is_a? DBBackupMaker }.first
-        expect(db_backupmaker[:keep_num]).to eq 12
-      end
-
-      it 'DBBackupMaker number to keep is 15 (default) if not in config' do
-        makers = described_class.create_backup_makers({})
-        db_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].is_a? DBBackupMaker }.first
-        expect(db_backupmaker[:keep_num]).to eq 15
-      end
-    end
-
-
-    describe 'number of file backups to keep' do
-      it 'FilesBackupMaker number to keep is from config if days_to_keep: {files_backup: N} exists' do
-        makers = described_class.create_backup_makers({ files: ['thisfile'], days_to_keep: { files_backup: 12 } })
-        code_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].class.name == 'FilesBackupMaker' }.first
-        expect(code_backupmaker[:keep_num]).to eq 12
-      end
-
-      it 'FilesBackupMaker number to keep is 31 (default) if not in config' do
-        makers = described_class.create_backup_makers({ files: ['thisfile'] })
-        code_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].class.name == 'FilesBackupMaker' }.first
-        expect(code_backupmaker[:keep_num]).to eq 31
-      end
-    end
-
-
-    describe 'adds a CodeBackupMaker and a DBBackupMaker' do
-
-      it 'creates a CodeBackupMaker with the number to keep and default target filename and source' do
-        allow(described_class).to receive(:create_files_backup_maker).and_return(nil)
-
-        makers = described_class.create_backup_makers({ files: ['thisfile'], days_to_keep: { files_backup: 12 } })
-        expect( makers.select { |maker_entry| maker_entry[:backup_maker].is_a? CodeBackupMaker }.size).to eq 1
-      end
-
-
-      it 'creates a DBBackupMaker with the number to keep and default target filename and source' do
-        allow(described_class).to receive(:create_files_backup_maker).and_return(nil)
-
-        makers = described_class.create_backup_makers({ files: ['thisfile'], days_to_keep: { files_backup: 12 } })
-        expect(makers.select { |maker_entry| maker_entry[:backup_maker].is_a? DBBackupMaker }.size).to eq 1
-      end
-    end
-
-
-    describe 'only adds a FileBackupMaker if needed' do
-
-      it 'no FileBackupMaker created after reading the config' do
-        allow(described_class).to receive(:create_files_backup_maker).and_return(nil)
-
-        makers = described_class.create_backup_makers({ files: ['thisfile'], days_to_keep: { files_backup: 12 } })
-        files_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].class.name == 'FilesBackupMaker' }
-
-        expect(files_backupmaker).to be_empty
-      end
-
-      it 'a FileBackupMaker is created after reading the config' do
-
-        allow(described_class).to receive(:create_files_backup_maker).and_return(FilesBackupMaker.new)
-
-        makers = described_class.create_backup_makers({ files: ['thisfile'], days_to_keep: { files_backup: 12 } })
-        files_backupmaker = makers.select { |maker_entry| maker_entry[:backup_maker].class.name == 'FilesBackupMaker' }
-
-        expect(files_backupmaker).not_to be_empty
-      end
-
-    end
-
-  end
-
-
-  describe '.create_files_backup_maker' do
-
-    it 'nil if there is no files: entry in config' do
-      expect(described_class.create_files_backup_maker({})).to be_nil
-    end
-
-    it 'raises ShfConditionError::BackupConfigFilesBadFormatError if not an array' do
-      expect { described_class.create_files_backup_maker({ files: 'blorf' }) }.to raise_exception(ShfConditionError::BackupConfigFilesBadFormatError)
-    end
-
-    it 'nil if the list is empty: []' do
-      expect(described_class.create_files_backup_maker({ files: [] })).to be_nil
-    end
-
-    it 'creates a FileBackupMaker with the list as the source files for the backup' do
-      created_maker = described_class.create_files_backup_maker({ files: ['~/NOTES_RUNNING_LOG.txt', '/var/log/nginx'] })
-      expect(created_maker.backup_sources).to match_array(['~/NOTES_RUNNING_LOG.txt', '/var/log/nginx'])
-    end
-
-  end
-
-
-  describe 'get_backup_files_pattern' do
-
-    it 'appends ".*" to the end of the File.join(backup directory, backup file)' do
-      expect(described_class.get_backup_files_pattern('dir', 'filename.zzk')).to eq('dir/filename.zzk.*')
-    end
-
-    it 'uses File.join so redundant/repeated slashes are not a problem' do
-      expect(described_class.get_backup_files_pattern('dir/with/ending/slash/', 'filename.zzk')).to eq('dir/with/ending/slash/filename.zzk.*')
-    end
-  end
 end

--- a/spec/models/conditions_response/backup_spec.rb
+++ b/spec/models/conditions_response/backup_spec.rb
@@ -485,10 +485,10 @@ RSpec.describe Backup, type: :model do
 
 
       before(:each) do
-        @code_backup_maker = CodeBackupMaker.new(backup_target_filebase: 'code_backup_maker_target_file.tar')
-        @db_backup_maker1 = DBBackupMaker.new(backup_target_filebase: 'db_backup_maker_target_file.sql')
-        @db_backup_maker2 = DBBackupMaker.new(backup_target_filebase: 'another_db_backup_maker_target_file.flurb')
-        @file_backup_maker = FilesBackupMaker.new(backup_target_filebase: 'files_maker_target_file.tar',
+        @code_backup_maker = CodeBackupMaker.new(target_filename: 'code_backup_maker_target_file.tar')
+        @db_backup_maker1 = DBBackupMaker.new(target_filename: 'db_backup_maker_target_file.sql')
+        @db_backup_maker2 = DBBackupMaker.new(target_filename: 'another_db_backup_maker_target_file.flurb')
+        @file_backup_maker = FilesBackupMaker.new(target_filename: 'files_maker_target_file.tar',
                                                   backup_sources: ['file1.txt', 'file2.zip'])
         @created_backup_makers = [
             { backup_maker: @code_backup_maker, keep_num: 3 },

--- a/spec/models/shf_notify_slack_spec.rb
+++ b/spec/models/shf_notify_slack_spec.rb
@@ -309,7 +309,34 @@ RSpec.describe SHFNotifySlack, type: :model do
 
 
     describe 'notification text' do
-      it_behaves_like "it has a default and allows custom text", 'Failure!', failure_notification_method
+
+      it 'the failure word is added before it' do
+        failure_notification_text = 'text about the failure'
+        expect(described_class).to receive(:notification)
+                                     .with('some source', "#{described_class.failure_word} text about the failure", anything)
+
+        described_class.failure_notification('some source', text: failure_notification_text)
+      end
+
+      it "default is 'Some unknown failure!'" do
+
+        expect(described_class).to receive(:notification)
+                                      .with(NOTIFICATION_SOURCE,
+                                            /(.*) Some unknown failure!/,
+                                            anything)
+        described_class.failure_notification(NOTIFICATION_SOURCE)
+      end
+
+      it 'can specify custom failure notification text' do
+        custom_notification_text = "some informative text to show in Slack"
+
+        expect(described_class).to receive(:notification)
+                                      .with(NOTIFICATION_SOURCE,
+                                            /(.*) #{custom_notification_text}/,
+                                            anything)
+
+        described_class.failure_notification(NOTIFICATION_SOURCE, text: custom_notification_text)
+      end
     end
 
     describe 'emoji' do

--- a/spec/models/shf_notify_slack_spec.rb
+++ b/spec/models/shf_notify_slack_spec.rb
@@ -91,7 +91,7 @@ end
 
 # ===============================================================
 
-RSpec.describe 'SHFNotifySlack', type: :model do
+RSpec.describe SHFNotifySlack, type: :model do
 
   before(:all) do
     # send the notifications to the _testing_ channel
@@ -691,6 +691,15 @@ RSpec.describe 'SHFNotifySlack', type: :model do
   end
 
   it '.footer_text has "SHF:" at the start' do
-    expect(SHFNotifySlack.footer_text('blorf')).to eq('SHF: blorf')
+    expect(described_class.footer_text('blorf')).to eq('SHF: blorf')
   end
+
+  it '.failure_word  is "Failure!"' do
+    expect(described_class.failure_word).to eq "Failure!"
+  end
+
+  it '.successful_word is "Success!"' do
+    expect(described_class.successful_word).to eq "Successful"
+  end
+
 end

--- a/spec/shared_examples/backup_maker_target_filename_with_default_spec.rb
+++ b/spec/shared_examples/backup_maker_target_filename_with_default_spec.rb
@@ -1,0 +1,35 @@
+# Shared example for Backup
+
+
+RSpec.shared_examples 'it takes a backup target filename, with default =' do |default_filename|
+
+  before(:each) do
+    @temp_backup_sourcedir = Dir.mktmpdir('faux-code-dir')
+    @temp_backup_sourcefn1 = File.open(File.join(@temp_backup_sourcedir, 'some-sourcefile.txt'), 'w').path
+  end
+
+  describe 'target filename (the name of the backup file created)' do
+
+    it "default target backup file is '#{default_filename}'" do
+      files_backup = described_class.new(backup_sources: [@temp_backup_sourcefn1])
+      backup_created_fn = files_backup.backup
+
+      expect(backup_created_fn).to eq default_filename
+      expect(File.exist?(default_filename)).to be_truthy
+      File.delete(default_filename)
+    end
+
+    it 'can provide the name of the file' do
+      files_backup = described_class.new(backup_sources: [@temp_backup_sourcefn1])
+
+      target_dir = Dir.mktmpdir('backup-target-dir')
+      given_backup_target_fn = File.join(target_dir, 'some_filename.tar.zzzx')
+
+      files_backup.backup(target: given_backup_target_fn)
+
+      expect(File.exist?(given_backup_target_fn)).to be_truthy
+      File.delete(given_backup_target_fn)
+    end
+  end
+
+end


### PR DESCRIPTION
## PT Story: HOTFIX: backups failing: extra "." at end
https://www.pivotaltracker.com/story/show/166718144

## Changes proposed in this pull request:
1.  This builds on a PR that I merged (but still wasn't working!):  #692 - extra "." at end of file extension
2.  Needed to pass  in the full target backup file name to the backup method (e.g. the `..... .tar.<date>.gz` filename
3. Created in-depth acceptance tests for the Backup Condition that actually verifies that the backup files are created and calls the shell commands (e.g. `tar ...`)
4. Put in `rescue` statements that will log any errors raised but will continue processing, so 1 error will not halt _all_ of the backups


### Ready for review:
@patmbolger 
