### PR TITLE
Add "become user" to admin's login menus

### DIFF
--- a/app/controllers/admin_only/user_profile_controller.rb
+++ b/app/controllers/admin_only/user_profile_controller.rb
@@ -12,9 +12,9 @@ module AdminOnly
 
       bypass_sign_in(new_user)
 
-      current_user = new_user # neccessary so feature test passes
+      current_user = new_user # necessary so feature test passes
 
-      helpers.flash_message(:warn, t('.have_become', user_id: @user.id))
+      helpers.flash_message(:warn, t('.have_become', user_id: @user.id, user_name: @user.full_name) )
 
       redirect_to user_path(params[:id])
     end

--- a/app/views/application/_login_items.html.haml
+++ b/app/views/application/_login_items.html.haml
@@ -10,6 +10,11 @@
       - if current_user.admin?
         %li
           = link_to t('menus.nav.admin.app_configuration'), admin_only_app_configuration_path, class: 'nav-link'
+
+        - unless @user.nil?
+          %li
+            = link_to t('admin_only.user_profile.edit.become_this_user'), admin_only_become_user_path(@user), class: 'nav-link'
+
       %li
         = link_to t('devise.sessions.destroy.log_out'),
                   destroy_user_session_path, method: :delete, class: 'nav-link'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1104,7 +1104,7 @@ en:
         success: User profile updated successfully
         error: One or more problems prevented the profile from being updated.
       become:
-        have_become: You are now acting as user with id %{user_id}
+        have_become: "You are now acting as user %{user_name} (id: %{user_id}). Log out then log back in as the admin if you need to administrate again."
 
 
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1109,7 +1109,7 @@ sv:
         success: Användarprofil uppdaterad framgångsrikt
         error: Ett eller flera problem hindrade profilen från att uppdateras.
       become:
-        have_become: Du fungerar nu som användare med id %{user_id}
+        have_become: "Du fungerar nu som användare %{user_name} (id: %{user_id}). Logga ut och logga sedan in som administratör om du behöver administrera igen."
 
 
   mailers:

--- a/features/admin_only/admin_becomes_user.feature
+++ b/features/admin_only/admin_becomes_user.feature
@@ -1,0 +1,52 @@
+Feature: Admin becomes a user
+
+  As an admin
+  So that I can see exactly what a user sees and be able to act as them
+  I need to be able to 'become' a user
+
+
+  Background:
+
+    Given the date is set to "2019-06-06"
+
+    Given the App Configuration is not mocked and is seeded
+
+    Given the following users exist
+      | email          | password | admin | member | first_name | last_name | membership_number |
+      | admin@shf.se   | password | true  |        | emma       | admin     |                   |
+      | member@shf.com | password | false | true   | mary       | member    | 1001              |
+
+    Given the following business categories exist
+      | name  | description             |
+      | rehab | physical rehabilitation |
+
+    Given the following companies exist:
+      | name       | company_number | email               | region    |
+      | HappyMutts | 5562252998     | woof@happymutts.com | Stockholm |
+
+    Given the following applications exist:
+      | user_email     | company_number | categories | state    |
+      | member@shf.com | 5562252998     | rehab      | accepted |
+
+
+    Given the following payments exist
+      | user_email     | start_date | expire_date | payment_type | status | hips_id |company_number|
+      | member@shf.com | 2019-1-1   | 2019-12-31  | member_fee   | betald | none    |              |
+      | member@shf.com | 2019-1-1   | 2019-12-31  | branding_fee | betald | none    | 5562252998     |
+
+
+    And I am logged in as "admin@shf.se"
+    And I am on the "all users" page
+
+
+  @selenium
+  Scenario: Admin becomes a user
+    Given I should see "member@shf.com"
+    And I click on "member@shf.com"
+    And I should see "mary member"
+    And I should see "member@shf.com"
+    And I click on t("hello", name: 'emma')
+    When I click on the t("admin_only.user_profile.edit.become_this_user") link
+    Then I should see t("admin_only.user_profile.become.have_become", user_id: 2, user_name: 'mary member')
+    And I should see "mary member"
+    And I should see "member@shf.com"

--- a/features/admin_only/admin_edits_user_profile.feature
+++ b/features/admin_only/admin_edits_user_profile.feature
@@ -39,20 +39,3 @@ Feature: Admin edits user profile
     And the t("activerecord.attributes.user.first_name") field should be set to "Mary"
     And the t("activerecord.attributes.user.last_name") field should be set to "Member"
     And the t("activerecord.attributes.user.membership_number") field should be set to "123"
-
-  @selenium
-  Scenario: Admin becomes user
-    Given I am logged in as "admin@shf.se"
-    And I am on the "all users" page
-    And I should see "member@shf.com"
-    Then I click the icon with CSS class "edit" for the row with "member@shf.com"
-    And I should see t("admin_only.user_profile.edit.title", user: 'mary member')
-
-    And I click on t("admin_only.user_profile.edit.become_this_user")
-
-    # The following step fails with Pundit::NotDefinedError, occurring
-    # in _navigation_edit_my_application.html.haml.  This is not unique
-    # to the following step - any step that looks for something on the page
-    # (and forces a render of the page) results in that error:
-
-    # And I should see t("admin_only.user_profile.become.have_become", user_id: 2)


### PR DESCRIPTION
## PT Story: add explicit admin menu item for Becoming a User
#### PT URL: https://www.pivotaltracker.com/story/show/168384142


## Changes proposed in this pull request:
1.  added 'become user' to the Admin's login menu
2.  added info to the flash message:  "Log out then log back in as the admin if you need to administrate again."
3. Fixed feature by adding complete data

---
## Ready for review:
@AgileVentures/shf-project-team 
