### PR TITLE
Cucumber: set eu_cookies_consent cookie to true by default; add steps for cookies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,4 +139,5 @@ group :test do
   gem 'timecop'
   gem 'rubocop-rspec'
 
+  gem "show_me_the_cookies"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -506,6 +506,8 @@ GEM
     sexp_processor (4.12.0)
     shoulda-matchers (4.0.1)
       activesupport (>= 4.2.0)
+    show_me_the_cookies (5.0.0)
+      capybara (>= 2, < 4)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -667,6 +669,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   shoulda-matchers
+  show_me_the_cookies
   simplecov (>= 0.13.0)
   slack-notifier
   smarter_csv

--- a/app/views/cookies_eu/_consent_banner.html.erb
+++ b/app/views/cookies_eu/_consent_banner.html.erb
@@ -1,6 +1,11 @@
 <%# Possible local variable: link is a local variable              %>
 <%# link - the url to a page to show with more info about cookies. %>
-<% if cookies && cookies['cookie_eu_consented'] != 'true' %>
+<%#                                                                %>
+<%# This uses ActionDispatch CookieJar for cookies, so they cannot %>
+<%# So we simply use  Rails.env != 'test'  to NOT display this     %>
+<%# during integration testing.                                    %>
+<%#                                                                %>
+<% if Rails.env != 'test' && cookies && cookies['cookie_eu_consented'] != 'true' %>
   <div class="cookies-eu js-cookies-eu">
     <p>
       <span class="cookies-eu-content-holder">

--- a/features/step_definitions/cookies_steps.rb
+++ b/features/step_definitions/cookies_steps.rb
@@ -6,17 +6,17 @@
 # You can display the current cookies with
 #   puts "show_me_cookies_adapter.get_me_the_cookies: #{@show_me_cookies_adapter.get_me_the_cookies}"
 
+EU_COOKIE_NAME = 'cookie_eu_consented'
 
 # -----------------------
 # EU cookies consent (see the cookies_eu gem)
 #
 And("the EU cookies consent cookie is set to {capture_string}") do | cookie_value|
-
   curr_driver = Capybara.current_driver
   curr_session_driver = Capybara.current_session.driver
   show_me_cookies_adapter = ShowMeTheCookies.adapters[curr_driver].new(curr_session_driver)
 
-  show_me_cookies_adapter.create_cookie('cookie_eu_consented', cookie_value, {})
+  show_me_cookies_adapter.create_cookie(EU_COOKIE_NAME, cookie_value, {})
 end
 
 And("the EU cookies consent cookie is set to true") do
@@ -33,5 +33,5 @@ And("the EU cookies consent cookie does not exist") do
   curr_session_driver = Capybara.current_session.driver
   show_me_cookies_adapter = ShowMeTheCookies.adapters[curr_driver].new(curr_session_driver)
 
-  show_me_cookies_adapter.delete_cookie('cookie_eu_consented')
+  show_me_cookies_adapter.delete_cookie(EU_COOKIE_NAME)
 end

--- a/features/step_definitions/cookies_steps.rb
+++ b/features/step_definitions/cookies_steps.rb
@@ -1,0 +1,37 @@
+# Steps dealing with cookies
+#
+# This uses the ShowMeTheCookies gem to show, set, delete cookies.
+# That gem handles the different possible drivers.
+#
+# You can display the current cookies with
+#   puts "show_me_cookies_adapter.get_me_the_cookies: #{@show_me_cookies_adapter.get_me_the_cookies}"
+
+
+# -----------------------
+# EU cookies consent (see the cookies_eu gem)
+#
+And("the EU cookies consent cookie is set to {capture_string}") do | cookie_value|
+
+  curr_driver = Capybara.current_driver
+  curr_session_driver = Capybara.current_session.driver
+  show_me_cookies_adapter = ShowMeTheCookies.adapters[curr_driver].new(curr_session_driver)
+
+  show_me_cookies_adapter.create_cookie('cookie_eu_consented', cookie_value, {})
+end
+
+And("the EU cookies consent cookie is set to true") do
+  step 'the EU cookies consent cookie is set to "true"'
+end
+
+And("the EU cookies consent cookie is set to false") do
+  step 'the EU cookies consent cookie is set to "false"'
+end
+
+And("the EU cookies consent cookie does not exist") do
+
+  curr_driver = Capybara.current_driver
+  curr_session_driver = Capybara.current_session.driver
+  show_me_cookies_adapter = ShowMeTheCookies.adapters[curr_driver].new(curr_session_driver)
+
+  show_me_cookies_adapter.delete_cookie('cookie_eu_consented')
+end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -1,8 +1,39 @@
-Given(/^I am on the "([^"]*)" page(?: for "([^"]*)")?$/) do |page, email|
+# Set the EU cookie consent cookie and then VISIT A PAGE
+#
+# Here are examples of strings that will match (the regular expression for) this step:
+#   I am on the "blorf" page
+#       page = 'blorf'
+#       email = nil
+#       eu_cookie_value = nil
+#
+#   I am on the "blorf" page for "x"
+#       page = 'blorf'
+#       email = 'x'
+#       eu_cookie_value = nil
+#
+#   I am on the "blorf" page for "x" and the EU cookie is "z"
+#       page = 'blorf'
+#       email = 'x'
+#       eu_cookie_value = 'z'
+#
+#   I am on the "blorf" page and the EU cookie is "z1"
+#       page = 'blorf'
+#       email = nil
+#       eu_cookie_value = 'z'
+#
+# The default is to set the EU cookie consent cookie to 'true' so that
+# the notice does NOT appear. If the notice does appear, it might block/cover
+# elements that other steps are trying to work with.
+#
+Given(/^I am on the "([^"]*)" page(?: for "([^"]*)")?(?: and the EU cookie is "([^"]*)")?$/) do |page, email, eu_cookie_value|
   user = email == nil ? @user :  User.find_by(email: email)
+
+  eu_cookie_value = eu_cookie_value.nil? ? 'true' : eu_cookie_value
 
   begin
     visit path_with_locale(get_path(page, user))
+    step "the EU cookies consent cookie is set to \"#{eu_cookie_value}\""
+
   rescue StandardError => orig_exception
     raise orig_exception  # if the original exception
 
@@ -13,7 +44,9 @@ Given(/^I am on the "([^"]*)" page(?: for "([^"]*)")?$/) do |page, email|
 
     begin
       path_components = page.split(/\s+/)
+      # TODO refactor this code duplicated above (create a block/method with 'visit'() and 'step...')
       visit self.send(path_components.push('path').join('_').to_sym)
+      step "the EU cookies consent cookie is set to \"#{eu_cookie_value}\""
 
     rescue NoMethodError, ArgumentError => error
       raise "Can't find mapping from \"#{page}\" to a path.\n" +

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -14,6 +14,11 @@ require_relative '../../spec/support/geocoder'
 # Mock the AppConfiguration so that Paperclip commands are not called multiple times for every scenario
 require_relative '../../spec/shared_context/mock_app_configuration.rb'
 
+
+require 'show_me_the_cookies'
+World(ShowMeTheCookies)
+
+
 #
 # Configurations
 #
@@ -72,7 +77,9 @@ Capybara.register_driver :selenium_browser do |app|
       browser: :chrome
   )
 end
-
+# register this driver so that ShowMeTheCookies knows which adapater to use for it
+#   have to use the same driver name (symbol)
+ShowMeTheCookies.register_adapter(:selenium_browser, ShowMeTheCookies::SeleniumChrome)
 
 #
 # Global Before/After


### PR DESCRIPTION
### PT Story: follow-up to Show visitor prompt: We use cookies,
https://www.pivotaltracker.com/story/show/165031450

Some cucumber tests are failing because the EU cookie prompt is obscuring elements.

### Changes proposed in this pull request:
1. Do not show the EU cookies consent during testing.  (Is very difficult to check and use the 'real' cookies vs. the test cookies)
1.  add `show_me_the_cookies` gem to help dealing with cookies
2. Add steps for dealing with EU cookie
3. set the EU cookie to 'true' by default
4. modify the `I am on the ___ page` Regex so that it also accepts a clause about the EU cookie

Ready for review:
@
