### PR TITLE
Failing cuke test: Upload file with bad type

### DIFF
--- a/app/controllers/shf_documents_controller.rb
+++ b/app/controllers/shf_documents_controller.rb
@@ -33,7 +33,8 @@ class ShfDocumentsController < ApplicationController
     if @shf_document.save
       redirect_to @shf_document, notice: t('.success', document_title: @shf_document.title)
     else
-      render :new, notice: t('.error', document_title: @shf_document.title )
+      helpers.flash_message(:error, t('.error', document_title: @shf_document.title ))
+      render :new
     end
 
   end

--- a/app/models/shf_document.rb
+++ b/app/models/shf_document.rb
@@ -27,7 +27,7 @@ class ShfDocument < ApplicationRecord
 =begin
 
   If the size validation fails, then the error message is looked up in the
-  locale file(s) starting based on I18n conventions, then adding 'actual_file_file'
+  locale file(s) starting based on I18n conventions, then adding 'actual_file_'
   as the attribute, and finally adding 'file_too_large' which is what is specified by the
   'message' key within the 'size' hash above.  For some reason, the Paperclip gem will
   raise (or find) 2 error messages:  the one for 'actual_file_file_size' and
@@ -57,8 +57,6 @@ class ShfDocument < ApplicationRecord
     max = the upper bound of the file size
     count = the upper bound, converted to 'human_size' by ActiveSupport::NumberHelper.number_to_human_size(size)
     value = the actual size of the file
-
-
 
 =end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,7 +234,8 @@ en:
         title: &title Title
         description: *description
         uploader: &uploader Uploader
-
+        actual_file_content_type: Uploaded file type
+        actual_file: Uploaded file
 
       member_app_waiting_reason:
         name_sv: "Name (Swedish)"
@@ -911,7 +912,7 @@ en:
     all_shf_documents: All SHF Documents
     all_shf_minutes: All Meeting Minutes
 
-    invalid_upload_type: Sorry, this is not a file type you can upload.
+    invalid_upload_type: *invalid_upload_type
     file_too_large: *file_too_large_5MB
 
     contents_access_error: 'There was an error accessing the file: %{message}'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -234,6 +234,9 @@ sv:
         title: &title Titel
         description: *description
         uploader: &uploader Uppladdad av
+        actual_file_content_type: Uppladdad filtyp
+        actual_file: Uppladdad fil
+
 
       member_app_waiting_reason:
         name_sv: "Namn (svenska)"

--- a/features/shf-documents/admin-uploads-shf-documents.feature
+++ b/features/shf-documents/admin-uploads-shf-documents.feature
@@ -43,7 +43,8 @@ Feature: Admin uploads meeting PDFs
       | Uploaded tred.exe        | some description              |
     And I choose a shf-document named "tred.exe" to upload
     When I click on t("submit") button
-    Then I should see t("shf_documents.invalid_upload_type")
+    Then I should see t("shf_documents.create.error", document_title: 'Uploaded tred.exe')
+    And I should see t("shf_documents.invalid_upload_type")
     When I am on the "all SHF documents" page
     Then I should not see "Uploaded diploma"
 

--- a/features/shf-documents/admin-uploads-shf-documents.feature
+++ b/features/shf-documents/admin-uploads-shf-documents.feature
@@ -23,6 +23,8 @@ Feature: Admin uploads meeting PDFs
 
     And I am logged in as "admin@shf.se"
 
+
+
   @admin
   Scenario: Upload a meeting PDF
     Given I am on the "new SHF document" page


### PR DESCRIPTION
## PT Story: Failing cuke test: upload a file with unacceptable content type 
#### PT URL: https://www.pivotaltracker.com/story/show/169444117

Was missing locale entries

Note that Paperclip shows 2 error messages (one about the file and one about the file type).  
Since (1) only the admin sees this error, and (2) we'll be changing to ActiveStorage, I didn't spend any time correcting that. 


## Changes proposed in this pull request:
1.  add missing locale entries (`activerecord.attributes.shf_document  actual_file and actual_file_content_type`
2. show the troublesome file name in the flash error message
---
## Ready for review:
@AgileVentures/shf-project-team 
