### PR TITLE
SHF logo in navigation section: remove height and width attribs

### DIFF
--- a/app/views/application/_navigation.html.haml
+++ b/app/views/application/_navigation.html.haml
@@ -1,6 +1,6 @@
 %nav.navbar.navbar-expand-md
   %a.logooo.navbar-brand{ :href => "https://hitta.sverigeshundforetagare.se" }
-    %img{ :src => "https://media.sverigeshundforetagare.se/2016/12/cropped-16465585_1046630372149121_513430848809205760_n.jpg", :alt => "Sveriges Hundforetagare",  :height => "257", :width => "120" }/
+    %img{ :src => "https://media.sverigeshundforetagare.se/2016/12/cropped-16465585_1046630372149121_513430848809205760_n.jpg", :alt => "Sveriges Hundforetagare" }/
   %button.navbar-toggler{ "aria-controls" => "dropdown-menu", "aria-expanded" => "false", "aria-label" => "Toggle navigation", "data-target" => "#dropdown-menu", "data-toggle" => "collapse", :type => "button" }
     = t('menus.menu')
   .collapse.navbar-collapse#dropdown-menu


### PR DESCRIPTION
## PT Story: SHF logo is distorted

#### PT URL: https://www.pivotaltracker.com/story/show/169310372


## Changes proposed in this pull request:
1. remove height and width attribs from `img` tag

---
## Ready for review:
@thesuss 
