### PR TITLE
Admin dashboard:  export payments, payments that apply to a given year

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,9 @@ gem 'sitemap_generator'
 
 gem 'whenever', require: false
 
+# Query ActiveRecord by time (ex:  Payment.by_year(2019), Payment.between_times(Time.zone.now - 3.hours, Time.zone.now)) # all posts in last 3 hours
+gem 'by_star'
+
 group :development, :test do
   gem 'rspec-rails'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,8 @@ GEM
     bullet (5.9.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    by_star (3.0.0)
+      activesupport (> 3)
     byebug (11.0.1)
     capistrano (3.11.0)
       airbrussh (>= 1.0.0)
@@ -605,6 +607,7 @@ DEPENDENCIES
   bootstrap-toggle-rails
   bootstrap-will_paginate
   bullet
+  by_star
   capistrano (~> 3.11)
   capistrano-bundler (~> 1.1.2)
   capistrano-env-config

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -47,6 +47,12 @@ $tab-active-background-color: rgba(85, 145, 206, 0.2);
 
 .dashboard {
 
+  .instructions {
+    font-size: smaller;
+    font-style: italic;
+  }
+
+
   .section {
     margin: 0 0 1.5em 3em;
     min-height: 300px;
@@ -122,6 +128,14 @@ $tab-active-background-color: rgba(85, 145, 206, 0.2);
         }
       }
 
+    }
+  }
+
+
+  .payments {
+
+    .row {
+      margin-top: 1rem;
     }
   }
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -185,7 +185,7 @@ class AdminController < AdminOnlyController
   def create_header_str(header_entries)
     out_str = '' # is this stmt needed?
 
-    out_str << header_entries.map { |header_str| "#{header_str.strip}" }.join(',')
+    out_str << header_entries.map { |header_str| "'#{header_str.strip}'" }.join(',')
 
     out_str << "\n"
   end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,5 +1,8 @@
 class AdminController < AdminOnlyController
 
+  # FIXME - this is really an exporter!
+  # FIXME - DRY
+
 
   # export shf_appplications
   def export_ansokan_csv
@@ -9,7 +12,7 @@ class AdminController < AdminOnlyController
 
       export_name = "Ansokningar-#{Time.zone.now.strftime('%Y-%m-%d--%H-%M-%S')}.csv"
 
-      send_data(export_str(@shf_applications), filename: export_name, type: "text/plain")
+      send_data(export_shf_apps_str(@shf_applications), filename: export_name, type: "text/plain")
 
       helpers.flash_message(:notice, t('.success'))
 
@@ -23,7 +26,57 @@ class AdminController < AdminOnlyController
   end
 
 
+  def export_payments_csv
+    payments = Payment.includes(:user).includes(:company).all
+    export_name = "betalningar-#{Time.zone.now.strftime('%Y-%m-%d--%H-%M-%S')}.csv"
+    file_contents = items_export_str(payments, Adapters::PaymentToCsvAdapter, export_payments_header_str)
+
+    export_file(file_contents, export_name, success_msg: t('.success'), error_msg: t('.error'))
+  end
+
+
+  def export_payments_covering_year_csv
+
+    year = params[:year].to_i
+    # FIXME - check params.  error if year is missing
+
+    payments = Payment.includes(:user).includes(:company).covering_year(year.to_i)
+    payments_for_year = payments.map { |payment| PaymentCoveringYear.new(payment: payment, year: year) }
+
+    export_name = "betalningar-for-#{year}--#{Time.zone.now.strftime('%Y-%m-%d--%H-%M-%S')}.csv"
+    file_contents = items_export_str(payments_for_year, Adapters::PaymentCoveringYearToCsvAdapter,
+                                     export_payments_covering_year_header_str(year))
+
+    export_file(file_contents, export_name, success_msg: t('.success'), error_msg: t('.error'))
+  end
+
+
   private
+
+  def export_file(file_contents_str, export_filename,
+                  success_msg: 'Success!', error_msg: 'Error: something went wrong with the export.')
+    begin
+      send_data(file_contents_str,
+                filename: export_filename, type: "text/plain")
+
+      helpers.flash_message(:notice, success_msg)
+
+    rescue => e
+      helpers.flash_message(:alert, error_msg)
+      redirect_to(request.referer.present? ? :back : root_path)
+    end
+
+  end
+
+
+  def items_export_str(items = [], csv_adapter_class = nil, header_str = '')
+    out_str = header_str
+    items.each do |item|
+      out_str << csv_adapter_class.new(item).as_target.to_s unless csv_adapter_class.nil?
+      out_str << "\n"
+    end
+    out_str.encode('UTF-8')
+  end
 
 
   # Create a comma separated string for all applications, each application is 1 row
@@ -35,9 +88,9 @@ class AdminController < AdminOnlyController
   # @return [String] - the Comma Separated Values (CSV) list, with a header and 1
   #    row of information for each application
   #
-  def export_str(shf_apps)
+  def export_shf_apps_str(shf_apps)
 
-    out_str = export_header_str
+    out_str = export_shf_apps_header_str
 
     shf_apps.each do |shf_app|
       out_str << Adapters::ShfApplicationToCsvAdapter.new(shf_app).as_target.to_s
@@ -48,37 +101,92 @@ class AdminController < AdminOnlyController
   end
 
 
-  # build the CSV export header string from strings in the locale file(s)
-  def export_header_str
+  # FIXME - these headers should belong to the Adapters
 
-    header_member_strs = [t('activerecord.attributes.shf_application.contact_email'),
-                          t('activerecord.attributes.user.email'),
-                          t('activerecord.attributes.shf_application.first_name'),
-                          t('activerecord.attributes.shf_application.last_name'),
-                          t('activerecord.attributes.user.membership_number'),
-                          t('activerecord.attributes.user.date_member_packet_sent'),
-                          t('activerecord.attributes.shf_application.state'),
-                          t('admin.export_ansokan_csv.date_state_changed'),
-                          t('activerecord.models.business_category.other'),
-                          t('activerecord.models.company.one'),
-                          t('admin.export_ansokan_csv.member_fee_paid'),
-                          t('admin.export_ansokan_csv.member_fee_expires'),
-                          t('admin.export_ansokan_csv.branding_fee_paid'),
-                          t('admin.export_ansokan_csv.branding_fee_expires'),
-                          t('activerecord.attributes.address.street'),
-                          t('activerecord.attributes.address.post_code'),
-                          t('activerecord.attributes.address.city'),
-                          t('activerecord.attributes.address.kommun'),
-                          t('activerecord.attributes.address.region'),
-                          t('activerecord.attributes.address.country'),
+  # build the CSV export ShfApplications header string from strings in the locale file(s)
+  def export_shf_apps_header_str
+
+    header_strs = [t('activerecord.attributes.shf_application.contact_email'),
+                   t('activerecord.attributes.user.email'),
+                   t('activerecord.attributes.shf_application.first_name'),
+                   t('activerecord.attributes.shf_application.last_name'),
+                   t('activerecord.attributes.user.membership_number'),
+                   t('activerecord.attributes.user.date_member_packet_sent'),
+                   t('activerecord.attributes.shf_application.state'),
+                   t('admin.export_ansokan_csv.date_state_changed'),
+                   t('activerecord.models.business_category.other'),
+                   t('activerecord.models.company.one'),
+                   t('admin.export_ansokan_csv.member_fee_paid'),
+                   t('admin.export_ansokan_csv.member_fee_expires'),
+                   t('admin.export_ansokan_csv.branding_fee_paid'),
+                   t('admin.export_ansokan_csv.branding_fee_expires'),
+                   t('activerecord.attributes.address.street'),
+                   t('activerecord.attributes.address.post_code'),
+                   t('activerecord.attributes.address.city'),
+                   t('activerecord.attributes.address.kommun'),
+                   t('activerecord.attributes.address.region'),
+                   t('activerecord.attributes.address.country'),
     ]
-
-    out_str = ''
-
-    out_str << header_member_strs.map { |header_str| "'#{header_str.strip}'" }.join(',')
-
-    out_str << "\n"
-
+    create_header_str(header_strs)
   end
 
+
+  # build the CSV export Payments header string from strings in the locale file(s)
+  def export_payments_header_str
+    payment_attribs = 'activerecord.attributes.payment'
+
+    header_strs = ['id',
+                   t('name'),
+                   'E-post',
+                   'SEK',
+                   'Org.',
+                   t('org_nr'),
+                   t('payment_type', scope: payment_attribs),
+                   t('start_date', scope: payment_attribs),
+                   t('expire_date', scope: payment_attribs),
+                   t('created', scope: payment_attribs),
+                   t('status', scope: payment_attribs),
+                   'HIPS id',
+                   t('notes', scope: payment_attribs)
+    ]
+    create_header_str(header_strs)
+  end
+
+
+  def export_payments_covering_year_header_str(year)
+    payment_attribs = 'activerecord.attributes.payment'
+
+    header_strs = ['id',
+                   t('name'),
+                   'E-post',
+
+                   t('payment_type', scope: payment_attribs),
+                   'total payment',
+
+                   'Term ' + t('start_date', scope: payment_attribs),
+                   'Term ' + t('expire_date', scope: payment_attribs),
+                   'total # days paid',
+
+                   'SEK / dag',
+                   "# days #{year} paid for",
+                   "SEK paid in #{year}",
+
+                   'Pay. date',
+                   'Org.',
+                   t('org_nr'),
+                   t('status', scope: payment_attribs),
+                   'HIPS id',
+                   t('notes', scope: payment_attribs)
+    ]
+    create_header_str(header_strs)
+  end
+
+
+  def create_header_str(header_entries)
+    out_str = '' # is this stmt needed?
+
+    out_str << header_entries.map { |header_str| "#{header_str.strip}" }.join(',')
+
+    out_str << "\n"
+  end
 end

--- a/app/controllers/admin_only/dashboard_controller.rb
+++ b/app/controllers/admin_only/dashboard_controller.rb
@@ -12,6 +12,22 @@ module AdminOnly
 
 
     def index
+
+      @payments_search = Payment.ransack(params[:q])
+      @payments = @payments_search.result
+
+      render partial: 'payments', locals: { payments_search: @payments_search,
+                                            payments: @payments } if request.xhr?
+
+    end
+
+    def payments
+      @payments_search = Payment.ransack(params[:q])
+      @payments = @payments_search.result
+
+      render partial: 'payments', locals: { payments_search: @payments_search,
+                                            payments: @payments } if request.xhr?
+
     end
 
 

--- a/app/models/adapters/abstract_adapter.rb
+++ b/app/models/adapters/abstract_adapter.rb
@@ -60,6 +60,11 @@ module Adapters
     end
 
 
+    # surround the item with double quotes ("")
+    def quote(item)
+      "\"#{item}\""
+    end
+
   end
 
 end

--- a/app/models/adapters/abstract_adapter.rb
+++ b/app/models/adapters/abstract_adapter.rb
@@ -59,12 +59,6 @@ module Adapters
       raise NoMethodError, "subclasses must implement #{__method__}"
     end
 
-
-    # surround the item with double quotes ("")
-    def quote(item)
-      "\"#{item}\""
-    end
-
   end
 
 end

--- a/app/models/adapters/abstract_csv_adapter.rb
+++ b/app/models/adapters/abstract_csv_adapter.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/ruby
+
+module Adapters
+
+  #--------------------------
+  #
+  # @class AbstractCsvAdapter
+  #
+  # @desc Responsibility: Common behavior and info for adapting an object to a CSV representation.
+  #  "CSV" = comma separated value text
+  #
+  #
+  # @author Ashley Engelund (ashley.engelund@gmail.com  weedySeaDragon @ github)
+  # @date   2020-02-20
+  #
+  #
+  #--------------------------
+  class AbstractCsvAdapter < AbstractAdapter
+
+
+    def target_class
+      CsvRow
+    end
+
+
+    # surround the item with double quotes ("")
+    def quote(item)
+      "\"#{item}\""
+    end
+
+
+    # subclasses should override and do whatever they need to do with the @adaptee to
+    # produce a CSV representation.
+    #
+    def set_target_attributes(target)
+      target
+    end
+
+
+    # Subclasses should override this and produce a string that can be used
+    # as a header row in a CSV file.
+    #
+    # @return [String] - a string of comma separated headers.
+    #
+    def self.header_str(*args)
+      create_header_str(headers(args))
+    end
+
+
+    def self.headers(*args)
+      []
+    end
+
+
+    # ==================================================================================
+
+    protected
+
+    def self.create_header_str(header_entries)
+      out_str = '' # is this stmt needed?
+
+      out_str << header_entries.map { |header_str| "'#{header_str.strip}'" }.join(',')
+
+      out_str << "\n"
+    end
+
+  end
+
+end

--- a/app/models/adapters/payment_covering_year_to_csv_adapter.rb
+++ b/app/models/adapters/payment_covering_year_to_csv_adapter.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/ruby
+
+module Adapters
+
+  #--------------------------
+  #
+  # @class PaymentCoveringYearToCsvAdapter
+  #
+  # @desc Responsibility: Takes a Payment and creates (adapts it to) CSV including
+  #  information about what part (percent) of the year it covers.
+  #
+  #
+  # @author Ashley Engelund (ashley.engelund@gmail.com  weedySeaDragon @ github)
+  # @date   2020-02-20
+  #
+  #
+  #--------------------------
+  class PaymentCoveringYearToCsvAdapter < AbstractAdapter
+
+
+    def target_class
+      CsvRow
+    end
+
+
+    def set_target_attributes(target)
+      co_name = ''
+      co_num = ''
+      amount = 0
+
+      payment_covering_year = @adaptee
+      payment = @adaptee.payment
+
+      target << payment.id
+      target << quote(payment.user.full_name)
+      target << payment.user.email
+
+      if payment.payment_type == Payment::PAYMENT_TYPE_BRANDING
+        co_name = payment.company.name
+        co_num = payment.company.company_number
+        amount = SHF_BRANDING_FEE / 100
+      else
+        amount = SHF_MEMBER_FEE / 100
+      end
+
+      target << payment.payment_type
+
+      target << amount
+      target << quote(payment.start_date)
+      target << quote(payment.expire_date)
+
+      target << payment_covering_year.total_number_of_days_paid
+      target << payment_covering_year.sek_per_day
+
+      target << payment_covering_year.num_days_of_year_covered
+      target << payment_covering_year.days_paid_for_year
+
+      target << quote(payment.created_at.strftime('%F'))
+
+      target << quote(co_name)
+      target << co_num
+
+      target << payment.status
+      target << payment.hips_id
+
+      target << quote(payment.notes)
+
+      target
+    end
+
+
+  end
+
+end

--- a/app/models/adapters/payment_covering_year_to_csv_adapter.rb
+++ b/app/models/adapters/payment_covering_year_to_csv_adapter.rb
@@ -15,12 +15,10 @@ module Adapters
   #
   #
   #--------------------------
-  class PaymentCoveringYearToCsvAdapter < AbstractAdapter
+  class PaymentCoveringYearToCsvAdapter < AbstractCsvAdapter
 
 
-    def target_class
-      CsvRow
-    end
+    I18N_PAYMENT_ATTRIBS = 'activerecord.attributes.payment'.freeze
 
 
     def set_target_attributes(target)
@@ -34,6 +32,7 @@ module Adapters
       target << payment.id
       target << quote(payment.user.full_name)
       target << payment.user.email
+      target << payment.user.membership_number
 
       if payment.payment_type == Payment::PAYMENT_TYPE_BRANDING
         co_name = payment.company.name
@@ -66,6 +65,35 @@ module Adapters
       target << quote(payment.notes)
 
       target
+    end
+
+
+    # @return [Array<String] - a list of the header strings
+    #
+    def self.headers(year)
+
+      ["#{I18n.t('activerecord.models.payment.one')} db id",
+       I18n.t('name'),
+       'E-post',
+       I18n.t('activerecord.attributes.user.membership_number'),
+       I18n.t('payment_type', scope: I18N_PAYMENT_ATTRIBS),
+       'total payment',
+
+       'Term ' + I18n.t('start_date', scope: I18N_PAYMENT_ATTRIBS),
+       'Term ' + I18n.t('expire_date', scope: I18N_PAYMENT_ATTRIBS),
+       'total # days paid',
+
+       'SEK / dag',
+       "# days #{year} paid for",
+       "SEK paid in #{year}",
+
+       'Pay. date',
+       'Org.',
+       I18n.t('org_nr'),
+       I18n.t('status', scope: I18N_PAYMENT_ATTRIBS),
+       'HIPS id',
+       I18n.t('notes', scope: I18N_PAYMENT_ATTRIBS)
+      ]
     end
 
 

--- a/app/models/adapters/payment_to_csv_adapter.rb
+++ b/app/models/adapters/payment_to_csv_adapter.rb
@@ -1,0 +1,66 @@
+#!/usr/bin/ruby
+
+module Adapters
+
+  #--------------------------
+  #
+  # @class PaymentToCsvAdapter
+  #
+  # @desc Responsibility: Takes a Payment and creates (adapts it to) CSV
+  #
+  #
+  # @author Ashley Engelund (ashley.engelund@gmail.com  weedySeaDragon @ github)
+  # @date   2020-02-20
+  #
+  #
+  #--------------------------
+  class PaymentToCsvAdapter < AbstractAdapter
+
+
+    def target_class
+      CsvRow
+    end
+
+
+    def set_target_attributes(target)
+      co_name = ''
+      co_num = ''
+      amount = 0
+
+      payment = @adaptee
+      target << payment.id
+      target << quote(payment.user.full_name)
+      target << payment.user.email
+
+      if payment.payment_type == Payment::PAYMENT_TYPE_BRANDING
+        co_name = payment.company.name
+        co_num = payment.company.company_number
+        amount = SHF_BRANDING_FEE / 100
+      else
+        amount = SHF_MEMBER_FEE / 100
+      end
+
+      target << amount
+
+      target << quote(co_name)
+      target << co_num
+
+      target << payment.payment_type
+
+      target << quote(payment.start_date)
+      target << quote(payment.expire_date)
+
+      target << quote(payment.created_at.strftime('%F'))
+
+      target << payment.status
+      target << payment.hips_id
+
+      target << quote(payment.notes)
+
+      target
+    end
+
+
+  end
+
+end

--- a/app/models/adapters/payment_to_csv_adapter.rb
+++ b/app/models/adapters/payment_to_csv_adapter.rb
@@ -14,12 +14,9 @@ module Adapters
   #
   #
   #--------------------------
-  class PaymentToCsvAdapter < AbstractAdapter
+  class PaymentToCsvAdapter < AbstractCsvAdapter
 
-
-    def target_class
-      CsvRow
-    end
+    I18N_PAYMENT_ATTRIBS = 'activerecord.attributes.payment'.freeze
 
 
     def set_target_attributes(target)
@@ -28,9 +25,13 @@ module Adapters
       amount = 0
 
       payment = @adaptee
+
       target << payment.id
       target << quote(payment.user.full_name)
       target << payment.user.email
+      target << payment.user.membership_number
+
+      target << payment.payment_type
 
       if payment.payment_type == Payment::PAYMENT_TYPE_BRANDING
         co_name = payment.company.name
@@ -42,15 +43,13 @@ module Adapters
 
       target << amount
 
-      target << quote(co_name)
-      target << co_num
-
-      target << payment.payment_type
-
       target << quote(payment.start_date)
       target << quote(payment.expire_date)
 
       target << quote(payment.created_at.strftime('%F'))
+
+      target << quote(co_name)
+      target << co_num
 
       target << payment.status
       target << payment.hips_id
@@ -60,6 +59,27 @@ module Adapters
       target
     end
 
+
+    def self.headers(*args)
+
+      ["#{I18n.t('activerecord.models.payment.one')} db id",
+       I18n.t('name'),
+       'E-post',
+       I18n.t('activerecord.attributes.user.membership_number'),
+       I18n.t('payment_type', scope: I18N_PAYMENT_ATTRIBS),
+       'SEK',
+
+       'Term ' + I18n.t('start_date', scope: I18N_PAYMENT_ATTRIBS),
+       'Term ' + I18n.t('expire_date', scope: I18N_PAYMENT_ATTRIBS),
+
+       'Pay. date',
+       'Org.',
+       I18n.t('org_nr'),
+       I18n.t('status', scope: I18N_PAYMENT_ATTRIBS),
+       'HIPS id',
+       I18n.t('notes', scope: I18N_PAYMENT_ATTRIBS)
+      ]
+    end
 
   end
 

--- a/app/models/adapters/shf_application_to_csv_adapter.rb
+++ b/app/models/adapters/shf_application_to_csv_adapter.rb
@@ -109,11 +109,6 @@ module Adapters
     end
 
 
-    # surround the item with double quotes ("")
-    def quote(item)
-      "\"#{item}\""
-    end
-
   end # ShfApplicationToCsvAdapter
 
 

--- a/app/models/adapters/shf_application_to_csv_adapter.rb
+++ b/app/models/adapters/shf_application_to_csv_adapter.rb
@@ -109,6 +109,11 @@ module Adapters
     end
 
 
+    # surround the item with double quotes ("")
+    def quote(item)
+      "\"#{item}\""
+    end
+
   end # ShfApplicationToCsvAdapter
 
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -75,6 +75,22 @@ class Payment < ApplicationRecord
   end
 
 
+  # Return all Payments that cover any days in the given year
+  # (used to help determine the total amount of money for all of the days in a given year)
+  #
+  # all payments that start in the given year OR
+  # all payments that expire in the given year OR
+  # (all payments that start_date < given year AND expire_date > given year)  (ex: the payment covered 3 years, including the given year)
+  # This uses the by_star gem for the scopes (ex: by_year(), before(), after() )
+  def self.covering_year(year)
+    year_start = DateTime.new(year,1,1)
+    year_end = year_start.end_of_year
+
+    by_year(year, field: :start_date).
+        or(by_year(year, field: :expire_date)).
+        or(before(year_start, field: :start_date).after(year_end, field: :expire_date)).distinct
+  end
+
   # The transaction was successful.  The transaction might depend on an external system (e.g. HIPS).
   # This method is called so we can do whatever it is we need to do
   # (e.g. set the status, notify observers, etc.).

--- a/app/models/payment_covering_year.rb
+++ b/app/models/payment_covering_year.rb
@@ -1,0 +1,83 @@
+#--------------------------
+#
+# @class PaymentCoveringYear
+#
+# @desc Responsibility: Simple class that calculates how many days of a year a payment covered.
+#  It has a payment and a year, and can do the simple calculations.
+#
+#
+# @author Ashley Engelund (ashley.engelund@gmail.com  weedySeaDragon @ github)
+# @date   2/20/20
+#
+#--------------------------
+
+
+class PaymentCoveringYear
+
+  attr_accessor :year, :payment
+
+  ROUND_PREC = 2
+
+
+  def initialize(payment: payment, year: year)
+    @payment = payment
+    @year = year
+  end
+
+
+  # the amount is in 100s of SEK (so divide by 100)
+  def payment_amount
+    (payment.payment_type == Payment::PAYMENT_TYPE_MEMBER ? SHF_MEMBER_FEE : SHF_BRANDING_FEE) / 100
+  end
+
+
+  def days_paid_for_year
+    (sek_per_day * num_days_of_year_covered).round(ROUND_PREC)
+  end
+
+
+  def sek_per_day
+    payment_amount.fdiv(total_number_of_days_paid).round(ROUND_PREC)
+  end
+
+
+  def percent_of_year_covered
+    return 100 if payment_covers_more_than_year?
+    (num_days_of_year_covered.fdiv(days_in_year) * 100).round(ROUND_PREC)
+  end
+
+
+  def total_number_of_days_paid
+    (payment.expire_date - payment.start_date + 1).to_i
+  end
+
+
+  def num_days_of_year_covered
+    return days_in_year if payment_covers_more_than_year?
+
+    starting_date = (payment.start_date < year_start) ? year_start : payment.start_date
+    ending_date = (payment.expire_date > year_end) ? year_end : payment.expire_date
+
+    (ending_date - starting_date + 1).to_i # Add 1 because the ending date should count as a full day
+  end
+
+
+  def payment_covers_more_than_year?
+    payment.start_date < year_start && payment.expire_date > year_end
+  end
+
+
+  def days_in_year
+    ((year_start + 1.year) - year_start).to_i
+  end
+
+
+  def year_start
+    DateTime.new(year, 1, 1)
+  end
+
+
+  def year_end
+    year_start.end_of_year
+  end
+end

--- a/app/views/admin_only/dashboard/_payment.html.haml
+++ b/app/views/admin_only/dashboard/_payment.html.haml
@@ -1,0 +1,26 @@
+-# This partial expects the following locals:
+-#   payment - the Payment to display as a row in a table
+
+:ruby
+  if payment.payment_type == Payment::PAYMENT_TYPE_BRANDING
+    co_name = payment.company.name
+    co_num = payment.company.company_number
+    amount = SHF_BRANDING_FEE / 100
+  else
+    co_name = ''
+    co_num = ''
+    amount = SHF_MEMBER_FEE / 100
+  end
+
+%tr.payment
+  %td.user-full-name= payment.user.full_name
+  %td.user-email= payment.user.email
+  %td.amount= amount
+  %td.company-name= co_name
+  %td.company-number= co_num
+  %td.type= payment.payment_type
+  %td.term-start-date= payment.start_date
+  %td.term-end-date= payment.expire_date
+  %td.created-at= payment.created_at
+  %td.status= payment.status
+  %td.hips-id= payment.hips_id

--- a/app/views/admin_only/dashboard/_payments.html.haml
+++ b/app/views/admin_only/dashboard/_payments.html.haml
@@ -1,0 +1,62 @@
+-# This partial expects the following locals:
+-#
+-#   title - title to display
+-#   ransack_payments_q - the Ransack search (used for sorting table headers)
+-#   payments - list of Payments to display
+
+-# ensure we have reasonable values:
+
+- displayed_title = title.blank? ? '' : title
+
+.payments
+
+  %h3.section-title= displayed_title
+
+  .row
+    .col
+      = button_to t('.export_all_payments'), admin_export_payments_csv_url, {class: 'btn btn-light export-payments'}
+
+
+  = form_tag(admin_export_payments_covering_year_csv_url, { method: 'put', class: '' }) do
+    .row
+      .col-2
+        = number_field_tag 'year', 2019, class: 'form-control'
+      .col-6
+        .actions
+          = submit_tag t('.export_payments_year'), {class: 'btn btn-secondary mb-2 form-control',
+            data: { disable_with: false } }
+
+      .col-3.instructions
+        = label_tag 'year', t('.export_payments_year_explain')
+
+
+
+  #payments_list
+    %table.table.table-hover
+      %thead
+        %tr
+          %th.user-full-name User
+          %th.user-email email
+          %th.amount SEK
+          %th.company-name Company name
+          %th.company-number Org nr
+          %th.type Type
+          %th.term-start-date= sort_link(payments_search, :start_date, 'Term Start Date', { default_order: { start_date: :asc } },{ class: 'payments_sort', remote: true } )
+          %th.term-end-date= sort_link(payments_search, :expire_date, 'Term End Date', {}, { class: 'payments_sort', remote: true } )
+          %th.created-at= sort_link(payments_search, :created_at, 'Date created', {},{ class: 'payments_sort', remote: true } )
+          %th.status HIPS Status
+          %th.hips-id HIPS id
+
+      %tbody.panel-body
+        = render partial: 'payment', collection: payments
+
+
+:javascript
+  $(function() {
+    "use strict";
+
+    $("body").on("ajax:success", ".payments_sort", function(e, data) {
+      $("#payments_list").html(data);
+    });
+
+  });

--- a/app/views/admin_only/dashboard/index.html.haml
+++ b/app/views/admin_only/dashboard/index.html.haml
@@ -9,30 +9,48 @@
   .row
     .col-md-11
       %ul.nav.nav-tabs#dashboard-tabs{ role: 'tablist' }
+
         %li.nav-item.current
           - tab_title = t('tabs.current.tab-title', scope: i18n_scope)
           %a#tab-current{ nav_tab_html_styles('#n1', tab_title, is_active: true) }= tab_title
+
         %li.nav-item.activity
           - tab_title = t('tabs.activity.tab-title', scope: i18n_scope)
           %a#tab-activity{ nav_tab_html_styles('#n2', tab_title) }= tab_title
-        %li.nav-item.applications
-          - tab_title = t('tabs.applications.tab-title', scope: i18n_scope)
-          %a#tab-applications{ nav_tab_html_styles('#n6', tab_title) }= tab_title
-        %li.nav-item.users
-          - tab_title = t('tabs.users.tab-title', scope: i18n_scope)
-          %a#tab-users{ nav_tab_html_styles('#n7', tab_title) }= tab_title
+
+
         %li.nav-item.members
           - tab_title = t('tabs.members.tab-title', scope: i18n_scope)
           %a#tab-members{ nav_tab_html_styles('#n3', tab_title) }= tab_title
-        %li.nav-item.membership
-          - tab_title = t('tabs.payments_memberships.tab-title', scope: i18n_scope)
-          %a#tab-membership{ nav_tab_html_styles('#n4', tab_title) }= tab_title
-        %li.nav-item.h-branding
+
+        %li.nav-item.applications
+          - tab_title = t('tabs.applications.tab-title', scope: i18n_scope)
+          %a#tab-applications{ nav_tab_html_styles('#n4', tab_title) }= tab_title
+
+        %li.nav-item.users
+          - tab_title = t('tabs.users.tab-title', scope: i18n_scope)
+          %a#tab-users{ nav_tab_html_styles('#n5', tab_title) }= tab_title
+
+
+        %li.nav-item.payments
+          - tab_title = t('tabs.payments.tab-title', scope: i18n_scope)
+          -# <a class="nav-link" id="messages-tab" data-toggle="tab" href="#messages" role="tab" aria-controls="messages" aria-selected="false">Messages</a>
+          %a#tab-payments{ nav_tab_html_styles('#n6', tab_title) }= tab_title
+
+
+        %li.nav-item.payments-membership
+          - tab_title = t('tabs.payments_membership.tab-title', scope: i18n_scope)
+          %a#tab-payments-membershp{ nav_tab_html_styles('#n7', tab_title) }= tab_title
+
+
+        %li.nav-item.payments-h-branding
           - tab_title = t('tabs.payments_h_branding.tab-title', scope: i18n_scope)
-          %a#tab-h-branding{ nav_tab_html_styles('#n5', tab_title) }= tab_title
+          %a#tab-payments-h-branding{ nav_tab_html_styles('#n8', tab_title) }= tab_title
+
+
         %li.nav-item.xhr-example
           - tab_title = 'XHR example'
-          %a#tab-xhr-example{ nav_tab_html_styles('#n8', tab_title) }= tab_title
+          %a#tab-xhr-example{ nav_tab_html_styles('#n9', tab_title) }= tab_title
 
 
       .tab-content#nav-tab-content
@@ -45,7 +63,7 @@
              companies_branding_not_paid: @data_gatherer.companies_branding_not_paid,
              companies_info_not_completed: @data_gatherer.companies_info_not_completed
 
-        .tab-pane.fade#n2{ role: "tabpanel", 'aria-labelledby': "tab-current" }
+        .tab-pane.fade#n2{ role: "tabpanel", 'aria-labelledby': "tab-activity" }
           -# smell:  passing so many vars to a view -> should encapsulate in a class
           .section
             = render 'recent_activity', recent_num_days: @data_gatherer.timeframe,
@@ -60,10 +78,36 @@
             %h3.total-members
               = styled_total(@data_gatherer.total_members, t('tabs.members.total_members', scope: i18n_scope))
 
-        .tab-pane.fade#n4{ role: 'tabpanel', 'aria-labelledby': 'tab-membership' }
+
+        .tab-pane.fade#n4{ role: 'tabpanel', 'aria-labelledby': 'tab-applications' }
+          .section
+            %h3.section-title= t("tabs.applications.title", scope: i18n_scope)
+            %p= @data_gatherer.app_states_translated.map{|k, v| "#{k}: #{v}"}.join(', ')
+            = pie_chart @data_gatherer.app_states_translated
+            = line_chart ShfApplication.group_by_day(:created_at).count
+
+
+        .tab-pane.fade#n5{ role: 'tabpanel', 'aria-labelledby': 'tab-users' }
+          .section
+            = render 'admin_only/dashboard/users',
+             users_by_membership_summary: @data_gatherer.translated_users.map{|k, v| "#{k}: #{v}"}.join(', '),
+             users_grouped_by_membership: @data_gatherer.translated_users,
+             users_grouped_by_day_created: User.all.group_by_day(:created_at).count,
+             not_members: User.all.reject(&:member?)
+
+
+        .tab-pane.fade#n6{ role: 'tabpanel', 'aria-labelledby': 'tab-payments' }
+          .section
+            = render partial:  'payments',
+                    locals: { title: t('admin_only.dashboard.tabs.payments.title'),
+                      payments_search: @payments_search,
+                      payments: @payments }
+
+
+        .tab-pane.fade#n7{ role: 'tabpanel', 'aria-labelledby': 'tab-payments-membership' }
           .section
             = render partial: 'payors_payment_status',
-              locals: { title: t('admin_only.dashboard.tabs.payments_memberships.title'),
+              locals: { title: t('admin_only.dashboard.tabs.payments_membership.title'),
                 payor_display_method: :full_name,
                 num_total: @data_gatherer.total_members,
                 num_paid: @data_gatherer.recent_payments[Payment::PAYMENT_TYPE_MEMBER.to_sym].count,
@@ -74,7 +118,7 @@
                 those_not_paid: @data_gatherer.apps_approved_member_fee_not_paid }
 
 
-        .tab-pane.fade#n5{ role: 'tabpanel', 'aria-labelledby': 'tab-h-branding' }
+        .tab-pane.fade#n8{ role: 'tabpanel', 'aria-labelledby': 'tab-payments-h-branding' }
           .section
             = render partial: 'payors_payment_status',
                 locals: { title: t('admin_only.dashboard.tabs.payments_h_branding.title'),
@@ -88,23 +132,7 @@
                   those_not_paid: @data_gatherer.companies_branding_not_paid }
 
 
-        .tab-pane.fade#n6{ role: 'tabpanel', 'aria-labelledby': 'tab-applications' }
-          .section
-            %h3.section-title= t("tabs.applications.title", scope: i18n_scope)
-            %p= @data_gatherer.app_states_translated.map{|k, v| "#{k}: #{v}"}.join(', ')
-            = pie_chart @data_gatherer.app_states_translated
-            = line_chart ShfApplication.group_by_day(:created_at).count
 
-
-        .tab-pane.fade#n7{ role: 'tabpanel', 'aria-labelledby': 'tab-users' }
-          .section
-            = render 'admin_only/dashboard/users',
-             users_by_membership_summary: @data_gatherer.translated_users.map{|k, v| "#{k}: #{v}"}.join(', '),
-             users_grouped_by_membership: @data_gatherer.translated_users,
-             users_grouped_by_day_created: User.all.group_by_day(:created_at).count,
-             not_members: User.all.reject(&:member?)
-
-
-        .tab-pane.fade#n8{ role: "tabpanel", 'aria-labelledby': "tab-xhr-example" }
+        .tab-pane.fade#n9{ role: "tabpanel", 'aria-labelledby': "tab-xhr-example" }
           .section
             = render 'xhr_example'

--- a/app/views/admin_only/dashboard/payments.html.haml
+++ b/app/views/admin_only/dashboard/payments.html.haml
@@ -1,0 +1,3 @@
+=render partial: 'payments',  locals: { title: t('admin_only.dashboard.tabs.payments.title'),
+                      payments_search: @payments_search,
+                      payments: @payments }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -980,8 +980,8 @@ en:
     all_applications_received: All applications received
 
     export_ansokan_csv:
-      success: Export successful. Check your browser downloads for the file.
-      error: There was a problem with the export.
+      success: &export_success Export successful. Check your browser downloads for the file.
+      error: &export_error There was a problem with the export.
       date_state_changed: Date State changed
       member_fee_paid: M fee paid
       member_fee_expires: M Expires
@@ -990,6 +990,15 @@ en:
       paid: *paid
       never_paid: *never_paid
       fee_payment_url: "Log in and pay here: https://hitta.sverigeshundforetagare.se%{payment_url}"
+
+  export_payments_csv:
+    success: *export_success
+    error: *export_error
+
+  export_payments_covering_year_csv:
+    success: *export_success
+    error: *export_error
+
 
 
   shf_documents:
@@ -1151,6 +1160,12 @@ en:
     dashboard:
       title: ADMIN DASHBOARD
 
+      payments:
+        export_all_payments: &dash_export_all_payments Export all payments
+        export_payments_year: &dash_export_payments_year Export payments covering year
+        export_payments_year_explain: Payments that cover any of the days in the year.
+
+
       tabs:
         current:
           tab-title: Current
@@ -1180,7 +1195,13 @@ en:
           title: *members
           total_members: *members
 
-        payments_memberships:
+        payments:
+          tab-title: &payments "Payments"
+          title: *payments
+          export_all_payments: Export all payments
+          export_payments_year: Export payments covering year
+
+        payments_membership:
           tab-title: &payments_membership "Payments: Membership"
           title: *payments_membership
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -991,13 +991,13 @@ en:
       never_paid: *never_paid
       fee_payment_url: "Log in and pay here: https://hitta.sverigeshundforetagare.se%{payment_url}"
 
-  export_payments_csv:
-    success: *export_success
-    error: *export_error
+    export_payments_csv:
+      success: *export_success
+      error: *export_error
 
-  export_payments_covering_year_csv:
-    success: *export_success
-    error: *export_error
+    export_payments_covering_year_csv:
+      success: *export_success
+      error: *export_error
 
 
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -985,8 +985,8 @@ sv:
     all_applications_received: Alla inkomna ansökningar
 
     export_ansokan_csv:
-      success: Exporten lyckades. Du hittar filen bland din webbläsares nedladdade filer.
-      error: Ett problem uppstod med exporten.
+      success: &export_success Exporten lyckades. Du hittar filen bland din webbläsares nedladdade filer.
+      error: &export_error Ett problem uppstod med exporten.
       date_state_changed: Date State changed
       member_fee_paid: M fee paid
       member_fee_expires: M Expires
@@ -995,6 +995,15 @@ sv:
       paid: *paid
       never_paid: *never_paid
       fee_payment_url: "Betalas som inloggad via: https://hitta.sverigeshundforetagare.se%{payment_url}"
+
+    export_payments_csv:
+      success: *export_success
+      error: *export_error
+
+    export_payments_covering_year_csv:
+      success: *export_success
+      error: *export_error
+
 
 
   shf_documents:
@@ -1158,6 +1167,11 @@ sv:
     dashboard:
       title: ADMIN DASHBOARD
 
+      payments:
+        export_all_payments: &dash_export_all_payments Export all payments
+        export_payments_year: &dash_export_payments_year Export payments covering year
+        export_payments_year_explain: Payments that cover any of the days in the year.
+
       tabs:
         current:
           tab-title: Nuvarande
@@ -1187,7 +1201,13 @@ sv:
           title: *members
           total_members: *members
 
-        payments_memberships:
+        payments:
+          tab-title: &payments "Betalningar"
+          title: *payments
+          export_all_payments: Export all payments
+          export_payments_year: Export payments covering year
+
+        payments_membership:
           tab-title: &payments_membership "Betalningar: medlemskap"
           title: *payments_membership
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,9 +13,15 @@ Rails.application.routes.draw do
         resources :master_checklists
         get  'master-checklists/max-list-position', to: 'master_checklists#max_list_position'
         post 'master-checklists/toggle-in-use', to: 'master_checklists#toggle_in_use'
+
+        get 'payments', to: 'dashboard#payments'
+
       end
 
+
       post 'admin/export-ansokan-csv'
+      post 'admin/export-payments-csv'
+      put 'admin/export-payments-covering-year-csv'
 
       # Route for testing Exception Notification configuration
       get "test_exception_notifications" => "application#test_exception_notifications"

--- a/features/admin-dashboard/admin_dashboard.feature
+++ b/features/admin-dashboard/admin_dashboard.feature
@@ -135,9 +135,9 @@ Feature: Admin sees the dashboard with summary of important information
     Then I should see t("admin_only.dashboard.tabs.members.title")
     And I should see t("admin_only.dashboard.tabs.members.total_members", total_num_members: 11)
 
-    When I click on t("admin_only.dashboard.tabs.payments_memberships.tab-title")
+    When I click on t("admin_only.dashboard.tabs.payments_membership.tab-title")
     # section title:
-    Then I should see t("admin_only.dashboard.tabs.payments_memberships.title")
+    Then I should see t("admin_only.dashboard.tabs.payments_membership.title")
 
     When I click on t("admin_only.dashboard.tabs.payments_h_branding.tab-title")
     # section title:


### PR DESCRIPTION
## PT Story:  Report for auditors: $ earned for days in 2019
#### PT URL: https://www.pivotaltracker.com/story/show/171388686

Needed to do this quickly to provide the information to the SHF Board. (The Board Treasurer needed this for Accounting auditing info.)

## Changes proposed in this pull request:
1.  Added the `by_star` gem -- which provides a lot of really helpful queries (ActiveRecord scopes) to query things `by_year` or `by_month` etc.
2. Added a new tab to the Admin Dashboard:  Payments
2.  Added 2 export buttons on that tab:
    1. Export all Payments
    2. Export payments that apply in part or in whole to a given year

 These will create `.csv` files that are downloaded.  (just like the current 'export applications' does)

## Screenshots (Optional):

<img width="1169" alt="admin-dashboard-new-payments-export-buttons" src="https://user-images.githubusercontent.com/673794/75077247-09e56b80-54b7-11ea-8991-0a8df1ffbda9.png">

---
## Ready for review:
@thesuss @patmbolger 

