### PR TITLE
clearer step: "I should [not] see a message telling me I am not allowed to see that page"

### DIFF
--- a/features/admin_creates_company.feature
+++ b/features/admin_creates_company.feature
@@ -65,12 +65,12 @@ Feature: As an admin
   Scenario: User tries to create a company
     Given I am logged in as "applicant_1@happymutts.com"
     And I am on the "create a new company" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   Scenario: Visitor tries to create a company
     Given I am Logged out
     And I am on the "create a new company" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   @time_adjust @dinkurs_fetch
   Scenario: Admin creates a company

--- a/features/create_business_category.feature
+++ b/features/create_business_category.feature
@@ -52,9 +52,9 @@ Feature: As an admin
   Scenario: Listing Business Categories restricted for Non-admins
     Given I am logged in as "applicant@random.com"
     And I am on the "business categories" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   Scenario: Listing Business Categories restricted for visitors
     Given I am Logged out
     And I am on the "business categories" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -431,10 +431,10 @@ Feature: Create a new membership application
     Given I am logged out
     And I am logged in as "member@random.com"
     And I am on the "new application" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
 
   Scenario: An admin cannot submit a new application because we don't know which User it is for
     Given I am logged in as "admin@shf.se"
     And I am on the "new application" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page

--- a/features/delete_shf_application.feature
+++ b/features/delete_shf_application.feature
@@ -58,7 +58,7 @@ Feature: As an admin
   Scenario: Member should not see the 'delete' button on their own application
     Given I am logged in as "emma@random.com"
     And I am on the "application" page for "emma@random.com"
-    Then I should not see t("errors.not_permitted")
+    Then I should not see a message telling me I am not allowed to see that page
     And I should not see t("shf_applications.show.delete")
 
   Scenario: Visitor should not see the 'delete' button

--- a/features/delete_shf_application.feature
+++ b/features/delete_shf_application.feature
@@ -51,7 +51,7 @@ Feature: As an admin
   Scenario: Admin should see the 'delete' button
     Given I am logged in as "admin@shf.se"
     And I am on the "application" page for "emma@random.com"
-    Then I should not see t("errors.not_permitted")
+    Then I should not see a message telling me I am not allowed to see that page
     And I should see t("shf_applications.show.delete")
 
 
@@ -64,7 +64,7 @@ Feature: As an admin
   Scenario: Visitor should not see the 'delete' button
     Given I am Logged out
     And I am on the "application" page for "emma@random.com"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see t("shf_applications.show.delete")
 
 

--- a/features/edit_business_category.feature
+++ b/features/edit_business_category.feature
@@ -42,9 +42,9 @@ Feature: As an admin
   Scenario: A non-admin user cannot edit business categories
     Given I am logged in as "applicant@random.com"
     And I navigate to the business category edit page for "dog grooming"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   Scenario: A visitor cannot edit business categories
     Given I am Logged out
     And I navigate to the business category edit page for "dog grooming"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page

--- a/features/edit_company.feature
+++ b/features/edit_company.feature
@@ -48,9 +48,9 @@ Feature: As a member
   Scenario: Visitor tries to edit a company
     Given I am Logged out
     And I am on the edit company page for "5560360793"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   Scenario: User can not edit someone else's company
     Given I am logged in as "mere_user@mutts.com"
     And I am on the edit company page for "5560360793"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page

--- a/features/edit_shf_application.feature
+++ b/features/edit_shf_application.feature
@@ -186,7 +186,7 @@ Feature: Edit SHF Application
   Scenario: Applicant can view accepted application
     Given I am logged in as "nils@random.com"
     And I am on the "show my application" page for "nils@random.com"
-    Then I should not see t("errors.not_permitted")
+    Then I should not see a message telling me I am not allowed to see that page
     And I should see t("shf_applications.accepted")
 
   Scenario: Applicant can not edit rejected application
@@ -197,7 +197,7 @@ Feature: Edit SHF Application
   Scenario: Applicant can view rejected application
     Given I am logged in as "bob@barkybobs.com"
     And I am on the "show my application" page for "bob@barkybobs.com"
-    Then I should not see t("errors.not_permitted")
+    Then I should not see a message telling me I am not allowed to see that page
     And I should see t("shf_applications.rejected")
 
   Scenario: Member wants to view their own application

--- a/features/edit_shf_application.feature
+++ b/features/edit_shf_application.feature
@@ -176,12 +176,12 @@ Feature: Edit SHF Application
   Scenario: Applicant can not edit applications not created by them
     Given I am logged in as "emma@random.com"
     And I am on the "edit application" page for "hans@random.com"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   Scenario: Applicant can not edit accepted application
     Given I am logged in as "nils@random.com"
     And I am on the "edit application" page for "nils@random.com"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   Scenario: Applicant can view accepted application
     Given I am logged in as "nils@random.com"
@@ -192,7 +192,7 @@ Feature: Edit SHF Application
   Scenario: Applicant can not edit rejected application
     Given I am logged in as "bob@barkybobs.com"
     And I am on the "edit application" page for "bob@barkybobs.com"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   Scenario: Applicant can view rejected application
     Given I am logged in as "bob@barkybobs.com"

--- a/features/export-member-email-info.feature
+++ b/features/export-member-email-info.feature
@@ -34,19 +34,19 @@ Feature: export member information to a CSV file so I can use it in other system
   Scenario: Visitor can't export
     Given I am Logged out
     When I am on the "membership applications" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
 
   Scenario: User can't export
     Given I am logged in as "wils@woof.com"
     When I am on the "membership applications" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
 
   Scenario: Member can't export
     Given I am logged in as "emma@happymutts.com"
     When I am on the "membership applications" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   Scenario: Admin can export
     Given I am logged in as "admin@shf.se"

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -60,7 +60,7 @@ Feature: As a registered user
     And I click on t("devise.sessions.new.log_in") button
     Then I should see t("devise.failure.invalid", authentication_keys: 'Email')
     When I fail to visit the "membership applications" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should see t("errors.try_login")
     And I should be on "login" page
 

--- a/features/membership-application-status/admin-manage-reasons-waiting-for-info.feature
+++ b/features/membership-application-status/admin-manage-reasons-waiting-for-info.feature
@@ -73,7 +73,7 @@ Feature: Admin manages the list of reasons why SHF is waiting for info from an a
   Scenario: An admin can view the list of reasons
     Given I am logged in as "admin@shf.se"
     When I am on the "all waiting for info reasons" page
-    Then I should not see t("errors.not_permitted")
+    Then I should not see a message telling me I am not allowed to see that page
     And I should see t("admin_only.member_app_waiting_reasons.index.title")
 
 
@@ -105,7 +105,7 @@ Feature: Admin manages the list of reasons why SHF is waiting for info from an a
   Scenario: An admin can create a new reason
     Given I am logged in as "admin@shf.se"
     When I am on the "new waiting for info reason" page
-    Then I should not see t("errors.not_permitted")
+    Then I should not see a message telling me I am not allowed to see that page
     And I should see t("admin_only.member_app_waiting_reasons.new.title")
 
 
@@ -138,7 +138,7 @@ Feature: Admin manages the list of reasons why SHF is waiting for info from an a
   Scenario: An admin can edit a reason
     Given I am logged in as "admin@shf.se"
     When I am on the edit member app waiting reason with name_sv "namn 1"
-    Then I should not see t("errors.not_permitted")
+    Then I should not see a message telling me I am not allowed to see that page
     And I should see t("admin_only.member_app_waiting_reasons.edit.title", name_sv: "namn 1", name_en: "name 1")
 
 

--- a/features/membership-application-status/admin-manage-reasons-waiting-for-info.feature
+++ b/features/membership-application-status/admin-manage-reasons-waiting-for-info.feature
@@ -50,14 +50,14 @@ Feature: Admin manages the list of reasons why SHF is waiting for info from an a
   Scenario: a visitor cannot view the list of reasons
     Given I am logged out
     When I am on the "all waiting for info reasons" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see t("admin_only.member_app_waiting_reasons.index.title")
 
   @user
   Scenario: A logged in user cannot view the list of reasons
     Given I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
     When I am on the "all waiting for info reasons" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see t("admin_only.member_app_waiting_reasons.index.title")
 
 
@@ -65,7 +65,7 @@ Feature: Admin manages the list of reasons why SHF is waiting for info from an a
   Scenario: A member cannot view the list of reasons
     Given I am logged in as "emma@happymutts.se"
     When I am on the "all waiting for info reasons" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see t("admin_only.member_app_waiting_reasons.index.title")
 
 
@@ -82,14 +82,14 @@ Feature: Admin manages the list of reasons why SHF is waiting for info from an a
   Scenario: A visitor cannot create a new reason
     Given I am logged out
     When I am on the "new waiting for info reason" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see t("admin_only.member_app_waiting_reasons.new.title")
 
   @user
   Scenario: A logged in user cannot create a new reason
     Given I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
     When I am on the "new waiting for info reason" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see t("admin_only.member_app_waiting_reasons.new.title")
 
 
@@ -97,7 +97,7 @@ Feature: Admin manages the list of reasons why SHF is waiting for info from an a
   Scenario: A member cannot create a new reason
     Given I am logged in as "emma@happymutts.se"
     When I am on the "new waiting for info reason" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see t("admin_only.member_app_waiting_reasons.new.title")
 
 
@@ -115,14 +115,14 @@ Feature: Admin manages the list of reasons why SHF is waiting for info from an a
   Scenario: A visitor cannot edit a reason
     Given I am logged out
     When I am on the edit member app waiting reason with name_sv "namn 1"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see t("admin_only.member_app_waiting_reasons.edit.title", name_sv: "namn 1", name_en: "name 1")
 
   @user
   Scenario: A logged in user cannot edit a reason
     Given I am logged in as "anna_waiting_for_info@nosnarkybarky.se"
     When I am on the edit member app waiting reason with name_sv "namn 1"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see t("admin_only.member_app_waiting_reasons.edit.title", name_sv: "namn 1", name_en: "name 1")
 
 
@@ -130,7 +130,7 @@ Feature: Admin manages the list of reasons why SHF is waiting for info from an a
   Scenario: A member cannot edit a reason
     Given I am logged in as "emma@happymutts.se"
     When I am on the edit member app waiting reason with name_sv "namn 1"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see t("admin_only.member_app_waiting_reasons.edit.title", name_sv: "namn 1", name_en: "name 1")
 
 

--- a/features/redirect-user-to-login-page.feature
+++ b/features/redirect-user-to-login-page.feature
@@ -43,7 +43,7 @@ Feature: Redirect User to the login page if they need to be logged in
     Given I am on the "landing" page
     When I am on the "create a new company" page
     Then I should be on "login" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should see t("errors.try_login")
 
 
@@ -51,7 +51,7 @@ Feature: Redirect User to the login page if they need to be logged in
     Given I am on the "login" page
     When I am on the "all waiting for info reasons" page
     Then I should be on "login" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should see t("errors.try_login")
 
 

--- a/features/redirect-user-to-login-page.feature
+++ b/features/redirect-user-to-login-page.feature
@@ -57,5 +57,5 @@ Feature: Redirect User to the login page if they need to be logged in
 
   Scenario: I can access a page that does not require a login (detail for 1 company)
     When  I am the page for company number "5560360793"
-    Then I should not see t("errors.not_permitted")
+    Then I should not see a message telling me I am not allowed to see that page
     And I should not see t("errors.try_login")

--- a/features/shf-documents/admin-edits-shf-document.feature
+++ b/features/shf-documents/admin-edits-shf-document.feature
@@ -84,7 +84,7 @@ Feature: Admin can edit details about an uploaded SHF Document
     And I click on t("submit") button
     And I am logged out
     When I am on the edit SHF document page for "Uploaded document"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   @user
   Scenario: User cannot upload a SHF document
@@ -96,7 +96,7 @@ Feature: Admin can edit details about an uploaded SHF Document
     And I click on t("submit") button
     And I am logged in as "bob@snarkybarky.se"
     When I am on the edit SHF document page for "Uploaded document"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   @member
   Scenario: Member cannot upload a SHF document
@@ -108,4 +108,4 @@ Feature: Admin can edit details about an uploaded SHF Document
     And I click on t("submit") button
     And I am logged in as "emma@happymutts.se"
     When I am on the edit SHF document page for "Uploaded document"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page

--- a/features/shf-documents/admin-uploads-shf-documents.feature
+++ b/features/shf-documents/admin-uploads-shf-documents.feature
@@ -55,16 +55,16 @@ Feature: Admin uploads meeting PDFs
   Scenario: Visitor cannot upload a SHF document
     Given I am Logged out
     And I am on the "new SHF document" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   @user
   Scenario: User cannot upload a SHF document
     Given I am logged in as "bob@snarkybarky.se"
     And I am on the "new SHF document" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   @member
   Scenario: Member cannot upload a SHF document
     Given I am logged in as "emma@happymutts.se"
     And I am on the "new SHF document" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page

--- a/features/shf-documents/admin-views-shf-document-details.feature
+++ b/features/shf-documents/admin-views-shf-document-details.feature
@@ -53,7 +53,7 @@ Feature: Admin can edit details about an uploaded SHF Document
     And I click on t("submit") button
     And I am logged out
     When I am on the SHF document page for "Uploaded document"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   @user
   Scenario: User cannot view the details for a SHF document
@@ -65,7 +65,7 @@ Feature: Admin can edit details about an uploaded SHF Document
     And I click on t("submit") button
     And I am logged in as "bob@snarkybarky.se"
     When I am on the SHF document page for "Uploaded document"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
   @member
   Scenario: Member cannot view the details for a SHF document
@@ -77,4 +77,4 @@ Feature: Admin can edit details about an uploaded SHF Document
     And I click on t("submit") button
     And I am logged in as "emma@happymutts.se"
     When I am on the SHF document page for "Uploaded document"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page

--- a/features/shf-documents/view-all-shf-documents.feature
+++ b/features/shf-documents/view-all-shf-documents.feature
@@ -108,10 +108,10 @@ Feature: SHF members (and admins) can views board meeting minutes (SHF documents
   Scenario: A visitor cannot see SHF documents
     Given I am logged out
     And I am on the "all SHF documents" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
 
   Scenario: A user cannot see SHF documents
     Given I am logged in as "bob@snarkybarky.se"
     And I am on the "all SHF documents" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page

--- a/features/show_all_shf_applications.feature
+++ b/features/show_all_shf_applications.feature
@@ -122,7 +122,7 @@ Feature: Admin can see all SHF applications so they can be managed
   Scenario: Visitor cannot see the list of all SHF Applications (denied access)
     Given I am logged out
     When I am on the "shf applications" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see t("shf_applications.index.title")
 
 
@@ -130,7 +130,7 @@ Feature: Admin can see all SHF applications so they can be managed
   Scenario: User cannot see the list of all SHF Applications (denied access)
     Given I am logged in as "emma_under_review@happymutts.se"
     When I am on the "shf applications" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see t("shf_applications.index.title")
 
 
@@ -138,5 +138,5 @@ Feature: Admin can see all SHF applications so they can be managed
   Scenario: Member cannot see the list of all SHF Applications (denied access)
     Given I am logged in as "markus_member@bowwowwow.se"
     When I am on the "shf applications" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see t("shf_applications.index.title")

--- a/features/show_shf_application.feature
+++ b/features/show_shf_application.feature
@@ -67,7 +67,7 @@ Feature: View a SHF Application
   Scenario: Listing incoming Applications restricted for Non-admins
     Given I am logged in as "hans_waits@waiting.se"
     And I am on the "membership applications" page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
 
   @admin

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -1,3 +1,10 @@
+
+
+And("I should{negate} see a message telling me I am not allowed to see that page") do | negation |
+  step %{I should#{negation} see t("errors.not_permitted")}
+end
+
+
 # Set the EU cookie consent cookie and then VISIT A PAGE
 #
 # Here are examples of strings that will match (the regular expression for) this step:

--- a/features/user-account-access.feature
+++ b/features/user-account-access.feature
@@ -179,13 +179,13 @@ Feature: Show user account (details) information to me
   Scenario: a visitor cannot see a user page
     Given I am logged out
     When I am on the "user account" page for "lars-member@example.com"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
 
   Scenario: user cannot see the user page for another user
     Given I am logged in as "emma-member@example.com"
     When I am on the "user account" page for "lars-member@example.com"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
 
   Scenario: a user can see their own user page
@@ -199,7 +199,7 @@ Feature: Show user account (details) information to me
   Scenario: member cannot see the user page for another user
     Given I am logged in as "lars-member@example.com"
     When I am on the "user account" page for "emma-member@example.com"
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
 
 
   Scenario: a member can see their own user page

--- a/features/user-account-access.feature
+++ b/features/user-account-access.feature
@@ -191,7 +191,7 @@ Feature: Show user account (details) information to me
   Scenario: a user can see their own user page
     Given I am logged in as "emma-member@example.com"
     When I am on the "user account" page for "emma-member@example.com"
-    Then I should not see t("errors.not_permitted")
+    Then I should not see a message telling me I am not allowed to see that page
     And I should see t("users.show_login_email_row_cols.email")
     And I should see "emma-member@example.com"
 
@@ -205,7 +205,7 @@ Feature: Show user account (details) information to me
   Scenario: a member can see their own user page
     Given I am logged in as "lars-member@example.com"
     When I am on the "user account" page for "lars-member@example.com"
-    Then I should not see t("errors.not_permitted")
+    Then I should not see a message telling me I am not allowed to see that page
     And I should see t("users.show_login_email_row_cols.email")
     And I should see "lars-member@example.com"
     And I should see t("users.show.membership_number")

--- a/features/view_hidden_pages.feature
+++ b/features/view_hidden_pages.feature
@@ -24,7 +24,7 @@ Feature: Only members and admins can see members only (hidden) pages
   Scenario: Visitor cannot see members only pages
     Given I am Logged out
     And I am on the static workgroups page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see "Yrkesråd"
 
   Scenario: Visitor cannot see members only menu
@@ -35,7 +35,7 @@ Feature: Only members and admins can see members only (hidden) pages
   Scenario: User cannot see members only pages
     Given I am logged in as "not_a_member@bowsers.com"
     And I am on the static workgroups page
-    Then I should see t("errors.not_permitted")
+    Then I should see a message telling me I am not allowed to see that page
     And I should not see "Yrkesråd"
 
   Scenario: User cannot see members only menu

--- a/features/view_hidden_pages.feature
+++ b/features/view_hidden_pages.feature
@@ -49,7 +49,7 @@ Feature: Only members and admins can see members only (hidden) pages
     Given I am logged in as "emma@happymutts.com"
     And  I am on the static workgroups page
     Then I should see "Yrkesrad"
-    Then I should not see t("errors.not_permitted")
+    Then I should not see a message telling me I am not allowed to see that page
 
   @time_adjust
   Scenario: Member can see members only menu
@@ -62,7 +62,7 @@ Feature: Only members and admins can see members only (hidden) pages
     Given I am logged in as "admin@shf.se"
     And  I am on the static workgroups page
     Then I should see "Yrkesrad"
-    Then I should not see t("errors.not_permitted")
+    Then I should not see a message telling me I am not allowed to see that page
 
   Scenario: Admin can see members only menu
     Given I am logged in as "admin@shf.se"


### PR DESCRIPTION
## PT Story:  Features: add less brittle step for (not-)seeing the "not permitted" page
#### PT URL: https://www.pivotaltracker.com/story/show/170987826


## Changes proposed in this pull request:
1. created a new step
2. replaced wording in features

ready for review:
@AgileVentures/shf-project-team 