### PR TITLE
comment out the scenario that uses 'headed' Chrome (@selenium_browser)

### DIFF
--- a/features/membership-application-status/admin-sets-custom-waiting-reason.feature
+++ b/features/membership-application-status/admin-sets-custom-waiting-reason.feature
@@ -113,17 +113,17 @@ Feature: Admin sets or enters the reason they are waiting for info from a user
     Then I should not see t("shf_applications.need_info.reason_title")
 
 
-  @selenium_browser @admin
-  Scenario: Press `back` button before saving custom reason
-    Given I am on the "landing" page
-    Then I am on the "application" page for "anna_waiting_for_info@nosnarkybarky.se"
-    When I select t("admin_only.member_app_waiting_reasons.other_custom_reason") in select list "member_app_waiting_reasons"
-    And I wait for all ajax requests to complete
-    And I fill in "custom_reason_text" with "This is my reason"
-    Then I click the browser back button and "dismiss" the prompt
-    And the t("shf_applications.need_info.other_reason_label") field should be set to "This is my reason"
-    And I fill in "custom_reason_text" with "This is my reason"
-    Then I click the browser back button and "accept" the prompt
-    And I should be on the "landing" page
-    Then I am on the "application" page for "anna_waiting_for_info@nosnarkybarky.se"
-    And I should not see "This is my reason"
+#  @selenium_browser @admin
+#  Scenario: Press `back` button before saving custom reason
+#    Given I am on the "landing" page
+#    Then I am on the "application" page for "anna_waiting_for_info@nosnarkybarky.se"
+#    When I select t("admin_only.member_app_waiting_reasons.other_custom_reason") in select list "member_app_waiting_reasons"
+#    And I wait for all ajax requests to complete
+#    And I fill in "custom_reason_text" with "This is my reason"
+#    Then I click the browser back button and "dismiss" the prompt
+#    And the t("shf_applications.need_info.other_reason_label") field should be set to "This is my reason"
+#    And I fill in "custom_reason_text" with "This is my reason"
+#    Then I click the browser back button and "accept" the prompt
+#    And I should be on the "landing" page
+#    Then I am on the "application" page for "anna_waiting_for_info@nosnarkybarky.se"
+#    And I should not see "This is my reason"


### PR DESCRIPTION
## PT Story: comment out old Feature scenarios that use full browser
#### PT URL: https://www.pivotaltracker.com/story/show/169668433

This scenario drives me crazy and makes running all features difficult while doing other work -- since the Chrome browser will pop up randomly at some point.
Per the PT story: (1) I think we've verified this scenario runs fine.  (2) I don't think there's real value in testing if a user uses their browser's "back" function (button): we can't (and shouldn't) do much about that.  

## Changes proposed in this pull request:
1.  commented out the 1 scenario that runs Chrome (visible; "headed")

---
## Ready for review:
@AgileVentures/shf-project-team 
