### PR TITLE
add standardized icon helper methods; document ShfIconsHelper

### DIFF
--- a/app/helpers/shf_icons_helper.rb
+++ b/app/helpers/shf_icons_helper.rb
@@ -1,25 +1,68 @@
-# Standardized icons and icon-related helpers to use in the app
+# Standardized icon helper methods and  names to use in this application.
 #
-# This information and methods provide standardized icons to use in the system.
-# This is the place to define exactly which FontAwesome icon should be used
-# for common things (they are standardized),
-# and the names of the helper methods to use when you need to display one of the icons.
+# This defines (creates) helper methods for using FontAwesome icons in the application.
+#  - itt defines a standard method for using an icon (ex: 'edit_icon'), and
+#  - it defines a standard method for getting the [String] name of the icon (ex: 'edit_icon_fa_name')
 #
-# For example, this defines the FontAwesome icon to always use for "edit" and provides
-# helper methods for it so you don't have to remember exactly which FontAwesome
-# to use.  You just need to call the "edit_icon" helper method and it will
-# use the correct (standardized) icon.
+# This defines exactly which FontAwesome icons are used.
 #
-# ** You should use the helper method(s) instead of specifying the FontAwesome icon yourself. **
+# ** You should ALWAYS USE THE HELPER METHODs instead of using the constants here
+#    or specifying the FontAwesome icon yourself. **
 #
 # That way, this is the only place the the FontAwesome icons need to be specified.
 # (It is DRY.)
 # And if we change them, this is the only place that needs to be changed.
 #
-# Provides a single point of connection (binding) to the FontAwesome icon method.
+# These methods provide a single point of connection (binding) to the FontAwesome icon method.
 #
-# Note:  There is a specific helper method 'fas_tooltip(...) that can be used. It is defined in application_helper.rb.
+# Here are some general examples. (More details are in the documentation and methods below.)
 #
+# @example: Assume that information below is set so that "edit_icon" is the
+#   helper method to use whenever you want to show an icon to the user to edit something.
+#   You could use the method like this in a view
+#     link_to(edit_icon, edit_user_profile_path(@user))
+#   This would show the icon as a link to the edit_user_profile(@user) path
+#
+#
+# @example: Assuming there a is 'destroy' icon defined and helper methods
+#   are defined to show when something needs to be _destroyed:_
+#   - assume "destroy_icon" is a method defined below that shows the right icon,
+#       and that it uses FA_DESTROY to define exactly this FontAwesome icon to use
+#   - assume that the constant FA_DESTROY is set to the "trash" FontAwesome icon.
+#
+#   You would use the "destroy_icon" method to display the correct icon, ex:
+#      link_to(destroy_icon, destroy_user_profile_path(@user))
+#   and it would display the "trash" FontAwesome icon in the line
+#
+#   Later, if we decide to use a different FontAwesome icon
+#     (e.g. the "dumpster_fire") FontAwesome icon,
+#   the "destroy_icon" method stays the same. None of the views that use that method
+#   need to be changed. We only need to change the FA_DESTROY constant here
+#   so that it refers to "dumpster_fire" instead of "trash".
+#    link_to(destroy_icon, destroy_user_profile_path(@user))  does not need to be changed.
+#   After the change, it will automatically now display the "dumpster_fire" FontAwesome icon.
+#
+# @example:
+#   To display the destroy icon with a tooltip (text that shows when you hover
+#   on the icon), you'd put this in your view:
+#
+#     destroy_icon(html_options: { 'data-toggle': 'tooltip',
+#                                  title: "Delete me!" })
+#
+#   This will:
+#     - display the icon defined in the METHODS_AND_ICONS array (e.g. FA_TRASH),
+#     - call the method 'destroy_icon' (see how it is defined in the  module_eval below)
+#     - per the HTML that is given with html_options:
+#         when the user hovers on the icon, display a tooltip with "Delete me!"
+#         (The title: string would really be a call to I18n.t to show it in the correct language. )
+#
+#
+# NOTE about tooltips:
+#   There is a specific helper method 'fas_tooltip(...) that can also be used.
+#   It is defined in application_helper.rb.
+#
+#
+# See the documentation below for more details.
 #
 module ShfIconsHelper
 
@@ -167,9 +210,9 @@ module ShfIconsHelper
   #      end
   #
   #
-  #
-  #---------------------
-  #
+  #-----------------------------------------------------------------------
+
+
   # Try to keep these in the same order as the icon constant groups above.
   #
   METHODS_AND_ICONS = [

--- a/app/helpers/shf_icons_helper.rb
+++ b/app/helpers/shf_icons_helper.rb
@@ -1,32 +1,263 @@
 # Standardized icons and icon-related helpers to use in the app
 #
+# This information and methods provide standardized icons to use in the system.
+# This is the place to define exactly which FontAwesome icon should be used
+# for common things (they are standardized),
+# and the names of the helper methods to use when you need to display one of the icons.
+#
+# For example, this defines the FontAwesome icon to always use for "edit" and provides
+# helper methods for it so you don't have to remember exactly which FontAwesome
+# to use.  You just need to call the "edit_icon" helper method and it will
+# use the correct (standardized) icon.
+#
+# ** You should use the helper method(s) instead of specifying the FontAwesome icon yourself. **
+#
+# That way, this is the only place the the FontAwesome icons need to be specified.
+# (It is DRY.)
+# And if we change them, this is the only place that needs to be changed.
+#
+# Provides a single point of connection (binding) to the FontAwesome icon method.
+#
+# Note:  There is a specific helper method 'fas_tooltip(...) that can be used. It is defined in application_helper.rb.
+#
 #
 module ShfIconsHelper
 
   FA_STYLE_DEFAULT = 'fas'
+
+  # ---------------------------------------
+  # Define the FontAwesome icons to be used
+  #
+
+  # Standard actions: edit, view, destroy, etc.,  icons:
   FA_EDIT = 'edit'
+  FA_VIEW = 'eye'
+  FA_DESTROY = 'trash'
+
+
+  # Icons for specific pages/views:
   FA_USER_PROFILE = 'id-card'
   FA_USER_ACCOUNT = 'folder'
+
+
+  # Commonly used actions and information:
   FA_EXTERNAL_LINK = 'external-link-alt'
+  FA_CHECKBOX = ''
+  FA_COMPLETE_CHECK = 'check-circle'
+  FA_WARNING = 'exclamation-triangle'
+  FA_PROBLEM = 'times-circle'
+
+  FA_TOOLTIP = 'info-circle'  # Note that there is a specific helper method 'fas_tooltip(...) that can be used (Defined in application_helper.rb)
+
+  FA_BLANK = 'blank'  # placeholder
 
 
-  # Create an entry for each method that you want to define and the icon name it should use
-  #  A method will be created for each entry (see the class_eval below).
+  # arrows
+  FA_ARROW_LEFT = 'arrow-left'
+  FA_ARROW_RIGHT = 'arrow-right'
+  FA_ARROW_UP = 'arrow-up'
+  FA_ARROW_DOWN = 'arrow-down'
+  FA_ARROW_CIRCLE_LEFT = 'arrow-circle-left'
+  FA_ARROW_CIRCLE_RIGHT = 'arrow-circle-right'
+  FA_ARROW_CIRCLE_UP = 'arrow-circle-up'
+  FA_ARROW_CIRCLE_DOWN = 'arrow-circle-down'
+  FA_ARROW_ALT_CIRCLE_LEFT = 'arrow-alt-circle-left'
+  FA_ARROW_ALT_CIRCLE_RIGHT = 'arrow-alt-circle-right'
+  FA_ARROW_ALT_CIRCLE_UP = 'arrow-alt-circle-up'
+  FA_ARROW_ALT_CIRCLE_DOWN = 'arrow-alt-circle-down'
+  FA_LONG_ARROW_ALT_LEFT = 'long-arrow-alt-left'
+  FA_LONG_ARROW_ALT_RIGHT = 'long-arrow-alt-right'
+  FA_LONG_ARROW_ALT_UP = 'long-arrow-alt-up'
+  FA_LONG_ARROW_ALT_DOWN = 'long-arrow-alt-down'
+
+
+  # -----------------------------------------------------------------------------------
+  # METHODS_AND_ICONS is the list that defines helper method names
+  # and connects each method name to an icon constant above.
+  #
+  # Create an entry for each method that you want to define
+  #  and the icon name it should use.
+  # It should have a "method_name:" key
+  #  with the value set to a string that will be the start of the method names,
+  #  and an "icon: " key with the value set to a FontAwesome constant defined
+  #  above (which specifies the main part of the FontAwesome icon name to be used).
+  #
+  #  @example  { method_name_start: 'next_arrow', icon: FA_ARROW_RIGHT }
+  #
+  #  Two methods will be defined for each entry.  (see the module_eval below):
+  #    1) a helper method that will produce the HTML needed for the icon
+  #    2) a helper method that returns the name of the FontAwesome icon used
+  #
+  #  @example:
+  #   To create the methods for the standard edit icon:
+  #   1. assume that FA_EDIT = 'edit'  is defined above
+  #   2. and that this entry is in the METHODS_AND_ICONS list:
+  #        { method_name_start: 'edit', icon: FA_EDIT },
+  #
+  #  Two methods will be defined in the module_eval code below:
+  #   1) edit_icon(...) = a method that can be used to generate the HTML for the FA_EDIT icon
+  #       Parameters for this method are the same as for the FontAwesome icon() method
+  #       except they are all keyword arguments.  All are optional.
+  #       (See the comments below where the method is defined in the module_eval )
+  #
+  #   2) edit_fa_icon_name = a method that returns the FontAwesome icon name for 'edit'
+  #
+  #  This uses the _method_name_start:_ value  as the start of the name for the methods created.
+  #   For this entry,  method_name_start: 'edit'  so the methods defined will start with "edit"
+  #   The full method names will be "edit_icon" and "edit_fa_icon_name"
+  #
+  #   In the entry, icon: FA_EDIT  means that the FontAwesome icon defined by
+  #   FA_EDIT will be used. Since FA_EDIT = 'edit', the the FontAwesome
+  #   icon used will be "fa-" + "edit" = "fa-edit"
+  #
+  #   These are the 2 methods defined that can be used in views and controllers
+  #   as helper methods:
+  #
+  #      def edit_icon(html_options: {}, fa_style: FA_STYLE_DEFAULT, text: nil)
+  #         get_fa_icon(fa_style, FA_EDIT, text, html_options)
+  #       end
+  #
+  #      def edit_fa_icon_name
+  #        "fa-edit"
+  #      end
+  #
+  # You can then use those helper methods in views:
+  #   = link_to edit_icon, admin_only_user_profile_edit_path(user), title: t('.edit_user_profile', name: user.full_name)
+  #
+  # instead of the old way where you had to specify the FontAwesome icon to use:
+  #   = link_to icon('fas', 'edit'), admin_only_user_profile_edit_path(user), title: t('.edit_user_profile', name: user.full_name)
+  #
+  #
+  # @example
+  #  In a view, instead of writing this:
+  #
+  #  # OLD WAY (BAD)
+  #  - trash_icon = icon('fas', 'trash')
+  #  = link_to trash_icon, remove_attachment_shf_application_path(shf_application.id,
+  #                             shf_application: { uploaded_files_attributes: { id: uploaded_file.id,  '_destroy' => true }}),
+  #                           method: :put, remote: true,
+  #                           id: "uploaded-file-#{uploaded_file.id}",
+  #                           class: "action-delete",
+  #                           data: { confirm: "#{t('shf_applications.uploads.confirm_delete', filename: uploaded_file.actual_file_file_name)}" }
+  #
+  #
+  # use the helper method like this:
+  #
+  # # NEW WAY WITH THE HELPER METHODS (GOOD)
+  # = link_to destroy_icon, remove_attachment_shf_application_path(shf_application.id,
+  #                             shf_application: { uploaded_files_attributes: { id: uploaded_file.id,  '_destroy' => true }}),
+  #                           method: :put, remote: true,
+  #                           id: "uploaded-file-#{uploaded_file.id}",
+  #                           class: "action-delete",
+  #                           data: { confirm: "#{t('shf_applications.uploads.confirm_delete', filename: uploaded_file.actual_file_file_name)}" }
+  #
+  #
+  #  @example:
+  #   assuming FA_COMPLETE_CHECK = 'check-circle'
+  #   for this entry:  { method_name_start: 'complete_check', icon: FA_COMPLETE_CHECK },
+  #
+  #   these methods are defined:
+  #
+  #      def complete_check_icon(html_options: {}, fa_style: FA_STYLE_DEFAULT, text: nil)
+  #         get_fa_icon(fa_style, FA_COMPLETE_CHECK, text, html_options)
+  #       end
+  #
+  #      def complete_check_fa_icon_name
+  #        "fa-check-circle"
+  #      end
+  #
+  #
+  #
+  #---------------------
+  #
+  # Try to keep these in the same order as the icon constant groups above.
+  #
   METHODS_AND_ICONS = [
+      { method_name_start: 'edit', icon: FA_EDIT },
+      { method_name_start: 'view', icon: FA_VIEW },
+      { method_name_start: 'destroy', icon: FA_DESTROY },
+
+
       { method_name_start: 'user_profile', icon: FA_USER_PROFILE },
       { method_name_start: 'user_account', icon: FA_USER_ACCOUNT },
-      { method_name_start: 'edit', icon: FA_EDIT },
+
+
       { method_name_start: 'external_link', icon: FA_EXTERNAL_LINK },
+      { method_name_start: 'complete_check', icon: FA_COMPLETE_CHECK },
+      { method_name_start: 'warning', icon: FA_WARNING },
+      { method_name_start: 'problem', icon: FA_PROBLEM },
+
+      { method_name_start: 'next_arrow', icon: FA_ARROW_RIGHT },
+      { method_name_start: 'previous_arrow', icon: FA_ARROW_LEFT },
+
+      { method_name_start: 'tooltip', icon: FA_TOOLTIP },
+
+      { method_name_start: 'blank', icon: FA_BLANK },
+
+
+      # arrows (These use the FontAwesome name to start the method names instead of a general action or common use)
+      { method_name_start: 'arrow_left', icon: FA_ARROW_LEFT },
+      { method_name_start: 'arrow_right', icon: FA_ARROW_RIGHT },
+      { method_name_start: 'arrow_up', icon: FA_ARROW_UP },
+      { method_name_start: 'arrow_down', icon: FA_ARROW_DOWN },
+      { method_name_start: 'arrow_circle_left', icon: FA_ARROW_CIRCLE_LEFT },
+      { method_name_start: 'arrow_circle_right', icon: FA_ARROW_CIRCLE_RIGHT },
+      { method_name_start: 'arrow_circle_up', icon: FA_ARROW_CIRCLE_UP },
+      { method_name_start: 'arrow_circle_down', icon: FA_ARROW_CIRCLE_DOWN },
+      { method_name_start: 'arrow_alt_circle_left', icon: FA_ARROW_ALT_CIRCLE_LEFT },
+      { method_name_start: 'arrow_alt_circle_right', icon: FA_ARROW_ALT_CIRCLE_RIGHT },
+      { method_name_start: 'arrow_alt_circle_up', icon: FA_ARROW_ALT_CIRCLE_UP },
+      { method_name_start: 'arrow_alt_circle_down', icon: FA_ARROW_ALT_CIRCLE_DOWN },
+      { method_name_start: 'long_arrow_alt_left', icon: FA_LONG_ARROW_ALT_LEFT },
+      { method_name_start: 'long_arrow_alt_right', icon: FA_LONG_ARROW_ALT_RIGHT },
+      { method_name_start: 'long_arrow_alt_up', icon: FA_LONG_ARROW_ALT_UP },
+      { method_name_start: 'long_arrow_alt_down', icon: FA_LONG_ARROW_ALT_DOWN },
+
   ]
 
+
+  # this method protects access to internals and also provides a way to test
+  def self.methods_and_icons
+    METHODS_AND_ICONS
+  end
+
+  def methods_and_icons
+    self.class.methods_and_icons
+  end
+
+
+  # -------------------------------------------------------------
+  # Define the helper methods for each entry in METHODS_AND_ICONS
+  #
   METHODS_AND_ICONS.each do |method_info|
 
-    module_eval <<-end_method, __FILE__, __LINE__ + 1
-      def #{method_info[:method_name_start]}_icon(fa_style = FA_STYLE_DEFAULT, text = nil, html_options = {})
+    # Define a helper method that returns the HTML for a FontAwesome icon.
+    # Can use this helper method in views instead of specifying the FontAwesome icon directly.
+    #
+    # The name of the method will start with method_info[:method_name_start]
+    # and the FontAwesome icon will be method_info[:icon]
+    #
+    # Parameters are the same as those accepted by the FontAwesome icon() method.
+    # All parameters are keywords and are all optional. ()All are passed on to the
+    #   FontAwesome icon() method.)
+    #   html_options:  [Hash] - HTML options to be applied to the icon.  Default = {}
+    #   fa_style: [String] - a specific FontAwesome style to use. Default = FA_STYLE_DEFAULT = 'fas'
+    #   text: [String] - any additional text to display.  Default = nil
+    #
+    module_eval <<-end_icon_method, __FILE__, __LINE__ + 1
+      def #{method_info[:method_name_start]}_icon(html_options: {}, fa_style: FA_STYLE_DEFAULT, text: nil)
         get_fa_icon(fa_style, '#{method_info[:icon]}', text, html_options)
       end
-    end_method
+    end_icon_method
 
+    # Define a helper method that will return the font awesome icon name [String].
+    # Ex:  blank_fa_icon_name
+    #   will return 'fa-blank'
+    module_eval <<-end_icon_name_method, __FILE__, __LINE__ + 1
+      def #{method_info[:method_name_start]}_fa_icon_name
+        "fa-#{method_info[:icon]}"
+      end
+    end_icon_name_method
   end
 
 

--- a/db/migrate/20200205213528_add_created_at_updated_at_to_addresses.rb
+++ b/db/migrate/20200205213528_add_created_at_updated_at_to_addresses.rb
@@ -1,0 +1,6 @@
+class AddCreatedAtUpdatedAtToAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :created_at, :timestamp
+    add_column :addresses, :updated_at, :timestamp
+  end
+end

--- a/spec/helpers/shf_icons_helper_spec.rb
+++ b/spec/helpers/shf_icons_helper_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+include ApplicationHelper
+
+
+RSpec.describe ShfIconsHelper, type: :helper do
+
+  describe 'for each entry in the list of {method starting names and the icons to use for each}' do
+
+    FA_EDIT = 'edit'
+    FA_DESTROY = 'trash'
+
+    METHODS_AND_ICONS_FOR_TESTING = [
+        { method_name_start: 'edit', icon: FA_EDIT },
+        { method_name_start: 'destroy', icon: FA_DESTROY },
+    ]
+
+    before(:each) do
+      allow(helper).to receive(:methods_and_icons).and_return(METHODS_AND_ICONS_FOR_TESTING)
+    end
+
+    describe 'defines a helper method the produces the HTML for the icon' do
+
+      it "full method name is '<method name start>_icon'" do
+        expect(helper.respond_to?('edit_icon')).to be_truthy
+        expect(helper.respond_to?('destroy_icon')).to be_truthy
+      end
+
+      it 'uses the icon specified in the entry' do
+        expect(helper.edit_icon).to match(/<i(.*)class="(.*) fa-edit"(.*)><\/i>/)
+        expect(helper.destroy_icon).to match(/<i(.*)class="(.*) fa-trash"(.*)><\/i>/)
+      end
+
+      it 'calls get_fa_icon to then produce the code via FontAwesome icon() method' do
+        expect(helper).to receive(:get_fa_icon)
+        helper.edit_icon
+      end
+
+
+      describe 'parameters' do
+
+        describe 'fa_style:' do
+
+          it "default is 'fas'" do
+            expect(helper.edit_icon).to match(/<i(.*)class="fas (.*)"(.*)><\/i>/)
+          end
+
+          it 'can specify the FontAwesome style to use' do
+            expect(helper.edit_icon(fa_style: 'far')).to match(/<i(.*)class="far (.*)"(.*)><\/i>/)
+          end
+        end
+
+
+        describe 'html_options:' do
+
+          it 'default is {}' do
+            expect(helper.edit_icon).to match(/<i(.*)class="fas (.*)"(.*)><\/i>/)
+          end
+
+          it 'can specify the html options to apply' do
+            expect(helper.edit_icon(html_options: {style: "margin: 15px; line-height: 1.5; text-align: center;"})).to match(/<i(.*)style="margin: 15px; line-height: 1.5; text-align: center;"(.*)><\/i>/)
+          end
+        end
+
+
+        describe 'text:' do
+
+          it 'default is nil (no text)' do
+            expect(helper.edit_icon).to match(/<i(.*)><\/i>/)
+          end
+
+          it 'can specify the text to display' do
+            expect(helper.edit_icon(text: 'blorfity blorf blorf blorf')).to match(/<i(.*)><\/i>(\s*)blorfity blorf blorf blorf/)
+          end
+        end
+      end
+    end
+
+
+    describe 'defines a helper method that returns the full name of the FontAwesome icon' do
+
+      it "full method name is '<method name start>_fa_icon_name'" do
+        expect(helper.respond_to?('edit_fa_icon_name')).to be_truthy
+        expect(helper.respond_to?('destroy_fa_icon_name')).to be_truthy
+      end
+
+      it 'returns the icon name' do
+        expect(helper.edit_fa_icon_name).to eq 'fa-edit'
+        expect(helper.destroy_fa_icon_name).to eq 'fa-trash'
+      end
+    end
+  end
+
+
+end
+
+


### PR DESCRIPTION
## PT Story: methods for standardized icons
#### PT URL: https://www.pivotaltracker.com/story/show/171134211


## Changes proposed in this pull request:
1.  added helper methods for:
   - view
   - destroy
   - complete_check
   - warning
   - problem
   - next_arrow
   - prev_arrow
   - tooltip  (also added a note - there is a method 'fas_toolip' in ApplicationHelper to use...)
   - FontAwesome arrows (method starts = the icon name)


2. documented!   Added examples to show how the helper methods look and how to use them

---
## Ready for review:
@patmbolger 
@Luleherll 
@pjbelo

