### PR TITLE
set lock to allow for all versions of 3.11; remove whenever_path (not needed)

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -13,7 +13,7 @@
 #
 
 # config valid only for Capistrano 3.11
-lock '3.11'
+lock '~> 3.11.0'
 
 set :rbenv_type, :user
 set :rbenv_ruby, '2.5.1'
@@ -61,9 +61,6 @@ set :bundle_binstubs, nil
 set :keep_releases, 5
 
 set :migration_role, :app
-
-# whenever gem configuration:  we have the schedule.rb file in a slightly different place (under app/config)
-set :whenever_path,         ->{ "#{release_path}/app/config" }
 
 # ============================================
 # Tasks


### PR DESCRIPTION
## PT Story: capistrano: update version allowed to deploy; fix whenever configuration
#### PT URL: https://www.pivotaltracker.com/story/show/171088377


## Changes proposed in this pull request:
1.  change `lock` setting
2. remove code to set the whenever path. it's not needed

