### PR TITLE
Admin dashboard: export payments (part 2) - handle nil Users and Companies

### DIFF
--- a/app/models/csv_row.rb
+++ b/app/models/csv_row.rb
@@ -30,7 +30,17 @@ class CsvRow
     self
   end
 
+
   alias_method :<<, :append
+
+
+  def append_items(items = [])
+    @elements.concat(items)
+  end
+
+
+  alias_method :concat, :append_items
+
 
   def elements
     @elements ||= []

--- a/app/views/admin_only/dashboard/_payment.html.haml
+++ b/app/views/admin_only/dashboard/_payment.html.haml
@@ -3,8 +3,8 @@
 
 :ruby
   if payment.payment_type == Payment::PAYMENT_TYPE_BRANDING
-    co_name = payment.company.name
-    co_num = payment.company.company_number
+    co_name = payment.company&.name
+    co_num = payment.company&.company_number
     amount = SHF_BRANDING_FEE / 100
   else
     co_name = ''
@@ -13,8 +13,8 @@
   end
 
 %tr.payment
-  %td.user-full-name= payment.user.full_name
-  %td.user-email= payment.user.email
+  %td.user-full-name= payment.user&.full_name
+  %td.user-email= payment.user&.email
   %td.amount= amount
   %td.company-name= co_name
   %td.company-number= co_num

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -78,9 +78,6 @@ set :keep_releases, 5
 
 set :migration_role, :app
 
-# whenever gem configuration:  we have the schedule.rb file in a slightly different place (under app/config)
-set :whenever_path,         ->{ "#{release_path}/app/config" }
-
 # ============================================
 # Tasks
 #   See Task sequencing below, after the code for the tasks

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,8 @@ en:
   none_n: *none
   name_missing: Name Missing
 
+  unknown: unknown
+
   time_ago: '%{amount_of_time} ago'
 
   confirm_are_you_sure: &are_you_sure_confirm Are you sure

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -54,6 +54,8 @@ sv:
   none_n: &none_n Ingen
   name_missing: Namn Saknas
 
+  unknown: okänd
+
   time_ago: '%{amount_of_time} sedan'
 
   confirm_are_you_sure: &are_you_sure_confirm Är du säker

--- a/spec/models/csv_row_spec.rb
+++ b/spec/models/csv_row_spec.rb
@@ -40,4 +40,20 @@ RSpec.describe CsvRow do
     expect(new_row.to_s).to eq '1,2,3'
   end
 
+
+  describe 'append_items' do
+
+    it 'adds all of the elements in the given array  at the end' do
+      new_row = described_class.new([1, 2])
+      new_row.append_items [3, 4]
+      expect(new_row.to_s).to eq '1,2,3,4'
+    end
+
+  end
+
+  it 'concat is an alias for append_items' do
+    new_row = described_class.new([1, 2])
+    new_row.concat [3, 4]
+    expect(new_row.to_s).to eq '1,2,3,4'
+  end
 end


### PR DESCRIPTION
## PT Story: Report for auditors: $ earned for days in 2019
#### PT URL: https://www.pivotaltracker.com/story/show/171388686

On the production system, some Payments have 'nil' for the User.  (That shouldn't happen/be true. But figuring that out is a separate story/PR.)
Updated the export to handle this situation with the data.

Also did  a wee bit of refactoring (DRY).

Fixed a capistrano line needed to deploy.

## Changes proposed in this pull request:
1.  handle `user is nil` for a Payment
2. handle 'company is nil' for a Payment
3. a little DRY refactoring
4. fix capistrano line: remove line that sets the `whenever` configuration to a custom location. (we don't)
