### PR TITLE
Improve cuke path helpers and clarify "user account", "user profile" page refs in features

### DIFF
--- a/features/edit_user_profile.feature
+++ b/features/edit_user_profile.feature
@@ -1,6 +1,10 @@
-Feature: As a registered user
-  in order to keep my account information up to date
-  I need to be able to edit my account
+Feature: Edit a User Profile
+  TODO: this should be moved into the features/user_profile directory and then scenarios reorganized as appropriate with scenarios that already exist in that directory.
+
+  As a registered user
+  in order to be able to change my login email and password,
+  and to edit what is displayed to the public
+  I need to be able to edit my profile
 
   Background:
     Given the following users exist:
@@ -9,8 +13,8 @@ Feature: As a registered user
 
     And I am logged in as "emma@andersson.com"
 
-  Scenario: Editing an account
-    Given I am on the "edit registration for a user" page
+  Scenario: Editing my user profile - change first, last names
+    Given I am on the "edit my user profile" page
     Then the t("activerecord.attributes.user.first_name") field should be set to "emma"
     And the t("activerecord.attributes.user.last_name") field should be set to "andersson"
     And the t("activerecord.attributes.user.email") field should be set to "emma@andersson.com"
@@ -20,12 +24,12 @@ Feature: As a registered user
     And I fill in t("devise.registrations.edit.current_password") with "password"
     And I click on t("devise.registrations.edit.submit_button_label")
     Then I should see t("devise.registrations.edit.success")
-    When I am on the "edit registration for a user" page
+    When I am on the "edit my user profile" page
     Then the t("activerecord.attributes.user.first_name") field should be set to "emma (changed)"
     And the t("activerecord.attributes.user.last_name") field should be set to "andersson (changed)"
 
   Scenario: Sad path: Missing first name
-    Given I am on the "edit registration for a user" page
+    Given I am on the "edit my user profile" page
     Then the t("activerecord.attributes.user.first_name") field should be set to "emma"
     And the t("activerecord.attributes.user.last_name") field should be set to "andersson"
     And the t("activerecord.attributes.user.email") field should be set to "emma@andersson.com"
@@ -39,7 +43,7 @@ Feature: As a registered user
     Then the t("activerecord.attributes.user.first_name") field should be set to "emma"
 
   Scenario: Sad path: Missing last name
-    Given I am on the "edit registration for a user" page
+    Given I am on the "edit my user profile" page
     Then the t("activerecord.attributes.user.first_name") field should be set to "emma"
     And the t("activerecord.attributes.user.last_name") field should be set to "andersson"
     And the t("activerecord.attributes.user.email") field should be set to "emma@andersson.com"
@@ -49,5 +53,5 @@ Feature: As a registered user
     Then I should see error t("activerecord.attributes.user.last_name") t("errors.messages.blank")
     And I should not see t("devise.registrations.edit.success")
     And I should see t("cannot_change_language") image
-    When I am on the "edit registration for a user" page
+    When I am on the "edit my user profile" page
     Then the t("activerecord.attributes.user.last_name") field should be set to "andersson"

--- a/features/support/path_helpers.rb
+++ b/features/support/path_helpers.rb
@@ -14,50 +14,60 @@ module PathHelpers
   end
 
 
+  # Given a page name [String] in a step, visit the right page.
+  #
   # All known paths.  Based on the page name, visit the appropriate page.
   # If the pagename is not in this list, then try to 'manually' construct it.
   #
+  # @param [String] pagename - the name of the page given in a step
+  # @param [User] user - the user with information needed for that page (e.g. get the shf_application for that user)
   # @return [String] - the path to visit
   def get_path(pagename, user = @user)
 
     case pagename.downcase
+
+      # Login and registration pages
       when  'login'
         path = new_user_session_path
-      when 'landing'
-        path = root_path
-      when 'new application'
-        path = new_shf_application_path
-      when 'edit application', 'edit my application'
-        user.reload
-        path = edit_shf_application_path(user.shf_application)
-      when 'application', 'show my application'
-        path = shf_application_path(user.shf_application)
-      when 'user instructions'
-        path = information_path
-      when 'member instructions'
-        path = information_path
-      when 'all waiting for info reasons'
-        path = admin_only_member_app_waiting_reasons_path
-      when 'new waiting for info reason'
-        path = new_admin_only_member_app_waiting_reason_path
       when 'register as a new user'
         path = new_user_registration_path
       when 'edit registration for a user'
         path = edit_user_registration_path
       when 'new password'
         path = new_user_password_path
-      when 'all member app waiting reasons'
-        path = admin_only_member_app_waiting_reasons_path
-      when 'business categories'
-        path = business_categories_path
+
+      # Home a.k.a 'landing' pages
+      when 'landing'
+        path = root_path
+
+      # Instruction pages
+      when 'user instructions'
+        path = information_path
+      when 'member instructions'
+        path = information_path
+
+      # SHF application pages
+      when 'new application'
+        path = new_shf_application_path
+      when 'submit new membership application'
+        path = new_shf_application_path
+      when 'edit application', 'edit my application'
+        user.reload
+        path = edit_shf_application_path(user.shf_application)
+      when 'application', 'show my application'
+        path = shf_application_path(user.shf_application)
       when 'membership applications', 'shf applications'
         path = shf_applications_path
+
+      # Business category pages
+      when 'business categories'
+        path = business_categories_path
+
+      # Company pages
       when 'all companies'
         path = companies_path
       when 'create a new company'
         path = new_company_path
-      when 'submit new membership application'
-        path = new_shf_application_path
       when 'my first company'
         path = company_path(user.shf_application.companies.first)
       when 'my second company'
@@ -66,25 +76,53 @@ module PathHelpers
         path = company_path(user.shf_application.companies.third)
       when 'edit my company'
         path = edit_company_path(user.shf_application.companies.first)
+
+      # User and Member pages
       when 'all users'
         path = users_path
+      when 'user details', 'user profile'
+        path = user_path(user)
+
+
+      # SHF Document pages
       when 'all shf documents'
         path = shf_documents_path
       when 'new shf document'
         path = new_shf_document_path
-      when 'user details', 'user profile'
-        path = user_path(user)
-      when 'test exception notifications'
-        path = test_exception_notifications_path
-      when 'admin dashboard'
-        path = admin_only_dashboard_path
+
+
+      # ==================================================
+      # Other Admin pages - pages only administrators can access
+      #   These are admin access only pages that don't fit with the groups/topics above.
+      #   Admin access only pages may also be listed above, grouped with specific topics/areas.
+      #   Ex: view all companies = only an admin can access, but is grouped with 'Company pages' above.
+
+      # Application configuration
       when 'admin edit app configuration'
         path = admin_only_edit_app_configuration_path(AdminOnly::AppConfiguration.config_to_use)
       when 'admin show app configuration'
         path = admin_only_app_configuration_path
+
+      # Reasons SHF is waiting for more application info
+      when 'all waiting for info reasons'
+        path = admin_only_member_app_waiting_reasons_path
+      when 'new waiting for info reason'
+        path = new_admin_only_member_app_waiting_reason_path
+      when 'all member app waiting reasons'
+        path = admin_only_member_app_waiting_reasons_path
+
+      when 'admin dashboard'
+        path = admin_only_dashboard_path
+
+      # ==================================================
+      # Other pages
+      when 'test exception notifications'
+        path = test_exception_notifications_path
       when 'cookies'
         path = cookies_path
 
+      # If this error is raised, the page isn't known by this method.
+      # Define it and add it to a when statement above or correct it to something known.
       else
         raise PagenameUnknown.new(page_name: pagename)
     end

--- a/features/support/path_helpers.rb
+++ b/features/support/path_helpers.rb
@@ -7,13 +7,6 @@
 #
 module PathHelpers
 
-  # remove any leading locale path info
-  def current_path_without_locale(path)
-    locale_pattern =  /^(\/)(en|sv)?(\/)?(.*)$/
-    path.gsub(locale_pattern, '\1\4')
-  end
-
-
   # Given a page name [String] in a step, visit the right page.
   #
   # All known paths.  Based on the page name, visit the appropriate page.
@@ -31,10 +24,7 @@ module PathHelpers
         path = new_user_session_path
       when 'register as a new user'
         path = new_user_registration_path
-      when 'edit registration for a user'
-        path = edit_user_registration_path
-      when 'new password'
-        path = new_user_password_path
+
 
       # Home a.k.a 'landing' pages
       when 'landing'
@@ -46,26 +36,31 @@ module PathHelpers
       when 'member instructions'
         path = information_path
 
+      # User Profile: this is the devise registrations page
+      when 'edit registration for a user', 'edit user profile', 'edit my user profile'
+        path = edit_user_registration_path
+      when 'new password'
+        path = new_user_password_path
+
+      # User Account
+      when 'user details', 'user account'
+        path = user_path(user)
+
+
       # SHF application pages
-      when 'new application'
-        path = new_shf_application_path
-      when 'submit new membership application'
+      when 'new application', 'submit new membership application'
         path = new_shf_application_path
       when 'edit application', 'edit my application'
         user.reload
         path = edit_shf_application_path(user.shf_application)
       when 'application', 'show my application'
         path = shf_application_path(user.shf_application)
-      when 'membership applications', 'shf applications'
-        path = shf_applications_path
 
       # Business category pages
       when 'business categories'
         path = business_categories_path
 
       # Company pages
-      when 'all companies'
-        path = companies_path
       when 'create a new company'
         path = new_company_path
       when 'my first company'
@@ -77,25 +72,29 @@ module PathHelpers
       when 'edit my company'
         path = edit_company_path(user.shf_application.companies.first)
 
-      # User and Member pages
-      when 'all users'
-        path = users_path
-      when 'user details', 'user profile'
-        path = user_path(user)
-
-
       # SHF Document pages
       when 'all shf documents'
         path = shf_documents_path
-      when 'new shf document'
-        path = new_shf_document_path
 
 
       # ==================================================
       # Other Admin pages - pages only administrators can access
-      #   These are admin access only pages that don't fit with the groups/topics above.
-      #   Admin access only pages may also be listed above, grouped with specific topics/areas.
-      #   Ex: view all companies = only an admin can access, but is grouped with 'Company pages' above.
+
+      # Users
+      when 'all users'
+        path = users_path
+
+      # Shf Applications
+      when 'membership applications', 'shf applications'
+        path = shf_applications_path
+
+      # Companies
+      when 'all companies'
+        path = companies_path
+
+      # SHF Documents
+      when 'new shf document'
+        path = new_shf_document_path
 
       # Application configuration
       when 'admin edit app configuration'
@@ -128,6 +127,13 @@ module PathHelpers
     end
 
     path
+  end
+
+
+  # remove any leading locale path info
+  def current_path_without_locale(path)
+    locale_pattern =  /^(\/)(en|sv)?(\/)?(.*)$/
+    path.gsub(locale_pattern, '\1\4')
   end
 
 

--- a/features/user-account-access.feature
+++ b/features/user-account-access.feature
@@ -1,8 +1,8 @@
-Feature: Show user account information
+Feature: Show user account information only to those that should see it
 
   As a user
-  So that I know what information SHF has about me
-  Show me my user account page
+  Because my user account page has private member and payment status information
+  Only I (and the admin) should be able to see it
 
   PT:  https://www.pivotaltracker.com/story/show/140358959
 
@@ -37,21 +37,21 @@ Feature: Show user account information
       | lars@example.com | 2019-03-01 |
 
 
-  Scenario: a visitor cannot see a user page
+  Scenario: a visitor cannot see a user account page
     Given I am logged out
-    When I am on the "user details" page for "lars@example.com"
+    When I am on the "user account" page for "lars@example.com"
     Then I should see t("errors.not_permitted")
 
 
-  Scenario: user cannot see the user page for another user
+  Scenario: user cannot see the user account page for another user
     Given I am logged in as "emma@example.com"
-    When I am on the "user details" page for "lars@example.com"
+    When I am on the "user account" page for "lars@example.com"
     Then I should see t("errors.not_permitted")
 
 
-  Scenario: a user can see their own user page
+  Scenario: a user can see their own user account page
     Given I am logged in as "emma@example.com"
-    When I am on the "user details" page for "emma@example.com"
+    When I am on the "user account" page for "emma@example.com"
     Then I should not see t("errors.not_permitted")
     And I should see t("users.show.email")
     And I should see "emma@example.com"
@@ -59,13 +59,13 @@ Feature: Show user account information
 
   Scenario: member cannot see the user page for another user
     Given I am logged in as "lars@example.com"
-    When I am on the "user details" page for "emma@example.com"
+    When I am on the "user account" page for "emma@example.com"
     Then I should see t("errors.not_permitted")
 
 
   Scenario: a member can see their own user page
     Given I am logged in as "lars@example.com"
-    When I am on the "user details" page for "lars@example.com"
+    When I am on the "user account" page for "lars@example.com"
     Then I should not see t("errors.not_permitted")
     And I should see t("users.show.email")
     And I should see "lars@example.com"

--- a/features/user_account/company_h_brand.feature
+++ b/features/user_account/company_h_brand.feature
@@ -60,7 +60,7 @@ Feature: Member gets their customized SHF membership card (proof of membership)
 
   @selenium @time_adjust
   Scenario: Member sees custom context menu instead of normal browser context menu
-    Given I am on the "user profile" page for "emma@mutts.se"
+    Given I am on the "user account" page for "emma@mutts.se"
     When I right click on "#company-h-brand"
     Then I should see t("users.show.download_image")
     And I should see t("users.show.show_image")

--- a/features/user_account/proof_of_membership.feature
+++ b/features/user_account/proof_of_membership.feature
@@ -52,7 +52,7 @@ Feature: Member gets their customized SHF membership card (proof of membership)
 
   @selenium @time_adjust
   Scenario: Member sees custom context menu instead of normal browser context menu
-    Given I am on the "user profile" page for "emma@mutts.se"
+    Given I am on the "user account" page for "emma@mutts.se"
     When I right click on "#proof-of-membership"
     Then I should see t("users.show.download_image")
     And I should see t("users.show.show_image")


### PR DESCRIPTION
## PT Story: Improve cucumber path_helpers
#### PT URL: https://www.pivotaltracker.com/story/show/168483267


## Changes proposed in this pull request:
1.  Add comments to and organize (group) the big case statement in `features/path_helpers` 
2. disambiguate "user profile" "user details" and "user account" page references and descriptions in features

---
## Ready for review:
@AgileVentures/shf-project-team 
