### PR TITLE
redirect to login page if user needs to be logged in

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -80,6 +80,10 @@ module SHFProject
   # Load from sub-folders of "models"
   Rails.application.config.autoload_paths += Dir[Rails.root.join("app", "models", "{*/}")]
 
+  # Load the /lib folder so that ShfDeviseFailureApp is loaded (redirects to login page if needed)
+  Rails.application.config.autoload_paths << Rails.root.join('lib')
+
+
   ############### New defaults from Rails version 5.0 ###############
 
   # Enable per-form CSRF tokens. Previous versions had false.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -258,6 +258,10 @@ Devise.setup do |config|
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
 
+  config.warden do |manager|
+    manager.failure_app = ShfDeviseFailureApp
+  end
+
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine
   # is mountable, there are some extra configurations to be taken into account.

--- a/features/redirect-user-to-login-page.feature
+++ b/features/redirect-user-to-login-page.feature
@@ -1,0 +1,61 @@
+Feature: Redirect User to the login page if they need to be logged in
+
+  As a visitor
+  if I try to access a page that requires me to be logged in
+  show me the login page with a message telling me I need to be logged in
+
+
+  Background:
+    Given the following regions exist:
+      | name         |
+      | Stockholm    |
+
+
+    Given the following kommuns exist:
+      | name     |
+      | Alingsås |
+
+
+    And the following business categories exist
+      | name    |
+      | Groomer |
+
+    Given the following companies exist:
+      | name      | company_number | email           | region       | kommun   |
+      | Company01 | 5560360793     | cmpy1@mail.com  | Stockholm    | Alingsås |
+
+
+    And the following users exists
+      | email         | admin | member |
+      | u1@mutts.com  |       | true   |
+
+    And the following payments exist
+      | user_email    | start_date | expire_date | payment_type | status | hips_id | company_name |
+      | u1@mutts.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | Company01    |
+
+    And the following applications exist:
+      | user_email    | company_name | state    | categories |
+      | u1@mutts.com  | Company01    | accepted | Groomer    |
+
+
+
+  Scenario: I try to access a page that requires a login
+    Given I am on the "landing" page
+    When I am on the "create a new company" page
+    Then I should be on "login" page
+    Then I should see t("errors.not_permitted")
+    And I should see t("errors.try_login")
+
+
+  Scenario: I try to access an admin page
+    Given I am on the "login" page
+    When I am on the "all waiting for info reasons" page
+    Then I should be on "login" page
+    Then I should see t("errors.not_permitted")
+    And I should see t("errors.try_login")
+
+
+  Scenario: I can access a page that does not require a login (detail for 1 company)
+    When  I am the page for company number "5560360793"
+    Then I should not see t("errors.not_permitted")
+    And I should not see t("errors.try_login")

--- a/lib/shf_devise_failure_app.rb
+++ b/lib/shf_devise_failure_app.rb
@@ -18,7 +18,6 @@ class ShfDeviseFailureApp < Devise::FailureApp
 
 
   def route(scope)
-
     # redirect only if they are a User,  not an Admin (or other type of Devise scope)
     scope.to_sym == :user ? :new_user_session_url : super
   end
@@ -29,8 +28,35 @@ class ShfDeviseFailureApp < Devise::FailureApp
     if http_auth?
       http_auth
     else
+      flash.now[:alert] = i18n_message(:invalid) if is_flashing_format? && warden_options[:recall]
       redirect
     end
   end
+
+
+  # This differs from super because it _adds_ the i18n_message to any existing
+  # flash alerts instead of just assigning (and thus clobbering any flash
+  # alerts that might already be there). This also uses flash.keep(:alert)
+  # so that any alert message won't be lost if we redirect to a sign in page.
+  # We must add to alerts if the email or password is missing from the sign_in
+  # page.
+  #
+  def redirect
+    store_location!
+    if is_flashing_format?
+      if flash[:timedout] && flash[:alert]
+        flash.keep(:timedout)
+        flash.keep(:alert)
+      else
+        unless flash[:alert] == i18n_message
+          flash[:alert] =  "#{flash[:alert]}  #{i18n_message}"
+        end
+        flash.keep(:alert)
+      end
+    end
+    redirect_to redirect_url
+  end
+
+
 end
 

--- a/lib/shf_devise_failure_app.rb
+++ b/lib/shf_devise_failure_app.rb
@@ -1,0 +1,36 @@
+#--------------------------
+#
+# @class ShfDeviseFailureApp
+#
+# @desc Responsibility: Redirect users to the login page if they try to
+#   access a page that requires them to be logged in
+#
+# @see https://github.com/plataformatec/devise/wiki/How-To:-Redirect-to-a-specific-page-when-the-user-can-not-be-authenticated
+# @see https://github.com/plataformatec/devise/wiki/Redirect-to-new-registration-(sign-up)-path-if-unauthenticated
+#
+# @author Ashley Engelund (ashley.engelund@gmail.com  weedySeaDragon @ github)
+# @date   2019-06-25
+#
+#--------------------------
+
+
+class ShfDeviseFailureApp < Devise::FailureApp
+
+
+  def route(scope)
+
+    # redirect only if they are a User,  not an Admin (or other type of Devise scope)
+    scope.to_sym == :user ? :new_user_session_url : super
+  end
+
+
+  # Override respond to eliminate recall (see the Devise documentation pages for more info)
+  def respond
+    if http_auth?
+      http_auth
+    else
+      redirect
+    end
+  end
+end
+


### PR DESCRIPTION
## PT Story: If user needs to be logged in but isn't, show friendly error with link to login screen
https://www.pivotaltracker.com/story/show/153527174


## Changes proposed in this pull request:
1.  per Devise documentation, added a 'Failure App' to `/lib`:  `ShfDeviseFailureApp`  This will redirect visitors to the Sign In page if they try to access a page that requires a log in.


## Ready for review:
@AgileVentures/shf-project-team 
