### PR TITLE
fix rspec test:  order of alert writing to log file about 2 users

### DIFF
--- a/spec/models/conditions_response/membership_expire_alert_spec.rb
+++ b/spec/models/conditions_response/membership_expire_alert_spec.rb
@@ -220,7 +220,8 @@ RSpec.describe MembershipExpireAlert do
           expect(ActionMailer::Base.deliveries.size).to eq 2
 
           logfile_contents = File.read(logfilepath)
-          expect(logfile_contents).to match(/\[info\] Started at #{dec_1_ts.to_s}(\s*)(.*)#{paid_exp_dec30_logmsg}(\s*)(.*)#{paid_expires_dec2_logmsg}/)
+          expect(logfile_contents).to match(/\[info\] Started at #{dec_1_ts.to_s}(\s*)(.*)#{paid_exp_dec30_logmsg}/m)
+          expect(logfile_contents).to match(/\[info\] Started at #{dec_1_ts.to_s}(\s*)(.*)#{paid_expires_dec2_logmsg}/m)
         end
       end
 


### PR DESCRIPTION
## PT Story: fix rspec test:  order of alert writing to log file about 2 users
#### PT URL:https://www.pivotaltracker.com/story/show/171063839


## Changes proposed in this pull request:
1. user 2 separate Regexps instead of 1 long one

---
## Ready for review:
@patmbolger @pjbelo 
