### PR TITLE
sitemap:  only index 'searchable' companies; put 'nofollow' into header for other companies

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -78,7 +78,7 @@ class Address < ApplicationRecord
     # Returns an array of address field values (strings) that starts with the
     # attribute associated with the  visibility level set for this address.
 
-    address_pattern = %w(street_address post_code city kommun)
+    address_pattern = %w(street_address post_code city kommun) # FIXME make this a constant
 
     pattern_length = address_pattern.length
 

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -65,6 +65,7 @@ class Company < ApplicationRecord
   # this scope is combined with a clause for a different table that also uses 'name',
   # SQL won't know which table to get 'name' from
   #  name could be NULL or it could be an empty string
+  # FIXME a company must have an address!  (cannot be nil)
   def self.complete
     where.not('companies.name' => '',
               id: Address.lacking_region.pluck(:addressable_id))
@@ -107,6 +108,10 @@ class Company < ApplicationRecord
     where.not(dinkurs_company_id: [nil, '']).order(:id)
   end
 
+
+  def searchable?
+    branding_license? && !current_members.empty?
+  end
 
   def complete?
     RequirementsForCoInfoComplete.requirements_met? company: self
@@ -234,6 +239,7 @@ class Company < ApplicationRecord
   end
 
 
+  # FIXME - the company member(s) need to set this.  Picking the 'first' one is arbitrary and may be wrong
   def main_address
 
     return addresses.mail_address.includes(:region)[0] if addresses.mail_address.exists?

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -5,25 +5,31 @@ SitemapGenerator::Sitemap.compress = false
 
 SitemapGenerator::Sitemap.create do
 
+  # Only add those companies that are searchable. The search engine bots should only
+  # crawl those company pages for companyes that would show up on
+  # the main list of companies for visitors. This is the 'searchable' scope.
+  companies_to_add = Company.searchable
+  company_options = Proc.new { |company| { lastmod: company.updated_at, changefreq: 'weekly' } }
+
   # Default version (and URLs) is the Swedish (svenska) version:
   group(filename: :svenska) do
 
     add root_path, changefreq: 'daily', priority: 0.8
 
-    Company.find_each do |co|
-      add company_path(co), lastmod: co.updated_at, changefreq: 'weekly'
+    companies_to_add.find_each do |co|
+      add company_path(co), company_options.call(co)
     end
   end
 
 
   # English version:
-  # pass in 'locale: :en' to  each path to get the English version
+  # pass in 'locale: :en' to each path to get the English version
   group(filename: :english) do
 
     add root_path(locale: :en), changefreq: 'daily', priority: 0.7
 
-    Company.find_each do |co|
-      add company_path(co, locale: :en), lastmod: co.updated_at, changefreq: 'weekly'
+    companies_to_add.find_each do |co|
+      add company_path(co, locale: :en), company_options.call(co)
     end
   end
 end


### PR DESCRIPTION
## PT Story:  incomplete companies are listed in sitemap: cause errors
#### PT URL: https://www.pivotaltracker.com/story/show/171111853


## Changes proposed in this pull request:
1.  use the `.searchable` scope as the list of Companies to index
2. DRY: use a Proc to generate the options for each Company link


---
## Ready for review:
@Luleherll 
@patmbolger 
