### PR TITLE
Correcting typo in devise email

### DIFF
--- a/config/locales/devise.sv.yml
+++ b/config/locales/devise.sv.yml
@@ -21,7 +21,7 @@ sv:
         subject: "Instruktioner för att bekräfta konto"
 
       reset_password_instructions:
-        subject: "Instrukionter för att återställa lösenord"
+        subject: "Instruktioner för att återställa lösenord"
         hello: "Hallå %{email}"
         reset_requested: "Någon har begärt en länk för att ändra ditt lösenord. Du kan göra det genom länken nedan."
         change_password: "Ändra mitt lösenord"


### PR DESCRIPTION
## PT Story: Typo in Devise email
#### PT URL: https://www.pivotaltracker.com/story/show/162745742


## Changes proposed in this pull request:
Changing:
Instrukionter för att återställa lösenord
To:
Instruktioner för att återställa lösenord


---
## Ready for review:
@weedySeaDragon @thesuss @patmbolger 
