### PR TITLE
AppConfig Singleton needs specialized routing and UX changes

### DIFF
--- a/app/controllers/admin_only/app_configuration_controller.rb
+++ b/app/controllers/admin_only/app_configuration_controller.rb
@@ -16,7 +16,9 @@ module AdminOnly
 
     def update
       if @app_configuration.update(app_config_params)
-        redirect_to @app_configuration, notice: t('.success')
+        # Do not specify the @app_configuration in the path so that the URL is
+        # correct: we do _not_ want the :id in the URL. (The AppConfiguration is a singleton)
+        render :show, notice: t('.success')
       else
         helpers.flash_message(:alert, "#{t('.error')}: #{@app_configuration.errors.full_messages.join(', ')}")
         render :edit

--- a/app/controllers/admin_only/app_configuration_controller.rb
+++ b/app/controllers/admin_only/app_configuration_controller.rb
@@ -16,8 +16,6 @@ module AdminOnly
 
     def update
       if @app_configuration.update(app_config_params)
-        # Do not specify the @app_configuration in the path so that the URL is
-        # correct: we do _not_ want the :id in the URL. (The AppConfiguration is a singleton)
         redirect_to @app_configuration, notice: t('.success')
       else
         helpers.flash_message(:alert, "#{t('.error')}: #{@app_configuration.errors.full_messages.join(', ')}")

--- a/app/controllers/admin_only/app_configuration_controller.rb
+++ b/app/controllers/admin_only/app_configuration_controller.rb
@@ -18,7 +18,7 @@ module AdminOnly
       if @app_configuration.update(app_config_params)
         # Do not specify the @app_configuration in the path so that the URL is
         # correct: we do _not_ want the :id in the URL. (The AppConfiguration is a singleton)
-        render :show, notice: t('.success')
+        redirect_to @app_configuration, notice: t('.success')
       else
         helpers.flash_message(:alert, "#{t('.error')}: #{@app_configuration.errors.full_messages.join(', ')}")
         render :edit

--- a/app/views/admin_only/app_configuration/_show_action_buttons.html.haml
+++ b/app/views/admin_only/app_configuration/_show_action_buttons.html.haml
@@ -3,5 +3,5 @@
 
 %hr
 .text-center
-  = link_to "#{t('edit')} #{t('admin_only.app_configuration.show.title')}", admin_only_edit_app_configuration_path(app_config), class:'btn btn-light btn-sm'
+  = link_to "#{t('edit')} #{t('admin_only.app_configuration.show.title')}", admin_only_edit_app_configuration_path, class:'btn btn-light btn-sm'
   = link_to "#{t('back')}", :back, class: 'btn btn-light btn-sm'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,10 +36,18 @@ Rails.application.routes.draw do
     # Admins only view and edit the AppConfiguration.
     # There is no need for index or destroy.
     #
-    get 'app_configuration', to: 'app_configuration#show'
-    get 'app_configuration/redigera', to: 'app_configuration#edit',
+    # :id is an optional parameter so that view buttons, etc., work fine
+    # with the Rails conventions
+    #
+    # as: :..app_configuration..  is needed when the id is an optional parameter
+
+    get 'app_configuration(/:id)/redigera', to: 'app_configuration#edit',
         as: :edit_app_configuration
-    put 'app_configuration', to: 'app_configuration#update'
+
+    # must use the as: :put_app_configuration so that the method does not conflict with get 'app_configuration(/:id)' route (#show)
+    put 'app_configuration(/:id)', to: 'app_configuration#update', as: :put_app_configuration
+
+    get 'app_configuration(/:id)', to: 'app_configuration#show', as: :app_configuration
 
 
     get 'user_profile_edit/:id', to: 'user_profile#edit', as: :user_profile_edit

--- a/features/admin_only/app-configuration/admin_edits_app_config.feature
+++ b/features/admin_only/app-configuration/admin_edits_app_config.feature
@@ -113,3 +113,12 @@ Feature: Admin edits application configuration
     And I click on t("submit") button
     Then I should see t("admin_only.app_configuration.update.success")
     And the "site_meta_image" attachment is available via a public url
+
+
+    Scenario: Problem with editting AppConfig, goes back to edit page (SAD PATH)
+      And I am logged in as "admin@random.com"
+      And I am on the "admin edit app configuration" page
+      And I fill in t("admin_only.app_configuration.edit.site_name") with ""
+      And I click on t("submit") button
+      Then I should see t("admin_only.app_configuration.update.error")
+      And I should see t("admin_only.app_configuration.edit.title")

--- a/spec/routing/application_configuration_routes_spec.rb
+++ b/spec/routing/application_configuration_routes_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'Application Configuration has limited actions and does NOT require :id', type: :routing do
+
+  let(:new)  { 'ny' }
+  let(:edit) { 'redigera' }
+
+  app_config_path = 'admin/app_configuration'
+  controller_name = 'admin_only/app_configuration'
+
+
+  it "/#{app_config_path}/redigera = #edit - use the Singleton ApplicationConfiguration" do
+    assert_routing({path: "#{app_config_path}/#{edit}", method: :get}, {controller: controller_name, action: 'edit'})
+  end
+
+  it "/#{app_config_path}/id/redigera = #edit" do
+    assert_routing({path: "#{app_config_path}/1/#{edit}", method: :get}, {controller: controller_name, action: 'edit', id: '1'})
+  end
+
+  it "/#{app_config_path} = #show - use the Singleton ApplicationConfiguration"  do
+    assert_routing({path: "#{app_config_path}", method: :get}, {controller: controller_name, action: 'show'})
+  end
+
+  it "/#{app_config_path}/id = #show" do
+    assert_routing({path: "#{app_config_path}/1", method: :get}, {controller: controller_name, action: 'show', id: '1'})
+  end
+
+  it "put /#{app_config_path} = #update - use the Singleton ApplicationConfiguration" do
+    assert_routing({path: "#{app_config_path}", method: :put}, {controller: controller_name, action: 'update'})
+  end
+
+  it "put /#{app_config_path}/id = #update" do
+    assert_routing({path: "#{app_config_path}/1", method: :put}, {controller: controller_name, action: 'update', id: '1'})
+  end
+
+end


### PR DESCRIPTION
### PT Story:  AppConfig singleton: UI and routing
https://www.pivotaltracker.com/story/show/168200109

### Changes proposed in this pull request:
1.  make an AppConfiguration `:id` in routes _optional); add routing tests (rspec)
2. change buttons to _not_ specify an AppConfiguration instance
3. add a SAD_PATH scenario: if editting an AppConfiguration produces an error, return to the edit page



### Ready for review:
@AgileVentures/shf-project-team 
