### PR TITLE
Uglifier gem: accept javascript ES6 syntax

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,11 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+
+  # Per the Uglifier gem documentation on https://github.com/lautis/uglifier,
+  # do the following so Uglifier will accept ES6 syntax:
+  config.assets.js_compressor = Uglifier.new(harmony: true)
+
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
## PT Story: Uglifier gem must handle ES6


#### PT URL: https://www.pivotaltracker.com/story/show/169134562


## Changes proposed in this pull request:
1.  change code in `config/environments/production.rb` to set Uglifier to accept ES6

---
## Ready for review:
@
