### PR TITLE
resize google map controls

### DIFF
--- a/app/assets/javascripts/google-maps.js
+++ b/app/assets/javascripts/google-maps.js
@@ -34,7 +34,10 @@ function initCenteredMap(centerCoordinates, markers, icon) {
 
     var map = new google.maps.Map(document.getElementById('map'), {
         center: mapCenter,
-        zoom: 13
+        zoom: 13,
+        mapTypeControl: false,
+        streetViewControl: false,
+        controlSize: 26 // Size (in pixels) of map control buttons       
     });
 
     var bounds = new google.maps.LatLngBounds();


### PR DESCRIPTION
## PT Story: NewLook: +1 zoom on the map
#### PT URL: https://www.pivotaltracker.com/story/show/164818457

## Changes proposed in this pull request:
1. Hide any control? To test, I've hidden mapTypeControl and streetViewControl
2. Resize controls. Controls size were set to 26 pixels. Please see if this size is appropriate.


---
## Ready for review:
@weedySeaDragon, @thesuss, @patmbolger 
