### PR TITLE
Set production logging level to :info

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -76,6 +76,20 @@ Rails.application.configure do
   # LOGGING
   #
 
+  # Use the HIGHEST log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
+
+  # Prepend all log lines with the following tags.
+  config.log_tags = [ :request_id ]
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Use a different logger for distributed setups.
+  # require 'syslog/logger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,8 +33,6 @@ Rails.application.configure do
   # Use sql schema to allow the use of functions, triggers and sequences
   config.active_record.schema_format = :sql
 
-  # Highlight code that triggered database queries in logs.
-  config.active_record.verbose_query_logs = true
 
   ###
   #
@@ -62,9 +60,6 @@ Rails.application.configure do
   #
   ###
 
-  # Print deprecation notices to the Rails logger.
-  config.active_support.deprecation = :log
-
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
@@ -73,8 +68,23 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
+
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
+
+  ########################################################################
+  # LOGGING
+  #
+
+  # Highlight code that triggered database queries in logs.
+  config.active_record.verbose_query_logs = true
+
   # Suppress logger output for asset requests.
   config.assets.quiet = true
+
+  # Print deprecation notices to the Rails logger.
+  config.active_support.deprecation = :log
+
 
   # To have the Rails log sent to the stdout and *not* a file,
   # define RAILS_LOG_TO_STDOUT as anything.
@@ -85,8 +95,10 @@ Rails.application.configure do
   end
 
 
-  # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  # end LOGGING
+  ########################################################################
+
+
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,13 +49,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :warn
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
@@ -64,7 +57,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "shf_project_#{Rails.env}"
 
 
-  ###
+  ########################################################################
   #
   # Mail
   #
@@ -86,7 +79,9 @@ Rails.application.configure do
   config.action_mailer.asset_host     =   ENV['SHF_MAIL_ASSETS_HOST'] ||
                                                  'http://hitta.sverigeshundforetagare.se'
   #
-  ###
+  # end Mail
+  ########################################################################
+
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
@@ -94,6 +89,19 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
+
+
+  ########################################################################
+  #
+  # LOGGING
+  #
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :warn
+
+  # Prepend all log lines with the following tags.
+  config.log_tags = [ :request_id ]
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
@@ -107,6 +115,12 @@ Rails.application.configure do
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
+
+  #
+  # end LOGGING
+  ########################################################################
+
+
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,7 +98,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :warn
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
@@ -110,6 +110,8 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
+  # To have the Rails log sent to the stdout and *not* a file,
+  # define RAILS_LOG_TO_STDOUT as anything.
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter


### PR DESCRIPTION
### PT Story: change production log level to :info
https://www.pivotaltracker.com/story/show/167794584

### Changes proposed in this pull request:
1.  change the production log level to `:info`
2.  put all of the `config.log` items into 1 section of the `config/environment/*.rb` file(s)
3. add `config.log` items  from `config/environment/production.rb` to `config/environment/development.rb` so `development.rb` mirrors `production.rb` as much as possible

Ready for review:
@AgileVentures/shf-project-team 
