### PR TITLE
Fixes User Table (swedish)

### DIFF
--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -823,7 +823,7 @@ sv:
       show_image: Visa bild
       company_h_brand: Företaget H-märke för %{company}
       company_h_brand_describe: Detta är ditt företags H-märke.
-      member_packet: &member_packet medlemspaket
+      member_packet: &member_packet pkt
       sent: skickat
       not_sent: inte skickat
 


### PR DESCRIPTION
1. Just changes one swedish word visible only to admin

## Screenshots (Optional):
![image](https://user-images.githubusercontent.com/7266909/65796433-d9e6a600-e16c-11e9-88da-b2d9a16ec61c.png)
VS 
![image](https://user-images.githubusercontent.com/7266909/65796457-ea971c00-e16c-11e9-800e-2612ddfab5f8.png)

---
## Ready for review:
@weedySeaDragon @patmbolger 
