### PR TITLE
add lang= and xml.lang= tags to <html>

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html
+%html{html_attrs(@locale), 'xml.lang': "#{@locale}"}
   %head
     = favicon_link_tag 'favicon.ico'
     = favicon_link_tag 'apple-touch-icon-120x120-shf_logo.png', rel: 'apple-touch-icon', type: 'image/png', sizes: '120x120'

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -304,7 +304,7 @@ end
 
 
 Then("the page title should{negate} be {capture_string}") do | negate, page_title |
-  expect(page).send (negate ? :not_to : :to), have_title(page_title)
+  expect(page).send((negate ? :not_to : :to), have_title(page_title))
 end
 
 
@@ -323,19 +323,19 @@ end
 
 Then("the page head should{negate} include meta {capture_string} {capture_string}") do | negate, meta_tag, value |
   meta_xpath = "/html/head/meta[@#{meta_tag}=\"#{value}\"]/@content"
-  expect(page).send (negate ? :not_to : :to), have_xpath(meta_xpath, visible: false)
+  expect(page).send((negate ? :not_to : :to), have_xpath(meta_xpath, visible: false))
 end
 
 
 Then("the page head should{negate} include a link tag with hreflang = {capture_string} and href = {capture_string}") do | negate, hreflang, href |
   hreflang_xpath = "/html/head/link[@rel='alternate'][@hreflang='#{hreflang}'][@href='#{href}']"
-  expect(page).send (negate ? :not_to : :to), have_xpath(hreflang_xpath, visible: false)
+  expect(page).send((negate ? :not_to : :to), have_xpath(hreflang_xpath, visible: false))
 end
 
 
 Then("the page head should{negate} include a link tag with rel = {capture_string} and href = {capture_string}") do | negate, rel, href |
   hreflang_xpath = "/html/head/link[@rel='#{rel}'][@href='#{href}']"
-  expect(page).send (negate ? :not_to : :to), have_xpath(hreflang_xpath, visible: false)
+  expect(page).send((negate ? :not_to : :to), have_xpath(hreflang_xpath, visible: false))
 end
 
 
@@ -376,9 +376,22 @@ And("the page head should{negate} include a ld+json script tag with key {capture
 end
 
 
+And("the html tag should{negate} include lang={capture_string}") do | negate,  lang_attrib|
+  lang_xpath = "/html[@lang=\"#{lang_attrib}\"]"
+  expect(page).send((negate ? :not_to : :to),  have_xpath(lang_xpath, visible: false))
+end
+
+
+And("the html tag should{negate} include xml\.lang={capture_string}") do | negate,  xml_lang_attrib|
+  lang_xpath = "/html[@xml.lang=\"#{xml_lang_attrib}\"]"
+  expect(page).send((negate ? :not_to : :to),  have_xpath(lang_xpath, visible: false))
+end
+
+
+
 def expect_head_has_ld_json_script(negated: false)
   ld_json_text_xpath  = "/html/head/script[@type='application/ld+json']/text()"
-  expect(page).send (negated ? :not_to : :to), have_xpath(ld_json_text_xpath, visible: false)
+  expect(page).send((negated ? :not_to : :to), have_xpath(ld_json_text_xpath, visible: false))
 
   ld_json = nil
   unless negated

--- a/features/view-site-in-lang-i18n-l10n.feature
+++ b/features/view-site-in-lang-i18n-l10n.feature
@@ -1,4 +1,5 @@
-Feature: As a visitor
+Feature: Site Language - default and visitor switches it
+  As a visitor
   In order to view the site in my language
   I need to be able choose either Swedish or English for the site
 
@@ -17,16 +18,29 @@ Feature: As a visitor
     Then I should see t("companies.index.title")
     And I should not see t("show_in_swedish") image
     And I should see t("show_in_english") image
+    And the html tag should include lang="sv"
+    And the html tag should include xml.lang="sv"
+    And the html tag should not include lang="en"
+    And the html tag should not include xml.lang="en"
 
 
   Scenario: Visitor switches the site language from English to Swedish
     Given I set the locale to "sv"
     And I am on the "all companies" page
     When I click on "change-lang-to-english"
+    And the html tag should not include lang="sv"
+    And the html tag should not include xml.lang="sv"
+    And the html tag should include lang="en"
+    And the html tag should include xml.lang="en"
     When I click on "change-lang-to-svenska"
     Then I should see t("companies.index.title")
     And I should not see t("show_in_swedish") image
     And I should see t("show_in_english") image
+    And the html tag should include lang="sv"
+    And the html tag should include xml.lang="sv"
+    And the html tag should not include lang="en"
+    And the html tag should not include xml.lang="en"
+
 
 
   Scenario: Visitor switches the site language from Swedish to English
@@ -35,3 +49,7 @@ Feature: As a visitor
     When I click on "change-lang-to-english"
     Then I should see t("show_in_swedish") image
     And I should not see t("show_in_english") image
+    And the html tag should not include lang="sv"
+    And the html tag should not include xml.lang="sv"
+    And the html tag should include lang="en"
+    And the html tag should include xml.lang="en"


### PR DESCRIPTION
### PT Story: HTML lang= tag needed!
https://www.pivotaltracker.com/story/show/166360323

### Changes proposed in this pull request:
1.  changed `application/layout.html.haml` so the <html> tag includes `lang=` and `xml.lang=` and set the values to the current locale (e.g. "sv" or "en")
2. added cucumber steps
3. added testing steps to the language-switching feature

### Screenshots (Optional):
Here is what is in \<html\> now:

#### locale == sv

<img width="324" alt="html-lang-tags--sv" src="https://user-images.githubusercontent.com/673794/62431160-b443a000-b6d9-11e9-8a0f-53d9276bf542.png">

#### locale == en
<img width="340" alt="html-lang-tags--en" src="https://user-images.githubusercontent.com/673794/62431159-b443a000-b6d9-11e9-8c23-005f34b4c582.png">


### Ready for review:
@thesuss 
