### PR TITLE
add color, fa_style, html_options to standardized icons

### DIFF
--- a/app/helpers/shf_icons_helper.rb
+++ b/app/helpers/shf_icons_helper.rb
@@ -75,7 +75,7 @@ module ShfIconsHelper
   # Standard actions: edit, view, destroy, etc.,  icons:
   FA_EDIT = 'edit'
   FA_VIEW = 'eye'
-  FA_DESTROY = 'trash'
+  FA_DESTROY = 'trash-alt'
 
 
   # Icons for specific pages/views:

--- a/app/helpers/shf_icons_helper.rb
+++ b/app/helpers/shf_icons_helper.rb
@@ -1,10 +1,11 @@
-# Standardized icon helper methods and  names to use in this application.
+# Standardized icon styles, helper methods, and names to use in this application.
 #
 # This defines (creates) helper methods for using FontAwesome icons in the application.
-#  - itt defines a standard method for using an icon (ex: 'edit_icon'), and
+#  - it defines a standard method for using an icon (ex: 'edit_icon'),
+#  - it defines the standard look (FontAwesome style, color and other html_options), and
 #  - it defines a standard method for getting the [String] name of the icon (ex: 'edit_icon_fa_name')
 #
-# This defines exactly which FontAwesome icons are used.
+# This defines exactly which FontAwesome icons are used and how they look
 #
 # ** You should ALWAYS USE THE HELPER METHODs instead of using the constants here
 #    or specifying the FontAwesome icon yourself. **
@@ -60,6 +61,16 @@
 # NOTE about tooltips:
 #   There is a specific helper method 'fas_tooltip(...) that can also be used.
 #   It is defined in application_helper.rb.
+#
+#
+# @example:
+#   to display the view icon with a specific color:
+#     view_icon(html_options: {style: "color: #123123;"})
+#
+#
+# @example:
+#   to add a class to the view icon:
+#     view_icon(html_options: {class: 'flurb'})
 #
 #
 # See the documentation below for more details.
@@ -216,9 +227,19 @@ module ShfIconsHelper
   # Try to keep these in the same order as the icon constant groups above.
   #
   METHODS_AND_ICONS = [
-      { method_name_start: 'edit', icon: FA_EDIT },
-      { method_name_start: 'view', icon: FA_VIEW },
-      { method_name_start: 'destroy', icon: FA_DESTROY },
+      { method_name_start: 'edit', icon: FA_EDIT,
+        html_options:{ class: 'edit'} },
+
+      { method_name_start: 'view', icon: FA_VIEW,
+        color: 'blue',
+        fa_style: 'far',
+        html_options:{ class: 'view'}},
+
+      { method_name_start: 'destroy', icon: FA_DESTROY,
+        color: 'red',
+        fa_style: 'far',
+        html_options:{ class: 'delete'}
+      },
 
 
       { method_name_start: 'user_profile', icon: FA_USER_PROFILE },
@@ -287,9 +308,32 @@ module ShfIconsHelper
     #   fa_style: [String] - a specific FontAwesome style to use. Default = FA_STYLE_DEFAULT = 'fas'
     #   text: [String] - any additional text to display.  Default = nil
     #
+
+    icon_fa_style = method_info.fetch(:fa_style, FA_STYLE_DEFAULT)
+    icon_html_options = method_info.fetch(:html_options, {})
+    icon_color = method_info.fetch(:color, false)
+
+    # if there is a color defined, create the string to use in the style key
+    #  Note this will overwrite any 'color: zzz' in the style:  string  defined in html_options
+    if icon_color
+      # replace any color defined in the html_options
+      if icon_html_options.has_key?(:style)
+        icon_html_options[:style].gsub!(/color:(.*[^;])/, "color: #{icon_color}")
+      else
+        icon_html_options[:style] = "color: #{icon_color};"
+      end
+    end
+
+
     module_eval <<-end_icon_method, __FILE__, __LINE__ + 1
-      def #{method_info[:method_name_start]}_icon(html_options: {}, fa_style: FA_STYLE_DEFAULT, text: nil)
-        get_fa_icon(fa_style, '#{method_info[:icon]}', text, html_options)
+      def #{method_info[:method_name_start]}_icon(html_options: #{icon_html_options},
+                       fa_style: '#{icon_fa_style}',
+                       text: nil)
+      
+        default_html_options = #{icon_html_options}
+        merged_html_options = default_html_options.merge(html_options)
+
+        get_fa_icon(fa_style, '#{method_info[:icon]}', text, merged_html_options)
       end
     end_icon_method
 

--- a/app/helpers/shf_icons_helper.rb
+++ b/app/helpers/shf_icons_helper.rb
@@ -101,9 +101,9 @@ module ShfIconsHelper
   FA_WARNING = 'exclamation-triangle'
   FA_PROBLEM = 'times-circle'
 
-  FA_TOOLTIP = 'info-circle'  # Note that there is a specific helper method 'fas_tooltip(...) that can be used (Defined in application_helper.rb)
+  FA_TOOLTIP = 'info-circle' # Note that there is a specific helper method 'fas_tooltip(...) that can be used (Defined in application_helper.rb)
 
-  FA_BLANK = 'blank'  # placeholder
+  FA_BLANK = 'blank' # placeholder
 
 
   # arrows
@@ -227,18 +227,16 @@ module ShfIconsHelper
   # Try to keep these in the same order as the icon constant groups above.
   #
   METHODS_AND_ICONS = [
-      { method_name_start: 'edit', icon: FA_EDIT,
-        html_options:{ class: 'edit'} },
+      { method_name_start: 'edit', icon: FA_EDIT },
 
       { method_name_start: 'view', icon: FA_VIEW,
         color: 'blue',
-        fa_style: 'far',
-        html_options:{ class: 'view'}},
+        fa_style: 'far'
+      },
 
       { method_name_start: 'destroy', icon: FA_DESTROY,
         color: 'red',
-        fa_style: 'far',
-        html_options:{ class: 'delete'}
+        fa_style: 'far'
       },
 
 
@@ -284,6 +282,7 @@ module ShfIconsHelper
   def self.methods_and_icons
     METHODS_AND_ICONS
   end
+
 
   def methods_and_icons
     self.class.methods_and_icons

--- a/spec/helpers/shf_icons_helper_spec.rb
+++ b/spec/helpers/shf_icons_helper_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe ShfIconsHelper, type: :helper do
 
     METHODS_AND_ICONS_FOR_TESTING = [
         { method_name_start: 'edit', icon: FA_EDIT },
-        { method_name_start: 'destroy', icon: FA_DESTROY },
+        { method_name_start: 'edit_far', icon: FA_EDIT, fa_style: 'far' },
+        { method_name_start: 'destroy', icon: FA_DESTROY, html_options: { style: "color: red;" } },
     ]
 
     before(:each) do
@@ -26,9 +27,28 @@ RSpec.describe ShfIconsHelper, type: :helper do
       end
 
       it 'uses the icon specified in the entry' do
-        expect(helper.edit_icon).to match(/<i(.*)class="(.*) fa-edit"(.*)><\/i>/)
-        expect(helper.destroy_icon).to match(/<i(.*)class="(.*) fa-trash"(.*)><\/i>/)
+        expect(helper.edit_icon).to match(/<i(.)*class="(.*) fa-edit(.*)"><\/i>/)
+        expect(helper.destroy_icon).to match(/<i(.*)class="(.*) fa-trash(.*)"><\/i>/)
       end
+
+
+      describe 'uses fa_style: in the entry, else uses FA_STYLE_DEFAULT' do
+
+        it 'defaults to FA_STYLE_DEFAULT' do
+          allow(helper).to receive(:methods_and_icons).and_return(METHODS_AND_ICONS_FOR_TESTING)
+
+          edit_icon_html = helper.edit_icon
+          expect(edit_icon_html).to match(/<i(.*)class="#{described_class::FA_STYLE_DEFAULT} (.*)"(.*)><\/i>/)
+          expect(edit_icon_html).not_to include('class="far" ')
+        end
+
+        it "fa_style: 'far' is set for the entry" do
+          destroy_icon_html = helper.destroy_icon
+          puts "destroy_icon_html: #{destroy_icon_html}"
+          expect(destroy_icon_html).to match(/<i(.*)class="far (.*)"(.*)><\/i>/)
+        end
+      end
+
 
       it 'calls get_fa_icon to then produce the code via FontAwesome icon() method' do
         expect(helper).to receive(:get_fa_icon)
@@ -37,6 +57,7 @@ RSpec.describe ShfIconsHelper, type: :helper do
 
 
       describe 'parameters' do
+
 
         describe 'fa_style:' do
 
@@ -50,15 +71,33 @@ RSpec.describe ShfIconsHelper, type: :helper do
         end
 
 
-        describe 'html_options:' do
+        describe 'html_options: are merged in' do
 
           it 'default is {}' do
             expect(helper.edit_icon).to match(/<i(.*)class="fas (.*)"(.*)><\/i>/)
           end
 
-          it 'can specify the html options to apply' do
-            expect(helper.edit_icon(html_options: {style: "margin: 15px; line-height: 1.5; text-align: center;"})).to match(/<i(.*)style="margin: 15px; line-height: 1.5; text-align: center;"(.*)><\/i>/)
+          describe 'can specify the html options to apply' do
+
+            it 'class: "blorf"' do
+              edit_icon_result = helper.edit_icon(html_options: { class: 'blorf' })
+              expect(edit_icon_result).to match(/<i(.*)class="(.*)blorf(.*)"(.*)><\/i>/)
+            end
+
+            it 'style: "color: #123123;' do
+              edit_icon_result = helper.edit_icon(html_options: { style: "color: #123123;" })
+              expect(edit_icon_result).to match(/<i(.*)style="(.*)color: #123123;(.*)"(.*)><\/i>/)
+            end
+
+            it 'style: .. margin, etc, class: "flurb"' do
+              edit_icon_result = helper.edit_icon(html_options: { class: 'flurb', style: "margin: 15px; line-height: 1.5; text-align: center;" })
+              expect(edit_icon_result).to match(/<i(.*)style="margin: 15px; line-height: 1.5; text-align: center;"(.*)><\/i>/)
+              expect(edit_icon_result).to match(/<i(.*)class="(.*)flurb(.*)"(.*)><\/i>/)
+            end
+
           end
+
+
         end
 
 
@@ -84,8 +123,8 @@ RSpec.describe ShfIconsHelper, type: :helper do
       end
 
       it 'returns the icon name' do
-        expect(helper.edit_fa_icon_name).to eq 'fa-edit'
-        expect(helper.destroy_fa_icon_name).to eq 'fa-trash'
+        expect(helper.edit_fa_icon_name).to eq "fa-#{described_class::FA_EDIT}"
+        expect(helper.destroy_fa_icon_name).to eq "fa-#{described_class::FA_DESTROY}"
       end
     end
   end

--- a/spec/helpers/shf_icons_helper_spec.rb
+++ b/spec/helpers/shf_icons_helper_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe ShfIconsHelper, type: :helper do
 
         it "fa_style: 'far' is set for the entry" do
           destroy_icon_html = helper.destroy_icon
-          puts "destroy_icon_html: #{destroy_icon_html}"
           expect(destroy_icon_html).to match(/<i(.*)class="far (.*)"(.*)><\/i>/)
         end
       end


### PR DESCRIPTION
## PT Story:  add color, fa_style, html_options to standardized icons
#### PT URL: https://www.pivotaltracker.com/story/show/171294248


## Changes proposed in this pull request:
1. can now set the color, fa_style, and html_options when an icon method is defined
1.  changed destroy icon defaults (red, trash-alt, class: 'delete')
2.  changed view icon defaults( blue, class: 'view)
3.  changed edit icon defaults( class: 'edit')
4. added examples to show how to also override class, color when helper_method is called

---
## Ready for review:
@patmbolger 
