### PR TITLE
Rspec, Features: add contexts, DRY, minor cleanup

### DIFF
--- a/features/admin-dashboard/admin_dashboard.feature
+++ b/features/admin-dashboard/admin_dashboard.feature
@@ -7,7 +7,7 @@ Feature: Admin sees the dashboard with summary of important information
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email                            | admin | member |
       | new_1@bowwowwow.se               |       |        |
       | new_2@mutts.se                   |       |        |

--- a/features/admin-dashboard/admin_search_everything_tool.feature
+++ b/features/admin-dashboard/admin_search_everything_tool.feature
@@ -15,7 +15,7 @@ Feature: Admin can search on everything and save results
 
 #  Background:
 #
-#    Given the following users exists
+#    Given the following users exist:
 #      | email                       | admin | member |
 #      | emma_member@mutts.se        |       | true   |
 #      | hans_member@mutts.se        |       | true   |

--- a/features/admin_clicks_cat_to_see_details.feature
+++ b/features/admin_clicks_cat_to_see_details.feature
@@ -27,7 +27,7 @@ Feature: Link categories to categories show for an Admin
       | Company7 | 7661057765     | cmpy7@mail.com | Stockholm    | Alingsås | Harplinge | street_address |
       | stockholmCo | 7736362901     | cmpy8@mail.com | Stockholm    | Alingsås | Harplinge | street_address |
 
-    And the following users exists
+    And the following users exist:
       | email           | admin | member |
       | user1@mutts.com |       | true   |
       | user2@mutts.com |       | true   |

--- a/features/admin_creates_company.feature
+++ b/features/admin_creates_company.feature
@@ -12,7 +12,7 @@ Feature: As an admin
   PT:  https://www.pivotaltracker.com/story/show/133081453
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email                      | admin | member |
       | applicant_1@happymutts.com |       | true   |
       | applicant_3@happymutts.com |       |        |

--- a/features/admin_only/app-configuration/admin_edits_app_config.feature
+++ b/features/admin_only/app-configuration/admin_edits_app_config.feature
@@ -6,7 +6,7 @@ Feature: Admin edits application configuration
 
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email             | password | admin | member    | first_name | last_name |
       | admin@random.com  | password | true  | false     | emma       | admin     |
 

--- a/features/admin_only/app-configuration/admin_toggle_new_app_emails_enabled.feature
+++ b/features/admin_only/app-configuration/admin_toggle_new_app_emails_enabled.feature
@@ -7,7 +7,7 @@ Feature: Admin enables/disables the emails sent when a new application is receiv
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email                 | admin | member |
       | new_user1@example.com |       |        |
       | admin@shf.se          | true  |        |

--- a/features/admin_only/app-configuration/app-config-missing-image.feature
+++ b/features/admin_only/app-configuration/app-config-missing-image.feature
@@ -7,7 +7,7 @@ Feature: App Config has a missing image or images
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email             | password | admin | member    | first_name | last_name |
       | admin@shf.se  | password | true  | false     | emma       | admin     |
 

--- a/features/admins/show-user-account-to-admin.feature
+++ b/features/admins/show-user-account-to-admin.feature
@@ -1,8 +1,8 @@
-Feature: Admin sees user account information
+Feature: Admin sees additional user details information
 
   As an admin
-  So that I can see and update the account info for a user
-  Show me all of the the user account information for a user
+  So that I can see and update the details for a user
+  Show me additional info about a user (in addition to all of the the user details information)
 
   PT:  https://www.pivotaltracker.com/story/show/140358959
 
@@ -42,12 +42,56 @@ Feature: Admin sees user account information
       | rejected@happymutts.com      | rejected@happymutts.com | 5560360793     | rejected |
 
 
+    And the following payments exist
+      | user_email                   | start_date | expire_date | payment_type | status | hips_id | notes                              |
+      | hannah-member@happymutts.com | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    | This is the membership status note |
+
+
     And the following membership packets have been sent:
       | user_email                 | date_sent  |
       | lars-member@happymutts.com | 2019-03-01 |
 
 
     And I am logged in as "admin@shf.se"
+
+
+  # ====================
+  # Admin sees User Info
+
+  # -----------------------------------
+  # Membership Packet info
+
+  Scenario: Membership packet sent to a member: show that it was sent and the date
+    When I am on the "user details" page for "lars-member@happymutts.com"
+    Then I should see t("users.show.member_packet")
+    And I should see t("users.show.sent")
+    And I should see "2019-03-01"
+
+
+  Scenario: Membership packet: If a member but no date sent, should show 'Membership packet not sent'
+    When I am on the "user details" page for "hannah-member@happymutts.com"
+    Then I should see t("users.show.member_packet")
+    And I should see t("users.show.not_sent")
+
+
+  Scenario: Membership packet info shows for non-members (maybe they used to be a member)
+    When I am on the "user details" page for "rejected@happymutts.com"
+    Then I should see t("users.show.member_packet")
+    And I should see t("users.show.not_sent")
+
+
+  Scenario: A member cannot see membership packet info
+    When I am logged out
+    And I am logged in as "lars-member@happymutts.com"
+    And I am on the "user details" page for "lars-member@happymutts.com"
+    Then I should not see t("users.show.member_packet")
+
+
+  Scenario: A user cannot see membership packet info
+    When I am logged out
+    And I am logged in as "user-anna@personal.se"
+    And I am on the "user details" page for "user-anna@personal.se"
+    Then I should not see t("users.show.member_packet")
 
 
   # -----------------------------------
@@ -144,6 +188,9 @@ Feature: Admin sees user account information
     Then I should see t("users.show.password_never_reset")
 
 
+  # ======================
+  # Membership Information
+
   # -----------------------------------
   # Membership number
 
@@ -153,11 +200,27 @@ Feature: Admin sees user account information
     And I should see "101"
 
 
+  # -----------------------------------
+  # Membership status notes
+
+  Scenario: Show membership status notes
+    When I am on the "user details" page for "hannah-member@happymutts.com"
+    Then I should see t("activerecord.attributes.payment.notes")
+    And I should see "This is the membership status note"
+
+  Scenario: Show 'none' if there are no membership status notes
+    When I am on the "user details" page for "lars-member@happymutts.com"
+    Then I should see t("activerecord.attributes.payment.notes")
+    And I should see t("none_plur")
+
 
   Scenario: Do not show the membership number when there is none
     When I am on the "user details" page for "user-never-logged-in@example.se"
     Then I should not see t("users.show.membership_number")
 
+
+  # ================
+  # Application Info
 
   # -----------------------------------
   # Email address and application state
@@ -170,40 +233,4 @@ Feature: Admin sees user account information
     And I should see t("shf_applications.state.new")
     Then I click on "change-lang-to-english"
     And I should see t("shf_applications.state.new")
-
-
-  # -----------------------------------
-  # Membership Packet info
-
-  Scenario: Membership packet sent to a member: show that it was sent and the date
-    When I am on the "user details" page for "lars-member@happymutts.com"
-    Then I should see t("users.show.member_packet")
-    And I should see t("users.show.sent")
-    And I should see "2019-03-01"
-
-
-  Scenario: Membership packet: If a member but no date sent, should show 'Membership packet not sent'
-    When I am on the "user details" page for "hannah-member@happymutts.com"
-    Then I should see t("users.show.member_packet")
-    And I should see t("users.show.not_sent")
-
-
-  Scenario: Membership packet info shows for non-members (maybe they used to be a member)
-    When I am on the "user details" page for "rejected@happymutts.com"
-    Then I should see t("users.show.member_packet")
-    And I should see t("users.show.not_sent")
-
-
-  Scenario: A member cannot see membership packet info
-    When I am logged out
-    And I am logged in as "lars-member@happymutts.com"
-    And I am on the "user details" page for "lars-member@happymutts.com"
-    Then I should not see t("users.show.member_packet")
-
-
-  Scenario: A user cannot see membership packet info
-    When I am logged out
-    And I am logged in as "user-anna@personal.se"
-    And I am on the "user details" page for "user-anna@personal.se"
-    Then I should not see t("users.show.member_packet")
 

--- a/features/admins/show-user-account-to-admin.feature
+++ b/features/admins/show-user-account-to-admin.feature
@@ -9,7 +9,7 @@ Feature: Admin sees user account information
   Background:
     Given the App Configuration is not mocked and is seeded
 
-    Given the following users exists
+    Given the following users exist:
       | email                           | admin | membership_number | member |
       | emma-new-app@bowsers.com        |       |                   |        |
       | lars-member@happymutts.com      |       | 101               | true   |

--- a/features/admins/users_list_edit_member_packets_sent.feature
+++ b/features/admins/users_list_edit_member_packets_sent.feature
@@ -8,7 +8,7 @@ Feature: Admin sets when member packets were sent on the all users page
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email                  | admin | membership_number | member |
       | emma@bowsers.se        |       | 100               | true   |
       | lars@happymutts.se     |       | 101               | true   |

--- a/features/approve-member.feature
+++ b/features/approve-member.feature
@@ -10,7 +10,7 @@ Feature: As an admin
   Background:
     Given the App Configuration is not mocked and is seeded
 
-    Given the following users exists
+    Given the following users exist:
       | email                 | admin |
       | emma@happymutts.se    |       |
       | hans@happymutts.se    |       |

--- a/features/company_shows_all_employee_categories.feature
+++ b/features/company_shows_all_employee_categories.feature
@@ -14,7 +14,7 @@ Feature: As a visitor
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email                 | admin |
       | emma@happymutts.com   |       |
       | lars@happymutts.com   |       |

--- a/features/conditions/company_incomplete_alerts.feature
+++ b/features/conditions/company_incomplete_alerts.feature
@@ -12,7 +12,7 @@ Feature: Alerts sent if Company info is incomplete (a Condition response)
     Given the date is set to "2018-01-01"
 
 
-    Given the following users exists
+    Given the following users exist:
       | email                              | admin | member |
       | memb01_paid_jan01@nil-region.se    |       | true   |
       | memb02_paid_jan03@nil-region.se    |       | true   |

--- a/features/conditions/hbrand_fee_due_alerts_has_hbrand_fee_pays.feature
+++ b/features/conditions/hbrand_fee_due_alerts_has_hbrand_fee_pays.feature
@@ -15,7 +15,7 @@ Feature: Alerts sent for H-branding fee is due; company HAS previous H-Branding 
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email                                      | admin | member |
       | memb01_exp_18_1_3@mutts-exp-17-6-6.se      |       | true   |
       | memb02_exp-17-1-4@mutts-exp-17-6-6.se      |       | true   |

--- a/features/conditions/hbrand_fee_due_alerts_no_hbrand_payments.feature
+++ b/features/conditions/hbrand_fee_due_alerts_no_hbrand_payments.feature
@@ -15,7 +15,7 @@ Feature: Alerts sent for H-branding fee needs to be paid; company has NO previou
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email                         | admin | member |
       | member01_start_jan_4@mutts.se |       | true   |
       | member02_start_jan_5@mutts.se |       | true   |

--- a/features/conditions/member_fee_lapsed_alerts.feature
+++ b/features/conditions/member_fee_lapsed_alerts.feature
@@ -8,7 +8,7 @@ Feature: Alerts for members whose membership has lapsed (a Condition response)
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email                       | admin | member |
       | member01_exp_jan_3@mutts.se |       | true   |
       | member02_exp_jan_4@mutts.se |       | true   |

--- a/features/conditions/member_unpaid_over6_months_alert.feature
+++ b/features/conditions/member_unpaid_over6_months_alert.feature
@@ -10,7 +10,7 @@ Feature: Membership address get emails when a member has been unpaid for > 6 mon
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email                          | admin | member |
       | exp_may_31_01@mutts.se         |       | true   |
       | exp_may_31_02@mutts.se         |       | true   |

--- a/features/conditions/membership_expiration_alerts.feature
+++ b/features/conditions/membership_expiration_alerts.feature
@@ -9,7 +9,7 @@ Feature: Membership expiration alerts are sent out (Condition response)
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email                            | admin | member |
       | member01_exp_jan_3@mutts.se      |       | true   |
       | member02_exp_jan_4@mutts.se      |       | true   |

--- a/features/conditions/shf_app_missing_uploads_alerts.feature
+++ b/features/conditions/shf_app_missing_uploads_alerts.feature
@@ -9,7 +9,7 @@ Feature: Reminder if SHF Application is missing uploaded files (Condition respon
 
     Given the date is set to "2018-11-30"
 
-    Given the following users exists
+    Given the following users exist:
       | email                                   | admin | member |
       | member01_new@mutts.se                   |       | false  |
       | member02_under_review@mutts.se          |       | false  |

--- a/features/create_business_category.feature
+++ b/features/create_business_category.feature
@@ -6,7 +6,7 @@ Feature: As an admin
   PT: https://www.pivotaltracker.com/story/show/135009339
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email                | admin |
       | applicant@random.com |       |
       | admin@shf.com        | true  |

--- a/features/db_seeding/seeding_business_categories.feature
+++ b/features/db_seeding/seeding_business_categories.feature
@@ -6,7 +6,7 @@ Feature: Seed business categories
   I expect to see business categories when the system is revised (when it's seeded).
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email                | admin |
       | admin@shf.com        | true  |
 

--- a/features/delete-company.feature
+++ b/features/delete-company.feature
@@ -14,7 +14,7 @@ Feature: As an admin
 
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email                          | admin |
       | emma@happymutts.com            |       |
       | hans@happymutts.com            |       |

--- a/features/delete_business_category.feature
+++ b/features/delete_business_category.feature
@@ -6,7 +6,7 @@ Feature: As an admin
 
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email                | admin |
       | applicant@random.com |       |
       | admin@shf.com        | true  |

--- a/features/delete_shf_application.feature
+++ b/features/delete_shf_application.feature
@@ -8,7 +8,7 @@ Feature: As an admin
   associated with a company, then delete the company too.
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email            | admin |
       | emma@random.com  |       |
       | hans@bowsers.com |       |

--- a/features/devise-views-i18n.feature
+++ b/features/devise-views-i18n.feature
@@ -9,7 +9,7 @@ Feature: As a non-swedish speaking potential member
   PT: https://www.pivotaltracker.com/story/show/133316647
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email                |
       | emma@random.com      |
 

--- a/features/disallow-company-malicious-website.feature
+++ b/features/disallow-company-malicious-website.feature
@@ -6,7 +6,7 @@ Feature: Don't allow malicious code in Company website value
 
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email          | admin | member |
       | emma@mutts.com |       | true   |
       | admin@shf.se   | true  |        |

--- a/features/edit_account.feature
+++ b/features/edit_account.feature
@@ -3,7 +3,7 @@ Feature: As a registered user
   I need to be able to edit my account
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | first_name | last_name | email              | password | admin |
       | emma       | andersson | emma@andersson.com | password | false |
 

--- a/features/edit_business_category.feature
+++ b/features/edit_business_category.feature
@@ -6,7 +6,7 @@ Feature: As an admin
 
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email                | admin |
       | applicant@random.com |       |
       | admin@shf.com        | true  |

--- a/features/edit_company.feature
+++ b/features/edit_company.feature
@@ -3,7 +3,7 @@ Feature: As a member
   I need to be able to edit my company
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email                   | admin | member |
       | paid_member@mutts.com   |       | true   |
       | unpaid_member@mutts.com |       | true   |

--- a/features/edit_link_on_company_page.feature
+++ b/features/edit_link_on_company_page.feature
@@ -4,7 +4,7 @@ Feature: As the owner of a company (or an admin)
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email                 | admin | member    |
       | emma@happymutts.com   |       | true      |
       | lars@happymutts.com   |       | true      |

--- a/features/edit_member_page.feature
+++ b/features/edit_member_page.feature
@@ -5,7 +5,7 @@ Feature: Edit a member page
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email                    | admin |
       | admin@shf.se             | true  |
 

--- a/features/edit_shf_application.feature
+++ b/features/edit_shf_application.feature
@@ -8,7 +8,7 @@ Feature: Edit SHF Application
 
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email             | member    | admin |
       | emma@random.com   | false     |       |
       | hans@random.com   | false     |       |

--- a/features/emails/email-applicant-membership-granted.feature
+++ b/features/emails/email-applicant-membership-granted.feature
@@ -10,7 +10,7 @@ Feature: Applicant gets an email when membership has been granted. (They are now
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email              | admin |
       | emma@happymutts.se |       |
       | admin@shf.com      | true  |

--- a/features/emails/email-applicant-when-app-approved.feature
+++ b/features/emails/email-applicant-when-app-approved.feature
@@ -9,7 +9,7 @@ Feature: Applicant gets an email when the application is approved
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email              | admin |
       | emma@happymutts.se |       |
       | admin@shf.com      | true  |

--- a/features/emails/new-application-email-to-admins.feature
+++ b/features/emails/new-application-email-to-admins.feature
@@ -9,7 +9,7 @@ Feature: When a new application is received, all admins get an email notificatio
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email               | admin | first_name | last_name  |
       | admin1@shf.se       | yes   |            |            |
       | admin2@shf.se       | yes   |            |            |

--- a/features/emails/new-application-gets-ack-email.feature
+++ b/features/emails/new-application-gets-ack-email.feature
@@ -8,7 +8,7 @@ Feature: New Applicant gets an email acknowledging their application
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email               | admin |
       | emma@happymutts.com |       |
 

--- a/features/events_management/dinkurs_events.feature
+++ b/features/events_management/dinkurs_events.feature
@@ -7,7 +7,7 @@ Feature: As a member of a company
   I want to see schduled company events when I view the company's page
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email            | admin | member |
       | member@mutts.com |       | true   |
       | visitor@mail.com |       |        |

--- a/features/export-member-email-info.feature
+++ b/features/export-member-email-info.feature
@@ -5,7 +5,7 @@ Feature: export member information to a CSV file so I can use it in other system
 
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | last_name   | email                       | admin |
       | Emmasdottir | emma@happymutts.com         |       |
       | Wilson      | wils@woof.com               |       |

--- a/features/landing_page_for_admin.feature
+++ b/features/landing_page_for_admin.feature
@@ -5,7 +5,7 @@ Feature: As an Admin
   PT: https://www.pivotaltracker.com/story/show/135683887
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email              | admin | member |
       | emma@happymutts.se |       | true   |
       | hans@bowsers.com   |       | false  |

--- a/features/list_companies_of_category.feature
+++ b/features/list_companies_of_category.feature
@@ -4,7 +4,7 @@ Feature: As any type of visitor
   PT: https://www.pivotaltracker.com/story/show/135684057
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email               | admin | member |
       | emma@happymutts.com |       | true   |
       | ernt@mutts.com      |       | true   |

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -3,7 +3,7 @@ Feature: As a registered user
   I need to be able to login
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email                | password | admin | member |
       | emma@random.com      | password | false | true   |
       | lars-user@random.com | password | false | false  |

--- a/features/mapping_and_geocoding/companies_are_geocoded_when_viewing_all.feature
+++ b/features/mapping_and_geocoding/companies_are_geocoded_when_viewing_all.feature
@@ -21,7 +21,7 @@ Feature: All companies are geocoded before being shown on the view all companies
       | Bowsers              | 2120000142     | bowwow@bowsersy.com    | Västerbotten | Bromölla | street_address |
       | CompanyNotVisible    | 5569467466     | company@notvisible.com | Stockholm    | Alingsås | none           |
 
-    And the following users exists
+    And the following users exist:
       | email               | admin | member |
       | emma@happymutts.com |       | true   |
       | a@happymutts.com    |       | true   |

--- a/features/member_edits_company_page.feature
+++ b/features/member_edits_company_page.feature
@@ -5,7 +5,7 @@ Feature: As a member
   PT:  https://www.pivotaltracker.com/story/show/133081453
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email               | admin | member |
       | emma@happymutts.com |       | true   |
       | member@random.com   |       | true   |

--- a/features/membership-application-status/admin-custom-reason-waiting.feature
+++ b/features/membership-application-status/admin-custom-reason-waiting.feature
@@ -19,7 +19,7 @@ Feature: "Other/Custom" waiting reason comes from locale file and Admin cannot e
     # Given the system is seeded with initial data
 
 
-    Given the following users exists
+    Given the following users exist:
       | email                                  | admin |
       | anna_waiting_for_info@nosnarkybarky.se |       |
       | anna_under_review@nosnarkybarky.se     |       |

--- a/features/membership-application-status/admin-manage-reasons-waiting-for-info.feature
+++ b/features/membership-application-status/admin-manage-reasons-waiting-for-info.feature
@@ -11,7 +11,7 @@ Feature: Admin manages the list of reasons why SHF is waiting for info from an a
 
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email                                  | admin |
       | anna_waiting_for_info@nosnarkybarky.se |       |
       | emma@happymutts.se                     |       |

--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -8,7 +8,7 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
   PT: https://www.pivotaltracker.com/story/show/143810729
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email                                  | admin |
       | anna_waiting_for_info@nosnarkybarky.se |       |
       | admin@shf.com                          | true  |

--- a/features/redirect-user-to-login-page.feature
+++ b/features/redirect-user-to-login-page.feature
@@ -25,7 +25,7 @@ Feature: Redirect User to the login page if they need to be logged in
       | Company01 | 5560360793     | cmpy1@mail.com  | Stockholm    | Alingsås |
 
 
-    And the following users exists
+    And the following users exist:
       | email         | admin | member |
       | u1@mutts.com  |       | true   |
 

--- a/features/search_companies.feature
+++ b/features/search_companies.feature
@@ -5,7 +5,7 @@ In order to find companies that I might want to work with
 I want to search for available companies by various criteria
 
 Background:
-  Given the following users exists
+  Given the following users exist:
     | email                | admin | member |
     | fred@barkyboys.com   |       | true   |
     | john@happymutts.com  |       | true   |

--- a/features/search_shf_applications.feature
+++ b/features/search_shf_applications.feature
@@ -5,7 +5,7 @@ Feature: Admin can search Shf Applications
   I want to search for applications by various criteria
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | first_name | last_name | email               | admin | membership_number |
       | Fred       | Fransson  | fred@barkyboys.com  |       | 3                 |
       | John       | Johanssen | john@happymutts.com |       | 14                |

--- a/features/shf-documents/admin-deletes-shf-document.feature
+++ b/features/shf-documents/admin-deletes-shf-document.feature
@@ -8,7 +8,7 @@ Feature: Admin can delete uploaded SHF Documents
   Background:
 
 
-    Given the following users exists
+    Given the following users exist:
       | email              | admin |
       | emma@happymutts.se |       |
       | bob@snarkybarky.se |       |

--- a/features/shf-documents/admin-edits-shf-document.feature
+++ b/features/shf-documents/admin-edits-shf-document.feature
@@ -8,7 +8,7 @@ Feature: Admin can edit details about an uploaded SHF Document
   Background:
 
 
-    Given the following users exists
+    Given the following users exist:
       | email               | admin |
       | emma@happymutts.se  |       |
       | bob@snarkybarky.se  |       |

--- a/features/shf-documents/admin-uploads-shf-documents.feature
+++ b/features/shf-documents/admin-uploads-shf-documents.feature
@@ -6,7 +6,7 @@ Feature: Admin uploads meeting PDFs
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email               | admin |
       | emma@happymutts.se  |       |
       | bob@snarkybarky.se  |       |

--- a/features/shf-documents/admin-views-shf-document-details.feature
+++ b/features/shf-documents/admin-views-shf-document-details.feature
@@ -8,7 +8,7 @@ Feature: Admin can edit details about an uploaded SHF Document
   Background:
 
 
-    Given the following users exists
+    Given the following users exist:
       | email               | admin |
       | emma@happymutts.se  |       |
       | bob@snarkybarky.se  |       |

--- a/features/shf-documents/view-all-shf-documents.feature
+++ b/features/shf-documents/view-all-shf-documents.feature
@@ -10,7 +10,7 @@ Feature: SHF members (and admins) can views board meeting minutes (SHF documents
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email              | admin | member |
       | emma@happymutts.se |       | true   |
       | bob@snarkybarky.se |       | false  |

--- a/features/show-company.feature
+++ b/features/show-company.feature
@@ -35,7 +35,7 @@ Feature: Show company page - display different info depending on role
       | Company7 | 7661057765     | cmpy7@mail.com | Stockholm    | Alingsås | Harplinge | street_address |
       | Company8 | 7736362901     | cmpy8@mail.com | Stockholm    | Alingsås | Harplinge | street_address |
 
-    And the following users exists
+    And the following users exist:
       | email           | admin | member |
       | user1@mutts.com |       | true   |
       | user2@mutts.com |       | true   |

--- a/features/show-user-details.feature
+++ b/features/show-user-details.feature
@@ -8,7 +8,7 @@ Feature: Show user account information
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email            | admin | membership_number | member |
       | emma@example.com |       |                   |        |
       | lars@example.com |       | 101               | true   |

--- a/features/show_all_shf_applications.feature
+++ b/features/show_all_shf_applications.feature
@@ -7,7 +7,7 @@ Feature: Admin can see all SHF applications so they can be managed
   PT: https://www.pivotaltracker.com/story/show/133080839
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | first_name         | email                               | admin |
       | Emma               | emma@personal.com                   |       |
       | Emma               | emma_waits@waiting.se               |       |

--- a/features/show_only_searchable_companies.feature
+++ b/features/show_only_searchable_companies.feature
@@ -30,7 +30,7 @@ Feature: So that I do not get frustrated by trying to find out more
       | NoPayment    | 5562252998     | hello@nopayment.se     | Stockholm             | Alingsås |
       | NoMember     | 9697222900     | hello@nomember.se      | Stockholm             | Alingsås |
 
-    And the following users exists
+    And the following users exist:
       | email                        | admin | member |
       | emmagroomer@happymutts.com   |       | true   |
       | annatrainer@bowsers.com      |       | true   |

--- a/features/show_shf_application.feature
+++ b/features/show_shf_application.feature
@@ -13,7 +13,7 @@ Feature: View a SHF Application
   PT: https://www.pivotaltracker.com/story/show/133080839
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | first_name         | email                               | admin |
       | Emma               | emma_waits@waiting.se               |       |
       | Emma               | emma@random.com                     |       |

--- a/features/show_status_of_all_shf_applications.feature
+++ b/features/show_status_of_all_shf_applications.feature
@@ -6,7 +6,7 @@ Feature: Admin sees the status of applications on page of all SHF applications
   PT: https://www.pivotaltracker.com/story/show/134357317
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email                         | admin |
       | new@mail.se                   |       |
       | under_review@mail.se          |       |

--- a/features/size_validation.feature
+++ b/features/size_validation.feature
@@ -5,7 +5,7 @@ Feature: Applicant uploads too large a file for their application
   PT: https://www.pivotaltracker.com/story/show/136316233
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email                 | admin |
       | hans@new_applicant.se |       |
       | emma@happymutts.se    |       |

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,4 +1,7 @@
-Given(/^the following users exist(?:s|)$/) do |table|
+# This should match any of the following
+#  the following users exist
+#  the following users exist:
+Given(/^the following users exist(?:[:])?$/) do |table|
 
   # Hash value "is_legacy" indicates a user account that was created before we
   # migrated the user's name attributes (first_name, last_name) from the

--- a/features/update_membership_application.feature
+++ b/features/update_membership_application.feature
@@ -12,7 +12,7 @@ Feature: SHF Application status is changed
 
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | first_name      | email                                  | admin |
       | EmmaUnderReview | emma_under_review@happymutts.se        |       |
       | HansUnderReview | hans_under_review@happymutts.se        |       |
@@ -80,7 +80,7 @@ Feature: SHF Application status is changed
     Then I should see t("shf_applications.accepted") 1 time in the list of applications
     Then I should see t("shf_applications.rejected") 1 time in the list of applications
 
-    
+
 
   # From under_review to...
 
@@ -322,7 +322,7 @@ Feature: SHF Application status is changed
     And I click on t("shf_applications.edit.submit_button_label")
 
     And I should see t("shf_applications.update.success_with_app_files_missing")
-        
+
     And I should see status line with status t("shf_applications.rejected")
     And I should see "rehab"
     When I am on the "landing" page

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -5,7 +5,7 @@ Feature: Applicant uploads a file for their application
   PT: https://www.pivotaltracker.com/story/show/133109591
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email                  | admin |
       | applicant_1@random.com |       |
       | applicant_2@random.com |       |

--- a/features/user-applies-approved-edits-co.feature
+++ b/features/user-applies-approved-edits-co.feature
@@ -4,7 +4,7 @@ Feature: Whole process of a new user creating a login, applying, being approved,
   Background:
     Given the App Configuration is not mocked and is seeded
 
-    Given the following users exists
+    Given the following users exist:
       | email                | admin | first_name | last_name |
       | new_user@example.com |       | NewUser1   | Lastname  |
       | admin@shf.se         | true  |            |           |

--- a/features/user_profile/admin-resets-users-password.feature
+++ b/features/user_profile/admin-resets-users-password.feature
@@ -5,7 +5,7 @@ Feature: As an admin
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email               | admin |
       | emma@happymutts.com |       |
       | bob@snarkybarky.se  |       |

--- a/features/user_profile/user-edits-profile.feature
+++ b/features/user_profile/user-edits-profile.feature
@@ -3,7 +3,7 @@ Feature: As a registered user
   Including my first name, last name, email and password
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email             | password | admin | member    | first_name | last_name |
       | admin@random.com  | password | true  | false     | emma       | admin     |
       | member@random.com | password | false | true      | mary       | member    |

--- a/features/user_profile/user-resets-password.feature
+++ b/features/user_profile/user-resets-password.feature
@@ -5,7 +5,7 @@ Feature: As a user
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email               | is_legacy |
       | emma@happymutts.com | true      |
 

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -60,7 +60,7 @@ Feature: Visitor sees all companies
       | Company02    | Norrbotten | Alvesta | Årsta   |
       | Company02    | Uppsala    | Aneby   | Kolbäck |
 
-    And the following users exists
+    And the following users exist:
       | email         | admin | member |
       | u1@mutts.com  |       | true   |
       | u2@mutts.com  |       | true   |

--- a/features/view_hidden_pages.feature
+++ b/features/view_hidden_pages.feature
@@ -2,7 +2,7 @@ Feature: Only members and admins can see members only (hidden) pages
 
   Background:
 
-    Given the following users exists
+    Given the following users exist:
       | email                    | admin | member    |
       | emma@happymutts.com      |       | true      |
       | not_a_member@bowsers.com |       | false     |

--- a/features/view_shf_applications.feature
+++ b/features/view_shf_applications.feature
@@ -5,7 +5,7 @@ Feature: Admin sees as many or few SHF Applications as they want (pagination)
   I want to see all membership applications
 
   Background:
-    Given the following users exists
+    Given the following users exist:
       | email         | admin | member    |
       | u1@mutts.com  |       | false     |
       | u2@mutts.com  |       | false     |

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -3,9 +3,15 @@ require 'rails_helper'
 RSpec.describe AdminController, type: :controller do
 
   # this will bypass Pundit policy access checks so logging in is not necessary
-  before(:each) { Warden.test_mode! }
+  before(:each) do
+    Warden.test_mode!
+    Timecop.freeze(Time.zone.parse("2019-01-01"))
+  end
 
-  after(:each) { Warden.test_reset! }
+  after(:each) do
+    Warden.test_reset!
+    Timecop.return
+  end
 
   let(:user) { create(:user) }
 
@@ -34,6 +40,9 @@ RSpec.describe AdminController, type: :controller do
   out_str }
 
   let(:expected_pattern) { /(.*)\n(.*),(.*),(.*),(.*),(.*),(.*),(.*),([^"]*),"([^"]*)","([^"]*)","([^"]*)","([^"]*)","([^"]*)","([^"]*)","([^"]*)",'(.*),"([^"]*)",(.*),(.*),(.*)\n/m }
+
+  let(:payment_successful) { 'betald' }
+  let(:payment_expiry_20191108) { Time.zone.parse("2019-11-08") }
 
 
   describe '#export_ankosan_csv' do
@@ -216,18 +225,18 @@ RSpec.describe AdminController, type: :controller do
 
         let(:membership_payment) do
           FactoryBot.create(:payment,
-                            status:      'betald',
+                            status:      payment_successful,
                             user:        u1,
-                            expire_date: Time.zone.parse("2019-11-08"))
+                            expire_date: payment_expiry_20191108)
         end
 
         let(:branding_payment) do
           FactoryBot.create(:payment,
-                            status:       'betald',
+                            status:       payment_successful,
                             user:         u1,
                             company:      membership_app.companies.first,
                             payment_type: Payment::PAYMENT_TYPE_BRANDING,
-                            expire_date:  Time.zone.parse("2019-11-08"))
+                            expire_date:  payment_expiry_20191108)
         end
 
 

--- a/spec/factories/app_configurations.rb
+++ b/spec/factories/app_configurations.rb
@@ -1,4 +1,4 @@
-APP_CONFIG_FIXTURES = Rails.root.join('spec', 'fixtures', 'app_configuration')
+APP_CONFIG_FIXTURES = Rails.root.join('spec', 'fixtures', 'app_configuration') unless defined?(APP_CONFIG_FIXTURES)
 
 FactoryBot.define do
 

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     start_date { Time.zone.today }
     expire_date { Time.zone.today + 1.year - 1.day }
     hips_id { 'none' }
-
+    notes { nil }
     updated_at { Time.zone.now }
   end
 

--- a/spec/factories/shf_applications.rb
+++ b/spec/factories/shf_applications.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     file_delivery_method { AdminOnly::FileDeliveryMethod.first ||
                            association(:file_delivery_method) }
 
-    file_delivery_selection_date { Date.current }                    
+    file_delivery_selection_date { Date.current }
 
     trait :legacy_application do
       file_delivery_method { nil }
@@ -41,6 +41,8 @@ FactoryBot.define do
       create_company { true }
     end
 
+    # TODO - this seems to _always_ create (build and save) a business category instead of trying to look up one with an existing name.
+    #    Fix and test very carefully.
     after(:build) do |shf_app, evaluator|
 
       if evaluator.num_categories == 1

--- a/spec/factories/uploaded_files.rb
+++ b/spec/factories/uploaded_files.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
 
     shf_application
 
-    FIXTURE_DIR = File.join("#{Rails.root}",'spec','fixtures','uploaded_files')
+    FIXTURE_DIR = File.join("#{Rails.root}",'spec','fixtures','uploaded_files') unless defined?(FIXTURE_DIR)
     trait :png do
       actual_file { File.new(File.join(FIXTURE_DIR, 'image.png')) }
     end

--- a/spec/models/concerns/payment_utility_spec.rb
+++ b/spec/models/concerns/payment_utility_spec.rb
@@ -82,9 +82,9 @@ RSpec.describe User, type: :model do
 
     it 'is the notes of the most recent payment' do
       most_recent_membership_payment = user_pays_every_nov30.payment_notes(membership_fee)
-      expect(most_recent_membership_payment).to eq('nov_30 membership')
+      expect(most_recent_membership_payment).to eq('membership starts 2018-11-30, expires 2019-11-29')
       most_recent_membership_payment = user_pays_every_nov30.payment_notes(branding_license_fee)
-      expect(most_recent_membership_payment).to eq('nov_30 branding')
+      expect(most_recent_membership_payment).to eq('branding license starts 2018-11-30, expires 2019-11-29')
     end
   end
 

--- a/spec/models/concerns/payment_utility_spec.rb
+++ b/spec/models/concerns/payment_utility_spec.rb
@@ -1,142 +1,22 @@
 require 'rails_helper'
+require 'shared_context/users'
+require 'shared_context/companies'
 
-
-# We use the User class to test the instance methods since it includes the PaymentUtility class
+# We use the User class to test most instance methods since it includes the PaymentUtility class
 
 RSpec.describe User, type: :model do
 
-  THIS_YEAR = 2018
+  let(:membership_fee) { Payment::PAYMENT_TYPE_MEMBER }
+  let(:branding_license_fee) { Payment::PAYMENT_TYPE_BRANDING }
 
-  let(:jul_1) { Time.zone.local(THIS_YEAR, 7, 1) }
-  let(:nov_29) { Time.zone.local(THIS_YEAR, 11, 29) }
-  let(:nov_30) { Time.zone.local(THIS_YEAR, 11, 30) }
-  let(:dec_1) { Time.zone.local(THIS_YEAR, 12, 1) }
-  let(:dec_2) { Time.zone.local(THIS_YEAR, 12, 2) }
-  let(:dec_3) { Time.zone.local(THIS_YEAR, 12, 3) }
+  include_context 'create users'
+  include_context 'create companies'
 
-  let(:nov_29_last_year) { Time.zone.local(THIS_YEAR - 1, 11, 29) }
-  let(:nov_30_last_year) { Time.zone.local(THIS_YEAR - 1, 11, 30) }
-  let(:nov_29_next_year) { Time.zone.local(THIS_YEAR + 1, 11, 29) }
-  let(:nov_30_next_year) { Time.zone.local(THIS_YEAR + 1, 11, 30) }
-
-  let(:lastyear_dec_2) { Time.zone.local(THIS_YEAR - 1, 12, 2) }
+  let(:company_for_user_unsuccessful_this_year) { user_unsuccessful_this_year.shf_application.companies.first }
 
 
-  let(:user_pays_every_nov30) do
-    u    = create(:member_with_membership_app)
-    u_co = u.shf_application.companies.first
-
-    Timecop.freeze(nov_30_last_year) do
-      create(:membership_fee_payment,
-             :successful,
-             user:        u,
-             company:     u_co,
-             start_date:  nov_30_last_year,
-             expire_date: User.expire_date_for_start_date(nov_30_last_year),
-             notes:       'nov_30_last_year membership')
-      create(:h_branding_fee_payment,
-             :successful,
-             user:        u,
-             company:     u_co,
-             start_date:  nov_30_last_year,
-             expire_date: Company.expire_date_for_start_date(nov_30_last_year),
-             notes:       'nov_30_last_year branding')
-    end
-
-    Timecop.freeze(nov_30) do
-      create(:membership_fee_payment,
-             :successful,
-             user:        u,
-             company:     u_co,
-             start_date:  nov_30,
-             expire_date: User.expire_date_for_start_date(nov_30),
-             notes:       'nov_30 membership')
-      create(:h_branding_fee_payment,
-             :successful,
-             user:        u,
-             company:     u_co,
-             start_date:  nov_30,
-             expire_date: Company.expire_date_for_start_date(nov_30),
-             notes:       'nov_30 branding')
-    end
-
-    u
-  end
-
-
-  let(:user_paid_only_lastyear_dec_2) do
-    u    = create(:member_with_membership_app)
-    u_co = u.shf_application.companies.first
-
-    Timecop.freeze(lastyear_dec_2) do
-      create(:membership_fee_payment,
-             :successful,
-             user:        u,
-             company:     u_co,
-             start_date:  lastyear_dec_2,
-             expire_date: User.expire_date_for_start_date(lastyear_dec_2),
-             notes:       'lastyear_dec_2 membership')
-      create(:h_branding_fee_payment,
-             :successful,
-             user:        u,
-             company:     u_co,
-             start_date:  lastyear_dec_2,
-             expire_date: Company.expire_date_for_start_date(lastyear_dec_2),
-             notes:       'lastyear_dec_2 branding')
-    end
-    u
-  end
-
-
-  let(:user_unsuccessful_this_year) do
-    u    = create(:member_with_membership_app)
-    u_co = u.shf_application.companies.first
-
-    # success on nov 30 last year
-    Timecop.freeze(nov_30_last_year) do
-      create(:membership_fee_payment,
-             :successful,
-             user:        u,
-             company:     u_co,
-             start_date:  nov_30_last_year,
-             expire_date: User.expire_date_for_start_date(nov_30_last_year),
-             notes:       'nov_30_last_year success membership')
-      create(:h_branding_fee_payment,
-             :successful,
-             user:        u,
-             company:     u_co,
-             start_date:  nov_30_last_year,
-             expire_date: Company.expire_date_for_start_date(nov_30_last_year),
-             notes:       'nov_30_last_year success branding')
-    end
-
-    # failed on nov 29
-    Timecop.freeze(nov_29) do
-      create(:membership_fee_payment,
-             :expired,
-             user:        u,
-             company:     u_co,
-             start_date:  nov_29,
-             expire_date: User.expire_date_for_start_date(nov_29),
-             notes:       'nov_29 failed (expired) membership')
-      create(:h_branding_fee_payment,
-             :expired,
-             user:        u,
-             company:     u_co,
-             start_date:  nov_29,
-             expire_date: Company.expire_date_for_start_date(nov_29),
-             notes:       'nov_29 failed (expired) branding')
-    end
-
-    u
-  end
-
-  let(:company__unsuccessful_this_year) { user_unsuccessful_this_year.shf_application.companies.first }
-
-
-  let(:user_no_payments)     { create(:user) }
-  let(:company_no_payments)  { create(:company) }
-
+  # ==================================
+  #  Today = DECEMBER 1 for EVERY EXAMPLE
   around(:each) do |example|
     Timecop.freeze(dec_1)
     example.run
@@ -147,14 +27,14 @@ RSpec.describe User, type: :model do
   describe '#most_recent_payment' do
 
     it 'if no payments, returns nil' do
-      expect(user_no_payments.most_recent_payment(Payment::PAYMENT_TYPE_MEMBER)).to be_nil
-      expect(user_no_payments.most_recent_payment(Payment::PAYMENT_TYPE_BRANDING)).to be_nil
+      expect(user_no_payments.most_recent_payment(membership_fee)).to be_nil
+      expect(user_no_payments.most_recent_payment(branding_license_fee)).to be_nil
     end
 
     it 'most recent is based on created_date' do
-      most_recent_membership_payment = user_pays_every_nov30.most_recent_payment(Payment::PAYMENT_TYPE_MEMBER)
+      most_recent_membership_payment = user_pays_every_nov30.most_recent_payment(membership_fee)
       expect(most_recent_membership_payment.created_at).to eq(nov_30)
-      most_recent_membership_payment = user_pays_every_nov30.most_recent_payment(Payment::PAYMENT_TYPE_BRANDING)
+      most_recent_membership_payment = user_pays_every_nov30.most_recent_payment(branding_license_fee)
       expect(most_recent_membership_payment.created_at).to eq(nov_30)
     end
 
@@ -164,14 +44,14 @@ RSpec.describe User, type: :model do
   describe '#payment_start_date' do
 
     it 'is nil if no payments' do
-      expect(user_no_payments.payment_start_date(Payment::PAYMENT_TYPE_MEMBER)).to be_nil
-      expect(user_no_payments.payment_start_date(Payment::PAYMENT_TYPE_BRANDING)).to be_nil
+      expect(user_no_payments.payment_start_date(membership_fee)).to be_nil
+      expect(user_no_payments.payment_start_date(branding_license_fee)).to be_nil
     end
 
     it 'is the start_date (Date) of the most recent payment' do
-      most_recent_membership_payment = user_pays_every_nov30.payment_start_date(Payment::PAYMENT_TYPE_MEMBER)
+      most_recent_membership_payment = user_pays_every_nov30.payment_start_date(membership_fee)
       expect(most_recent_membership_payment).to eq(nov_30)
-      most_recent_membership_payment = user_pays_every_nov30.payment_start_date(Payment::PAYMENT_TYPE_BRANDING)
+      most_recent_membership_payment = user_pays_every_nov30.payment_start_date(branding_license_fee)
       expect(most_recent_membership_payment).to eq(nov_30)
     end
   end
@@ -180,15 +60,15 @@ RSpec.describe User, type: :model do
   describe '#payment_expire_date' do
 
     it 'is nil if no payments' do
-      expect(user_no_payments.payment_expire_date(Payment::PAYMENT_TYPE_MEMBER)).to be_nil
-      expect(user_no_payments.payment_expire_date(Payment::PAYMENT_TYPE_BRANDING)).to be_nil
+      expect(user_no_payments.payment_expire_date(membership_fee)).to be_nil
+      expect(user_no_payments.payment_expire_date(branding_license_fee)).to be_nil
     end
 
     it 'is the expire_date (Date) of the most recent payment' do
-      most_recent_membership_payment = user_pays_every_nov30.payment_expire_date(Payment::PAYMENT_TYPE_MEMBER)
-      expect(most_recent_membership_payment).to eq(nov_29_next_year)
-      most_recent_membership_payment = user_pays_every_nov30.payment_expire_date(Payment::PAYMENT_TYPE_BRANDING)
-      expect(most_recent_membership_payment).to eq(nov_29_next_year)
+      most_recent_membership_payment = user_pays_every_nov30.payment_expire_date(membership_fee)
+      expect(most_recent_membership_payment).to eq(nextyear_nov_29)
+      most_recent_membership_payment = user_pays_every_nov30.payment_expire_date(branding_license_fee)
+      expect(most_recent_membership_payment).to eq(nextyear_nov_29)
     end
   end
 
@@ -196,14 +76,14 @@ RSpec.describe User, type: :model do
   describe '#payment_notes' do
 
     it 'is nil if no payments' do
-      expect(user_no_payments.payment_notes(Payment::PAYMENT_TYPE_MEMBER)).to be_nil
-      expect(user_no_payments.payment_notes(Payment::PAYMENT_TYPE_BRANDING)).to be_nil
+      expect(user_no_payments.payment_notes(membership_fee)).to be_nil
+      expect(user_no_payments.payment_notes(branding_license_fee)).to be_nil
     end
 
     it 'is the notes of the most recent payment' do
-      most_recent_membership_payment = user_pays_every_nov30.payment_notes(Payment::PAYMENT_TYPE_MEMBER)
+      most_recent_membership_payment = user_pays_every_nov30.payment_notes(membership_fee)
       expect(most_recent_membership_payment).to eq('nov_30 membership')
-      most_recent_membership_payment = user_pays_every_nov30.payment_notes(Payment::PAYMENT_TYPE_BRANDING)
+      most_recent_membership_payment = user_pays_every_nov30.payment_notes(branding_license_fee)
       expect(most_recent_membership_payment).to eq('nov_30 branding')
     end
   end
@@ -213,11 +93,11 @@ RSpec.describe User, type: :model do
 
     context 'entity not found raises ActiveRecord::RecordNotFound because it signals a problem in the program logic' do
       it 'User (membership fee and branding fee)' do
-        expect { described_class.next_payment_dates(100, Payment::PAYMENT_TYPE_MEMBER) }.to raise_error(ActiveRecord::RecordNotFound)
-        expect { described_class.next_payment_dates(100, Payment::PAYMENT_TYPE_BRANDING) }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { described_class.next_payment_dates(100, membership_fee) }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { described_class.next_payment_dates(100, branding_license_fee) }.to raise_error(ActiveRecord::RecordNotFound)
       end
       it 'Company (branding fee)' do
-        expect { described_class.next_payment_dates(100, Payment::PAYMENT_TYPE_BRANDING) }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { described_class.next_payment_dates(100, branding_license_fee) }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -230,14 +110,14 @@ RSpec.describe User, type: :model do
 
           context 'User (membership fee and branding fee)' do
             it 'start date = today, expire date = calculated based on today' do
-              expect(User.next_payment_dates(user_no_payments.id, Payment::PAYMENT_TYPE_MEMBER)).to eq [dec_1, nov_30_next_year]
-              expect(User.next_payment_dates(user_no_payments.id, Payment::PAYMENT_TYPE_BRANDING)).to eq [dec_1, nov_30_next_year]
+              expect(User.next_payment_dates(user_no_payments.id, membership_fee)).to eq [dec_1, nextyear_nov_30]
+              expect(User.next_payment_dates(user_no_payments.id, branding_license_fee)).to eq [dec_1, nextyear_nov_30]
             end
           end
 
           context 'Company (branding fee)' do
             it 'start date = today, expire date = calculated based on today' do
-              expect(Company.next_payment_dates(company_no_payments.id, Payment::PAYMENT_TYPE_BRANDING)).to eq [dec_1, nov_30_next_year]
+              expect(Company.next_payment_dates(company_no_payments.id, branding_license_fee)).to eq [dec_1, nextyear_nov_30]
             end
           end
 
@@ -250,23 +130,23 @@ RSpec.describe User, type: :model do
         context 'User (membership fee and branding fee)' do
 
           it 'occurs in the past' do
-            expect(User.next_payment_dates(user_paid_only_lastyear_dec_2.id, Payment::PAYMENT_TYPE_MEMBER)).to eq [dec_1, nov_30_next_year]
-            expect(User.next_payment_dates(user_paid_only_lastyear_dec_2.id, Payment::PAYMENT_TYPE_BRANDING)).to eq [dec_1, nov_30_next_year]
+            expect(User.next_payment_dates(user_paid_only_lastyear_dec_2.id, membership_fee)).to eq [dec_1, nextyear_nov_30]
+            expect(User.next_payment_dates(user_paid_only_lastyear_dec_2.id, branding_license_fee)).to eq [dec_1, nextyear_nov_30]
           end
 
           it 'occurs in the future' do
-            expect(User.next_payment_dates(user_pays_every_nov30.id, Payment::PAYMENT_TYPE_MEMBER)).to eq [nov_30_next_year, Date.new(THIS_YEAR+2, 11,29)]
-            expect(User.next_payment_dates(user_pays_every_nov30.id, Payment::PAYMENT_TYPE_BRANDING)).to eq [nov_30_next_year, Date.new(THIS_YEAR+2, 11,29)]
+            expect(User.next_payment_dates(user_pays_every_nov30.id, membership_fee)).to eq [nextyear_nov_30, Date.new(THIS_YEAR + 2, 11, 29)]
+            expect(User.next_payment_dates(user_pays_every_nov30.id, branding_license_fee)).to eq [nextyear_nov_30, Date.new(THIS_YEAR + 2, 11, 29)]
           end
         end
 
         context 'Company (branding fee)' do
           it 'occurs in the past' do
-            expect(User.next_payment_dates(user_paid_only_lastyear_dec_2.id, Payment::PAYMENT_TYPE_BRANDING)).to eq [dec_1, nov_30_next_year]
+            expect(User.next_payment_dates(user_paid_only_lastyear_dec_2.id, branding_license_fee)).to eq [dec_1, nextyear_nov_30]
           end
 
           it 'occurs in the future' do
-            expect(User.next_payment_dates(user_pays_every_nov30.id, Payment::PAYMENT_TYPE_BRANDING)).to eq [nov_30_next_year, Date.new(THIS_YEAR+2, 11,29)]
+            expect(User.next_payment_dates(user_pays_every_nov30.id, branding_license_fee)).to eq [nextyear_nov_30, Date.new(THIS_YEAR + 2, 11, 29)]
           end
         end
 
@@ -274,12 +154,12 @@ RSpec.describe User, type: :model do
         describe 'only uses the successful payments' do
 
           it 'User membership fee and branding fee' do
-            expect(User.next_payment_dates(user_unsuccessful_this_year.id, Payment::PAYMENT_TYPE_MEMBER)).to eq [dec_1, nov_30_next_year]
-            expect(User.next_payment_dates(user_unsuccessful_this_year.id, Payment::PAYMENT_TYPE_BRANDING)).to eq [dec_1, nov_30_next_year]
+            expect(User.next_payment_dates(user_unsuccessful_this_year.id, membership_fee)).to eq [dec_1, nextyear_nov_30]
+            expect(User.next_payment_dates(user_unsuccessful_this_year.id, branding_license_fee)).to eq [dec_1, nextyear_nov_30]
           end
 
           it 'Company branding fee' do
-            expect(Company.next_payment_dates(company__unsuccessful_this_year.id, Payment::PAYMENT_TYPE_BRANDING)).to eq [dec_1, nov_30_next_year]
+            expect(Company.next_payment_dates(company_for_user_unsuccessful_this_year.id, branding_license_fee)).to eq [dec_1, nextyear_nov_30]
           end
 
         end
@@ -327,15 +207,15 @@ RSpec.describe User, type: :model do
     let(:expire_2018_12_31) { Date.new(2018, 12, 31) }
 
     it 'is_start_date is true by default' do
-      expect(described_class.other_date_for_given_date( start_2018_1_1) ).to eq described_class.other_date_for_given_date( start_2018_1_1, is_start_date: true)
+      expect(described_class.other_date_for_given_date(start_2018_1_1)).to eq described_class.other_date_for_given_date(start_2018_1_1, is_start_date: true)
     end
 
     it 'given a start date, calc the expiration' do
-      expect(described_class.other_date_for_given_date( start_2018_1_1) ).to eq expire_2018_12_31
+      expect(described_class.other_date_for_given_date(start_2018_1_1)).to eq expire_2018_12_31
     end
 
     it 'given an expiration date, calc the start date' do
-      expect(described_class.other_date_for_given_date( expire_2018_12_31, is_start_date: false) ).to eq start_2018_1_1
+      expect(described_class.other_date_for_given_date(expire_2018_12_31, is_start_date: false)).to eq start_2018_1_1
     end
 
     describe 'handles leap years' do
@@ -344,13 +224,14 @@ RSpec.describe User, type: :model do
       let(:expire_2021_10_31) { Date.new(2021, 10, 31) }
 
       it 'given a start date, calc the expiration' do
-        expect(described_class.other_date_for_given_date( start_2020_11_1) ).to eq expire_2021_10_31
+        expect(described_class.other_date_for_given_date(start_2020_11_1)).to eq expire_2021_10_31
       end
 
       it 'given an expiration date, calc the start date' do
-        expect(described_class.other_date_for_given_date( expire_2021_10_31, is_start_date: false) ).to eq start_2020_11_1
+        expect(described_class.other_date_for_given_date(expire_2021_10_31, is_start_date: false)).to eq start_2020_11_1
       end
     end
 
   end
+
 end

--- a/spec/models/conditions_response/hbranding_fee_due_alert_spec.rb
+++ b/spec/models/conditions_response/hbranding_fee_due_alert_spec.rb
@@ -2,26 +2,15 @@ require 'rails_helper'
 require 'email_spec/rspec'
 require 'shared_context/activity_logger'
 require 'shared_context/stub_email_rendering'
+require 'shared_context/named_dates'
 
 
 RSpec.describe HBrandingFeeDueAlert do
 
   include_context 'create logger'
+  include_context 'named dates'
 
   subject  { described_class.instance }
-
-  let(:jan_1) { Date.new(2018, 1, 1) }
-
-  let(:nov_29) { Date.new(2018, 11, 29) }
-  let(:nov_30) { Date.new(2018, 11, 30) }
-  let(:dec_1)  { Date.new(2018, 12, 1) }
-  let(:dec_2)  { Date.new(2018, 12, 2) }
-  let(:dec_3)  { Date.new(2018, 12, 3) }
-  let(:dec_5)  { Date.new(2018, 12, 5) }
-
-  let(:nov_30_last_year) { Date.new(2017, 11, 30) }
-  let(:dec_2_last_year) { Date.new(2017, 12, 2) }
-  let(:dec_3_last_year) { Date.new(2017, 12, 3) }
 
   let(:user) { create(:user, email: FFaker::InternetSE.disposable_email) }
 
@@ -221,8 +210,8 @@ RSpec.describe HBrandingFeeDueAlert do
               create(:membership_fee_payment,
                      :successful,
                      user:        member,
-                     start_date:  dec_3_last_year,
-                     expire_date: User.expire_date_for_start_date(dec_3_last_year))
+                     start_date:  lastyear_dec_3,
+                     expire_date: User.expire_date_for_start_date(lastyear_dec_3))
               member
             }
 
@@ -250,8 +239,8 @@ RSpec.describe HBrandingFeeDueAlert do
               create(:membership_fee_payment,
                      :successful,
                      user:        member,
-                     start_date:  dec_2_last_year,
-                     expire_date: User.expire_date_for_start_date(dec_2_last_year))
+                     start_date:  lastyear_dec_2,
+                     expire_date: User.expire_date_for_start_date(lastyear_dec_2))
               member
             }
 
@@ -274,8 +263,8 @@ RSpec.describe HBrandingFeeDueAlert do
             create(:membership_fee_payment,
                    :successful,
                    user:        member,
-                   start_date:  nov_30_last_year,
-                   expire_date: User.expire_date_for_start_date(nov_30_last_year))
+                   start_date:  lastyear_nov_30,
+                   expire_date: User.expire_date_for_start_date(lastyear_nov_30))
             member
           }
 
@@ -316,13 +305,13 @@ RSpec.describe HBrandingFeeDueAlert do
             paid_members_co
             member_paid_dec_5
 
-            Timecop.freeze(nov_30_last_year) do
+            Timecop.freeze(lastyear_nov_30) do
               create(:h_branding_fee_payment,
                      :successful,
                      user:        member_paid_dec_5,
                      company:     paid_members_co,
-                     start_date:  nov_30_last_year,
-                     expire_date: Company.expire_date_for_start_date(nov_30_last_year))
+                     start_date:  lastyear_nov_30,
+                     expire_date: Company.expire_date_for_start_date(lastyear_nov_30))
             end
 
             expect(paid_members_co.branding_license?).to be_falsey
@@ -339,13 +328,13 @@ RSpec.describe HBrandingFeeDueAlert do
             paid_members_co
             member_paid_dec_3
 
-            Timecop.freeze(nov_30_last_year) do
+            Timecop.freeze(lastyear_nov_30) do
               create(:h_branding_fee_payment,
                      :successful,
                      user:        member_paid_dec_3,
                      company:     paid_members_co,
-                     start_date:  nov_30_last_year,
-                     expire_date: Company.expire_date_for_start_date(nov_30_last_year))
+                     start_date:  lastyear_nov_30,
+                     expire_date: Company.expire_date_for_start_date(lastyear_nov_30))
             end
 
             expect(paid_members_co.branding_license?).to be_falsey

--- a/spec/models/conditions_response/hbranding_fee_will_be_due_alert_spec.rb
+++ b/spec/models/conditions_response/hbranding_fee_will_be_due_alert_spec.rb
@@ -2,27 +2,16 @@ require 'rails_helper'
 require 'email_spec/rspec'
 require 'shared_context/activity_logger'
 require 'shared_context/stub_email_rendering'
+require 'shared_context/named_dates'
 
 
 RSpec.describe HBrandingFeeWillExpireAlert do
 
   include_context 'create logger'
+  include_context 'named dates'
 
   subject  { described_class.instance }
 
-
-  let(:jan_1) { Date.new(2018, 1, 1) }
-
-  let(:nov_29) { Date.new(2018, 11, 29) }
-  let(:nov_30) { Date.new(2018, 11, 30) }
-  let(:dec_1)  { Date.new(2018, 12, 1) }
-  let(:dec_2)  { Date.new(2018, 12, 2) }
-  let(:dec_3)  { Date.new(2018, 12, 3) }
-  let(:dec_5)  { Date.new(2018, 12, 5) }
-
-  let(:nov_30_last_year) { Date.new(2017, 11, 30) }
-  let(:dec_2_last_year) { Date.new(2017, 12, 2) }
-  let(:dec_3_last_year) { Date.new(2017, 12, 3) }
 
   let(:user) { create(:user, email: FFaker::InternetSE.disposable_email) }
 
@@ -156,15 +145,15 @@ RSpec.describe HBrandingFeeWillExpireAlert do
 
       context 'h-branding fee has been paid but is expired' do
 
-        let(:hbrandpay_nov_30_last_year) do
+        let(:hbrandpay_lastyear_nov_30) do
 
-          Timecop.freeze(nov_30_last_year) do
+          Timecop.freeze(lastyear_nov_30) do
             create(:h_branding_fee_payment,
                    :successful,
                    user:        member_paid_dec_3,
                    company:     paid_members_co,
-                   start_date:  nov_30_last_year,
-                   expire_date: Company.expire_date_for_start_date(nov_30_last_year))
+                   start_date:  lastyear_nov_30,
+                   expire_date: Company.expire_date_for_start_date(lastyear_nov_30))
           end
         end
 
@@ -173,7 +162,7 @@ RSpec.describe HBrandingFeeWillExpireAlert do
 
           paid_members_co
           member_paid_dec_3
-          hbrandpay_nov_30_last_year
+          hbrandpay_lastyear_nov_30
 
           expect(paid_members_co.branding_expire_date).to eq nov_29
 
@@ -188,7 +177,7 @@ RSpec.describe HBrandingFeeWillExpireAlert do
         it 'false when the day  is not in the config list of days to send the alert' do
           paid_members_co
           member_paid_dec_3
-          hbrandpay_nov_30_last_year
+          hbrandpay_lastyear_nov_30
 
           expect(subject.send_alert_this_day?(timing, { days: [999] }, paid_members_co)).to be_falsey
         end

--- a/spec/models/conditions_response/membership_expire_alert_spec.rb
+++ b/spec/models/conditions_response/membership_expire_alert_spec.rb
@@ -2,22 +2,16 @@ require 'rails_helper'
 require 'email_spec/rspec'
 require 'shared_context/activity_logger'
 require 'shared_context/stub_email_rendering'
+require 'shared_context/named_dates'
 
 
 RSpec.describe MembershipExpireAlert do
 
   include_context 'create logger'
+  include_context 'named dates'
 
   subject  { described_class.instance }
 
-
-  let(:jan_1) { Date.new(2018, 1, 1) }
-  let(:dec_1) { Date.new(2018, 12, 1) }
-  let(:dec_2) { Date.new(2018, 12, 2) }
-
-  let(:nov_30_last_year) { Date.new(2017, 11, 30) }
-  let(:dec_2_last_year) { Date.new(2017, 12, 2) }
-  let(:dec_3_last_year) { Date.new(2017, 12, 3) }
 
   let(:user) { create(:user, email: FFaker::InternetSE.disposable_email) }
 
@@ -38,8 +32,8 @@ RSpec.describe MembershipExpireAlert do
     create(:membership_fee_payment,
            :successful,
            user:        member,
-           start_date:  dec_3_last_year,
-           expire_date: User.expire_date_for_start_date(dec_3_last_year))
+           start_date:  lastyear_dec_3,
+           expire_date: User.expire_date_for_start_date(lastyear_dec_3))
     member
   }
 
@@ -98,8 +92,8 @@ RSpec.describe MembershipExpireAlert do
             create(:membership_fee_payment,
                    :successful,
                    user:        member,
-                   start_date:  dec_2_last_year,
-                   expire_date: User.expire_date_for_start_date(dec_2_last_year))
+                   start_date:  lastyear_dec_2,
+                   expire_date: User.expire_date_for_start_date(lastyear_dec_2))
             member
           }
 
@@ -120,8 +114,8 @@ RSpec.describe MembershipExpireAlert do
           create(:membership_fee_payment,
                  :successful,
                  user:        member,
-                 start_date:  nov_30_last_year,
-                 expire_date: User.expire_date_for_start_date(nov_30_last_year))
+                 start_date:  lastyear_nov_30,
+                 expire_date: User.expire_date_for_start_date(lastyear_nov_30))
           member
         }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'email_spec/rspec'
 require 'shared_context/unstub_paperclip_all_run_commands'
-
+require 'shared_context/named_dates'
 
 # ================================================================================
 
@@ -37,6 +37,8 @@ RSpec.describe User, type: :model do
 
   # These are required to get the content type and validate it
   include_context 'unstub Paperclip all run commands'
+
+  include_context 'named dates'
 
   before(:each) do
     allow_any_instance_of(Paperclip::Attachment).to receive(:post_process_file)
@@ -99,24 +101,6 @@ RSpec.describe User, type: :model do
            start_date:     start_date,
            expire_date:    expire_date)
   end
-
-  let(:jan_1) { Time.zone.local(2018, 1, 1) }
-
-  let(:nov_29) { Time.zone.local(2018, 11, 29) }
-  let(:nov_30) { Time.zone.local(2018, 11, 30) }
-  let(:dec_1) { Time.zone.local(2018, 12, 1) }
-  let(:dec_2) { Time.zone.local(2018, 12, 2) }
-  let(:dec_3) { Time.zone.local(2018, 12, 3) }
-  let(:dec_31) { Time.zone.local(2018, 12, 31) }
-
-  let(:nov_29_last_year) { Time.zone.local(2017, 11, 29) }
-  let(:nov_30_last_year) { Time.zone.local(2017, 11, 30) }
-  let(:dec_1_last_year) { Time.zone.local(2017, 12, 1) }
-  let(:dec_2_last_year) { Time.zone.local(2017, 12, 2) }
-  let(:dec_3_last_year) { Time.zone.local(2017, 12, 3) }
-
-  let(:nov_30_next_year) { Time.zone.local(2019, 11, 30) }
-
 
   describe 'Factory' do
     it 'has valid factories' do
@@ -300,23 +284,19 @@ RSpec.describe User, type: :model do
 
     describe 'current_members' do
 
-      # set today to January 1, 2019 for every example run
+      # set today to January 1 for every example run
       around(:each) do |example|
-        Timecop.freeze(Date.new(2019, 1, 1))
+        Timecop.freeze(jan_1)
         example.run
         Timecop.return
       end
 
-      let(:jan1) { Date.new(2019, 1, 1) }
-      let(:jan2) { Date.new(2019, 1, 2) }
-      let(:jan3) { Date.new(2019, 1, 3) }
-
       let(:user_no_app) { create(:user) }
       let(:user_app_not_accepted) { create(:user_with_membership_app) }
 
-      let(:member_exp_jan1_today)   { create(:member_with_expiration_date, expiration_date: jan1) }
-      let(:member_current_exp_jan2) { create(:member_with_expiration_date, expiration_date: jan2) }
-      let(:member_current_exp_jan3) { create(:member_with_expiration_date, expiration_date: jan3) }
+      let(:member_exp_jan1_today)   { create(:member_with_expiration_date, expiration_date: jan_1) }
+      let(:member_current_exp_jan2) { create(:member_with_expiration_date, expiration_date: jan_2) }
+      let(:member_current_exp_jan3) { create(:member_with_expiration_date, expiration_date: jan_3) }
 
 
       it 'all applications are accepted' do
@@ -353,7 +333,7 @@ RSpec.describe User, type: :model do
         payments_expire_after_today = expires_dates.select{|date| date > Date.current}
 
         expect(payments_expire_today_or_before).to be_empty
-        expect(payments_expire_after_today).to match_array([jan2, jan3])
+        expect(payments_expire_after_today).to match_array([jan_2, jan_3])
       end
 
     end
@@ -893,8 +873,8 @@ RSpec.describe User, type: :model do
         create(:membership_fee_payment,
                :successful,
                user:        member,
-               start_date:  dec_3_last_year,
-               expire_date: User.expire_date_for_start_date(dec_3_last_year))
+               start_date:  lastyear_dec_3,
+               expire_date: User.expire_date_for_start_date(lastyear_dec_3))
         member
       }
 
@@ -965,8 +945,8 @@ RSpec.describe User, type: :model do
         create(:membership_fee_payment,
                :successful,
                user:        member,
-               start_date:  dec_3_last_year,
-               expire_date: User.expire_date_for_start_date(dec_3_last_year))
+               start_date:  lastyear_dec_3,
+               expire_date: User.expire_date_for_start_date(lastyear_dec_3))
         member
       }
 
@@ -1038,8 +1018,8 @@ RSpec.describe User, type: :model do
           create(:membership_fee_payment,
                  :successful,
                  user:        member,
-                 start_date:  dec_3_last_year,
-                 expire_date: User.expire_date_for_start_date(dec_3_last_year))
+                 start_date:  lastyear_dec_3,
+                 expire_date: User.expire_date_for_start_date(lastyear_dec_3))
           member
         }
 
@@ -1135,8 +1115,8 @@ RSpec.describe User, type: :model do
           create(:membership_fee_payment,
                  :successful,
                  user:        user,
-                 start_date:  dec_3_last_year,
-                 expire_date: User.expire_date_for_start_date(dec_3_last_year))
+                 start_date:  lastyear_dec_3,
+                 expire_date: User.expire_date_for_start_date(lastyear_dec_3))
           user
         }
 
@@ -1215,8 +1195,8 @@ RSpec.describe User, type: :model do
           create(:membership_fee_payment,
                  :successful,
                  user:        member,
-                 start_date:  dec_3_last_year,
-                 expire_date: User.expire_date_for_start_date(dec_3_last_year))
+                 start_date:  lastyear_dec_3,
+                 expire_date: User.expire_date_for_start_date(lastyear_dec_3))
           member
         }
 
@@ -1295,8 +1275,8 @@ RSpec.describe User, type: :model do
           create(:membership_fee_payment,
                  :successful,
                  user:        user,
-                 start_date:  dec_3_last_year,
-                 expire_date: User.expire_date_for_start_date(dec_3_last_year))
+                 start_date:  lastyear_dec_3,
+                 expire_date: User.expire_date_for_start_date(lastyear_dec_3))
           user
         }
 

--- a/spec/shared_context/companies.rb
+++ b/spec/shared_context/companies.rb
@@ -1,5 +1,6 @@
-# This will create 7 companies:
+# This will create these companies:
 #
+#  company_no_payments - a company with no payments
 #  complete_co1 - has 2 branding payments
 #  complete_co2 - just has a company name, number, and the company Factory defaults
 #  co_no_viz_addresses - a company with just 1 address with visibility: none, and the company Factory defaults
@@ -13,6 +14,9 @@
 #
 RSpec.shared_context 'create companies' do
 
+  let(:company_no_payments)  { create(:company) }
+
+
   let(:complete_co1) do
     co1 = create(:company, name: 'Complete Company 1',
            description:    'This co has a 2 branding payments',
@@ -21,6 +25,8 @@ RSpec.shared_context 'create companies' do
     create(:shf_application, :accepted, company_number: co1.company_number, num_categories: 3)
     co1
   end
+
+
   let(:payment1_co1) do
     start_date, expire_date = Company.next_branding_payment_dates(complete_co1.id)
     create(:payment,

--- a/spec/shared_context/mock_app_configuration.rb
+++ b/spec/shared_context/mock_app_configuration.rb
@@ -30,7 +30,8 @@ end
 
 class MockAttachment
 
-  def self.url
+  # Ignore any arguments. Always just return the Faux url
+  def self.url(*_args)
     FauxUrl.url
   end
 

--- a/spec/shared_context/named_dates.rb
+++ b/spec/shared_context/named_dates.rb
@@ -1,0 +1,52 @@
+# Dates that can be used in examples, tests, etc.
+#
+# Use:
+#  require 'shared_context/named_dates'
+#
+#  within a 'describe' or 'context' block:
+#   include_context 'named dates'
+#
+RSpec.shared_context 'named dates' do
+
+  THIS_YEAR = 2018 unless defined?(THIS_YEAR)
+
+  let(:jan_1) { Time.zone.local(2018, 1, 1) }
+  let(:jan_2) { Time.zone.local(2018, 1, 2) }
+  let(:jan_3) { Time.zone.local(2018, 1, 3) }
+  let(:jan_30) { Time.zone.local(THIS_YEAR, 1, 30) }
+
+  let(:feb_1) { Time.zone.local(THIS_YEAR, 2, 1) }
+  let(:feb_2) { Time.zone.local(THIS_YEAR, 2, 2) }
+  let(:feb_3) { Time.zone.local(THIS_YEAR, 2, 3) }
+
+  let(:jul_1) { Time.zone.local(THIS_YEAR, 7, 1) }
+
+  let(:nov_29) { Time.zone.local(THIS_YEAR, 11, 29) }
+  let(:nov_30) { Time.zone.local(THIS_YEAR, 11, 30) }
+
+  let(:dec_1) { Time.zone.local(THIS_YEAR, 12, 1) }
+  let(:dec_2) { Time.zone.local(THIS_YEAR, 12, 2) }
+  let(:dec_3) { Time.zone.local(THIS_YEAR, 12, 3) }
+  let(:dec_5) { Time.zone.local(THIS_YEAR, 12, 5) }
+  let(:dec_31) { Time.zone.local(2018, 12, 31) }
+
+  #
+  # Last year
+  #
+  let(:lastyear_nov_29) { Time.zone.local(THIS_YEAR - 1, 11, 29) }
+  let(:lastyear_nov_30) { Time.zone.local(THIS_YEAR - 1, 11, 30) }
+
+  let(:lastyear_dec_1) { Time.zone.local(THIS_YEAR - 1, 12, 1) }
+  let(:lastyear_dec_2) { Time.zone.local(THIS_YEAR - 1, 12, 2) }
+  let(:lastyear_dec_3) { Time.zone.local(THIS_YEAR - 1, 12, 3) }
+  let(:lastyear_dec_8) { Time.zone.local(THIS_YEAR - 1, 12, 8) }
+  let(:lastyear_dec_9) { Time.zone.local(THIS_YEAR - 1, 12, 9) }
+
+  #
+  # Next year
+  #
+
+  let(:nextyear_nov_29) { Time.zone.local(THIS_YEAR + 1, 11, 29) }
+  let(:nextyear_nov_30) { Time.zone.local(THIS_YEAR + 1, 11, 30) }
+
+end

--- a/spec/shared_context/named_dates.rb
+++ b/spec/shared_context/named_dates.rb
@@ -14,6 +14,7 @@ RSpec.shared_context 'named dates' do
   let(:jan_2) { Time.zone.local(2018, 1, 2) }
   let(:jan_3) { Time.zone.local(2018, 1, 3) }
   let(:jan_30) { Time.zone.local(THIS_YEAR, 1, 30) }
+  let(:jan_31) { Time.zone.local(THIS_YEAR, 1, 31) }
 
   let(:feb_1) { Time.zone.local(THIS_YEAR, 2, 1) }
   let(:feb_2) { Time.zone.local(THIS_YEAR, 2, 2) }
@@ -41,6 +42,7 @@ RSpec.shared_context 'named dates' do
   let(:lastyear_dec_3) { Time.zone.local(THIS_YEAR - 1, 12, 3) }
   let(:lastyear_dec_8) { Time.zone.local(THIS_YEAR - 1, 12, 8) }
   let(:lastyear_dec_9) { Time.zone.local(THIS_YEAR - 1, 12, 9) }
+  let(:lastyear_dec_10) { Time.zone.local(THIS_YEAR - 1, 12, 10) }
 
   #
   # Next year

--- a/spec/shared_context/users.rb
+++ b/spec/shared_context/users.rb
@@ -1,7 +1,28 @@
+require 'shared_context/named_dates'
+
+# This creates these users: (all use create() unless "[uses build()]" is noted in the description below)
+#   (Note that 'shared_context/named_dates' defines THIS_YEAR; last year = THIS_YEAR - 1; next year = THIS_YEAR + 1)
+#
+# user - a user (no payments, not a member)
+# user_no_payments - a user (no payments, not a member)
+# member_paid_up - [uses build(), then saves] a member with a membership application and a membership payment made today
+# member_expired - [uses build(), then saves] a member with a membership application and a membership payment that expired yesterday
+# user_pays_every_nov30 - current member with membership app; paid membership fee Nov 30 last year; paid branding fee Nov 30 last year; paid membership fee Nov 30 THIS_YEAR; paid branding fee Nov 30 THIS_YEAR;
+# user_paid_only_lastyear_dec_2 - member with membership app; paid membership fee Dec 2 last year; paid branding fee Dec 2 last year
+# user_paid_lastyear_nov_29 - member with membership app; paid membership fee Nov 29 last year; paid branding fee Nov 29 last year
+# user_unsuccessful_this_year - member with membership app; unsuccessful membership fee Nov 29 THIS_YER; unsuccessful branding fee Nov 29 THIS_YEAR; successful membership fee Nov 30 last year; successful branding fee Nov 30 last year
+# user_membership_expires_EOD_jan29 - member with membership app; membership term and branding fee term expire end of day (EOD) Jan 29 next year
+# user_membership_expires_EOD_feb1 - member with membership app; membership term and branding fee term expire end of day (EOD) Feb 1 next year
+# user_membership_expires_EOD_feb2 - member with membership app; membership term and branding fee term expire end of day (EOD) Feb 2 next year
+# user_membership_expires_EOD_dec7 - member with membership app; membership term and branding fee term expire end of day (EOD) Dec 7 next year
+# user_membership_expires_EOD_dec8 - member with membership app; membership term and branding fee term expire end of day (EOD) Dec 8 next year
+#
 RSpec.shared_context 'create users' do
 
+  include_context 'named dates'
+
   let(:user) { create(:user) }
-  
+
   let(:member_paid_up) do
     user = build(:member_with_membership_app)
     user.payments << create(:membership_fee_payment)
@@ -15,5 +36,263 @@ RSpec.shared_context 'create users' do
     user.save!
     user
   end
+
+
+  let(:user_pays_every_nov30) do
+    u    = create(:member_with_membership_app)
+    u_co = u.shf_application.companies.first
+
+    Timecop.freeze(lastyear_nov_30) do
+      create(:membership_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  lastyear_nov_30,
+             expire_date: User.expire_date_for_start_date(lastyear_nov_30),
+             notes:       'lastyear_nov_30 membership')
+      create(:h_branding_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  lastyear_nov_30,
+             expire_date: Company.expire_date_for_start_date(lastyear_nov_30),
+             notes:       'lastyear_nov_30 branding')
+    end
+
+    Timecop.freeze(nov_30) do
+      create(:membership_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  nov_30,
+             expire_date: User.expire_date_for_start_date(nov_30),
+             notes:       'nov_30 membership')
+      create(:h_branding_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  nov_30,
+             expire_date: Company.expire_date_for_start_date(nov_30),
+             notes:       'nov_30 branding')
+    end
+
+    u
+  end
+
+
+  let(:user_paid_only_lastyear_dec_2) do
+    u    = create(:member_with_membership_app)
+    u_co = u.shf_application.companies.first
+
+    Timecop.freeze(lastyear_dec_2) do
+      create(:membership_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  lastyear_dec_2,
+             expire_date: User.expire_date_for_start_date(lastyear_dec_2),
+             notes:       'lastyear_dec_2 membership')
+      create(:h_branding_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  lastyear_dec_2,
+             expire_date: Company.expire_date_for_start_date(lastyear_dec_2),
+             notes:       'lastyear_dec_2 branding')
+    end
+    u
+  end
+
+
+  let(:user_paid_lastyear_nov_29) do
+    u    = create(:member_with_membership_app)
+    u_co = u.shf_application.companies.first
+
+    Timecop.freeze(lastyear_nov_29) do
+      create(:membership_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  lastyear_nov_29,
+             expire_date: User.expire_date_for_start_date(lastyear_nov_29),
+             notes:       'lastyear_nov_29 membership')
+      create(:h_branding_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  lastyear_nov_29,
+             expire_date: Company.expire_date_for_start_date(lastyear_nov_29),
+             notes:       'lastyear_nov_29 branding')
+    end
+    u
+  end
+
+
+  let(:user_unsuccessful_this_year) do
+    u    = create(:member_with_membership_app)
+    u_co = u.shf_application.companies.first
+
+    # success on nov 30 last year
+    Timecop.freeze(lastyear_nov_30) do
+      create(:membership_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  lastyear_nov_30,
+             expire_date: User.expire_date_for_start_date(lastyear_nov_30),
+             notes:       'lastyear_nov_30 success membership')
+      create(:h_branding_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  lastyear_nov_30,
+             expire_date: Company.expire_date_for_start_date(lastyear_nov_30),
+             notes:       'lastyear_nov_30 success branding')
+    end
+
+    # failed on nov 29
+    Timecop.freeze(nov_29) do
+      create(:membership_fee_payment,
+             :expired,
+             user:        u,
+             company:     u_co,
+             start_date:  nov_29,
+             expire_date: User.expire_date_for_start_date(nov_29),
+             notes:       'nov_29 failed (expired) membership')
+      create(:h_branding_fee_payment,
+             :expired,
+             user:        u,
+             company:     u_co,
+             start_date:  nov_29,
+             expire_date: Company.expire_date_for_start_date(nov_29),
+             notes:       'nov_29 failed (expired) branding')
+    end
+
+    u
+  end
+
+
+  let(:user_no_payments)     { create(:user) }
+
+
+  let(:user_membership_expires_EOD_jan29) {
+    u    = create(:member_with_membership_app)
+    u_co = u.shf_application.companies.first
+
+    Timecop.freeze(jan_30) do
+      create(:membership_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  jan_30,
+             expire_date: User.expire_date_for_start_date(jan_30),
+             notes:       'jan_30 membership')
+      create(:h_branding_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  jan_30,
+             expire_date: Company.expire_date_for_start_date(jan_30),
+             notes:       'jan_30 branding')
+    end
+
+    u
+  }
+
+  let(:user_membership_expires_EOD_feb1) {
+    u    = create(:member_with_membership_app)
+    u_co = u.shf_application.companies.first
+
+    Timecop.freeze(feb_2) do
+      create(:membership_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  feb_2,
+             expire_date: User.expire_date_for_start_date(feb_2),
+             notes:       'feb_2 membership')
+      create(:h_branding_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  feb_2,
+             expire_date: Company.expire_date_for_start_date(feb_2),
+             notes:       'feb_2 branding')
+    end
+
+    u
+  }
+
+  let(:user_membership_expires_EOD_feb2) {
+    u    = create(:member_with_membership_app)
+    u_co = u.shf_application.companies.first
+
+    Timecop.freeze(feb_3) do
+      create(:membership_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  feb_3,
+             expire_date: User.expire_date_for_start_date(feb_3),
+             notes:       'feb_3 membership')
+      create(:h_branding_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  feb_3,
+             expire_date: Company.expire_date_for_start_date(feb_3),
+             notes:       'feb_3 branding')
+    end
+
+    u
+  }
+
+  let(:user_membership_expires_EOD_dec7) {
+    u    = create(:member_with_membership_app)
+    u_co = u.shf_application.companies.first
+
+    Timecop.freeze(lastyear_dec_8) do
+      create(:membership_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  lastyear_dec_8,
+             expire_date: User.expire_date_for_start_date(lastyear_dec_8),
+             notes:       'lastyear_dec_8 membership')
+      create(:h_branding_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  lastyear_dec_8,
+             expire_date: Company.expire_date_for_start_date(lastyear_dec_8),
+             notes:       'lastyear_dec_8 branding')
+    end
+
+    u
+  }
+
+  let(:user_membership_expires_EOD_dec8) {
+    u    = create(:member_with_membership_app)
+    u_co = u.shf_application.companies.first
+
+    Timecop.freeze(lastyear_dec_9) do
+      create(:membership_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  lastyear_dec_9,
+             expire_date: User.expire_date_for_start_date(lastyear_dec_9),
+             notes:       'lastyear_dec_9 membership')
+      create(:h_branding_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  lastyear_dec_9,
+             expire_date: Company.expire_date_for_start_date(lastyear_dec_9),
+             notes:       'lastyear_dec_9 branding')
+    end
+
+    u
+  }
 
 end

--- a/spec/shared_context/users.rb
+++ b/spec/shared_context/users.rb
@@ -20,8 +20,6 @@ require 'shared_context/named_dates'
 # user_membership_expires_EOD_dec8 - member with membership app; membership term and branding fee term expire end of day (EOD) Dec 8 next year
 # user_membership_expires_EOD_dec9 - member with membership app; membership term and branding fee term expire end of day (EOD) Dec 8 next year
 #
-# TODO - DRY up by defining a method that creates the user, payments, company for a given start day (and any other arguments needed)
-#
 RSpec.shared_context 'create users' do
 
   include_context 'named dates'
@@ -142,4 +140,7 @@ RSpec.shared_context 'create users' do
   let(:user_membership_expires_EOD_jan31) { create_member_with_payments_on([feb_1]) }
   let(:user_membership_expires_EOD_feb1) { create_member_with_payments_on([feb_2]) }
 
+  let(:user_membership_expires_EOD_dec7) { create_member_with_payments_on([lastyear_dec_8]) }
+  let(:user_membership_expires_EOD_dec8) { create_member_with_payments_on([lastyear_dec_9]) }
+  let(:user_membership_expires_EOD_dec9) { create_member_with_payments_on([lastyear_dec_10]) }
 end

--- a/spec/shared_context/users.rb
+++ b/spec/shared_context/users.rb
@@ -12,10 +12,15 @@ require 'shared_context/named_dates'
 # user_paid_lastyear_nov_29 - member with membership app; paid membership fee Nov 29 last year; paid branding fee Nov 29 last year
 # user_unsuccessful_this_year - member with membership app; unsuccessful membership fee Nov 29 THIS_YER; unsuccessful branding fee Nov 29 THIS_YEAR; successful membership fee Nov 30 last year; successful branding fee Nov 30 last year
 # user_membership_expires_EOD_jan29 - member with membership app; membership term and branding fee term expire end of day (EOD) Jan 29 next year
+# user_membership_expires_EOD_jan30 - member with membership app; membership term and branding fee term expire end of day (EOD) Jan 30 next year
+# user_membership_expires_EOD_jan31 - member with membership app; membership term and branding fee term expire end of day (EOD) Jan 31 next year
 # user_membership_expires_EOD_feb1 - member with membership app; membership term and branding fee term expire end of day (EOD) Feb 1 next year
 # user_membership_expires_EOD_feb2 - member with membership app; membership term and branding fee term expire end of day (EOD) Feb 2 next year
 # user_membership_expires_EOD_dec7 - member with membership app; membership term and branding fee term expire end of day (EOD) Dec 7 next year
 # user_membership_expires_EOD_dec8 - member with membership app; membership term and branding fee term expire end of day (EOD) Dec 8 next year
+# user_membership_expires_EOD_dec9 - member with membership app; membership term and branding fee term expire end of day (EOD) Dec 8 next year
+#
+# TODO - DRY up by defining a method that creates the user, payments, company for a given start day (and any other arguments needed)
 #
 RSpec.shared_context 'create users' do
 
@@ -199,6 +204,54 @@ RSpec.shared_context 'create users' do
     u
   }
 
+  let(:user_membership_expires_EOD_jan30) {
+    u    = create(:member_with_membership_app)
+    u_co = u.shf_application.companies.first
+
+    Timecop.freeze(jan_31) do
+      create(:membership_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  jan_31,
+             expire_date: User.expire_date_for_start_date(jan_31),
+             notes:       'jan_31 membership; expires jan 30 next year')
+      create(:h_branding_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  jan_31,
+             expire_date: Company.expire_date_for_start_date(jan_31),
+             notes:       'jan_31 branding; expires jan 30 next year')
+    end
+
+    u
+  }
+
+  let(:user_membership_expires_EOD_jan31) {
+    u    = create(:member_with_membership_app)
+    u_co = u.shf_application.companies.first
+
+    Timecop.freeze(feb_1) do
+      create(:membership_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  feb_1,
+             expire_date: User.expire_date_for_start_date(feb_1),
+             notes:       'feb_1 membership; expires jan 31 next year')
+      create(:h_branding_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  feb_1,
+             expire_date: Company.expire_date_for_start_date(feb_1),
+             notes:       'feb_1 branding; expires jan 31 next year')
+    end
+
+    u
+  }
+
   let(:user_membership_expires_EOD_feb1) {
     u    = create(:member_with_membership_app)
     u_co = u.shf_application.companies.first
@@ -290,6 +343,31 @@ RSpec.shared_context 'create users' do
              start_date:  lastyear_dec_9,
              expire_date: Company.expire_date_for_start_date(lastyear_dec_9),
              notes:       'lastyear_dec_9 branding')
+    end
+
+    u
+  }
+
+
+  let(:user_membership_expires_EOD_dec9) {
+    u    = create(:member_with_membership_app)
+    u_co = u.shf_application.companies.first
+
+    Timecop.freeze(lastyear_dec_10) do
+      create(:membership_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  lastyear_dec_10,
+             expire_date: User.expire_date_for_start_date(lastyear_dec_10),
+             notes:       'lastyear_dec_10 membership; expires dec 9')
+      create(:h_branding_fee_payment,
+             :successful,
+             user:        u,
+             company:     u_co,
+             start_date:  lastyear_dec_10,
+             expire_date: Company.expire_date_for_start_date(lastyear_dec_10),
+             notes:       'lastyear_dec_10 branding; expires dec 9')
     end
 
     u


### PR DESCRIPTION
## PT Story: Rspec, Features: add contexts, DRY, minor cleanup
#### PT URL: https://www.pivotaltracker.com/story/show/169668496

Some simple changes to clean up some RSpec and cucumber features stuff, and add some data (shared context) that can be used in tests.  This only changes `/features` and `/spec` files.

I did this while working on another PT task [Warn if user is paying 'too soon'](https://www.pivotaltracker.com/story/show/166273184)

## Changes proposed in this pull request:
1.  Add shared contexts (named data that can be used in specs).  Most notable:
    - named dates that can be reused, all based on the same starting year ("THIS_YEAR")
    - members with successful payments that can be reused 
2.  fix grammar in "Given the users exists" step
3. use Timecop where needed
4. other minor comments, reorganization, etc.

---
## Ready for review:
@AgileVentures/shf-project-team 
