### PR TITLE
Addresses - migration to add timestamps

### DIFF
--- a/db/migrate/20200205213528_add_created_at_updated_at_to_addresses.rb
+++ b/db/migrate/20200205213528_add_created_at_updated_at_to_addresses.rb
@@ -1,0 +1,6 @@
+class AddCreatedAtUpdatedAtToAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :created_at, :timestamp
+    add_column :addresses, :updated_at, :timestamp
+  end
+end


### PR DESCRIPTION
## PT Story: add timestamps to Address
#### PT URL: https://www.pivotaltracker.com/story/show/171118484


## Changes proposed in this pull request:
1.  added migration that adds the standard `created_at` and `updated_at` attributes
2. I left the data as is (did not initialize values) because having 'nil' values will be informative; it will tell us that the created_date or updated_date happened before these fields were added.  Setting the date to the day/time for these to the day this is deployed would provide false information.
---
## Ready for review:
@AgileVentures/shf-project-team 
