### PR TITLE
fix typo: should be File.join not "file.join"

### DIFF
--- a/lib/tasks/conditions/load_conditions.rake
+++ b/lib/tasks/conditions/load_conditions.rake
@@ -9,7 +9,7 @@ namespace :shf do
     RUNNING_LOG = '~/NOTES-RUNNING-LOG.txt'
     NGINX_LOG_DIR = '/var/log/nginx'
     APP_DIR = File.join(ENV['APP_PATH'], 'current/')
-    PUBLIC_DIR = file.join(APP_DIR, 'public')
+    PUBLIC_DIR = File.join(APP_DIR, 'public')
 
 
     # Add a Hash for each Condition to be created


### PR DESCRIPTION
## PT Story: Fix typo in SHF rake task load_conditions
#### PT URL: https://www.pivotaltracker.com/story/show/169135110


## Changes proposed in this pull request:
1.  fix typo in `lib/tasks/conditions/load_conditions.rake`

---
## Ready for review:
@
