### PR TITLE
cap deploy: delete test directories -- use test(-d..) not test(-f...) 

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -115,7 +115,7 @@ namespace :deploy do
 
 
   def remove_dir(full_dir_path)
-    if test("[ -f #{full_dir_path} ]") # if the file exists on the remote server
+    if test("[ -d #{full_dir_path} ]") # if the directory exists on the remote server
       execute %{rm -r #{full_dir_path} }
     else
       warn "Directory doesn't exist, so it could not be removed: #{full_dir_path}" # log and puts


### PR DESCRIPTION
## PT Story:  cap deploy.rb: why isn't`remove_test dirs` happening?
https://www.pivotaltracker.com/story/show/166741233

Changes proposed in this pull request:
1.  change `test(-f ...)` to `test(-d ...`

## Ready for review:
@AgileVentures/shf-project-team 
