### PR TITLE
Fix cmpy show btns, add designguide in admin menu

### DIFF
--- a/app/views/application/_login_items.html.haml
+++ b/app/views/application/_login_items.html.haml
@@ -11,12 +11,15 @@
         %li
           = link_to t('menus.nav.admin.app_configuration'), admin_only_app_configuration_path, class: 'nav-link'
 
+        %li
+          = link_to t('menus.nav.admin.design_guide'), admin_only_designguide_path, class: 'nav-link'
+
         - unless @user.nil?
           %li
             = link_to t('admin_only.user_profile.edit.become_this_user'), admin_only_become_user_path(@user), class: 'nav-link'
 
         %li
-          = link_to 'Dashbaord', admin_only_dashboard_path, class: 'nav-link'
+          = link_to 'Dashboard', admin_only_dashboard_path, class: 'nav-link'
 
       %li
         = link_to t('devise.sessions.destroy.log_out'),

--- a/app/views/companies/show.html.haml
+++ b/app/views/companies/show.html.haml
@@ -89,14 +89,16 @@
 
 
     %hr
-    .text-center
-      - if user_can_edit
-        = link_to "#{t('companies.edit_company')}",
-                  edit_company_path(@company), class: 'btn btn-secondary btn-sm edit-company'
+    .row
+      .col.d-flex.justify-content-center
+        - if user_can_edit
+          = link_to "#{t('companies.edit_company')}",
+                    edit_company_path(@company),
+                    class: 'btn btn-light btn-sm edit-company mr-3'
 
-      - if current_user.admin?
-        = link_to "#{t('.delete')}", @company, method: :delete,
-                  class:'btn btn-danger btn-sm delete-company',
-                  data: { confirm: "#{t('.confirm_are_you_sure')}" }
+        - if current_user.admin?
+          = link_to "#{t('.delete')}", @company, method: :delete,
+                    class:'btn btn-danger btn-sm delete-company',
+                    data: { confirm: "#{t('.confirm_are_you_sure')}" }
 
 = render('edit_branding_modal', company: @company) if current_user.admin?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1564,6 +1564,7 @@ en:
         shf_meeting_minutes: *member_pages_board_meetings
         manage_applications: Manage Applications
         app_configuration: App Configuration
+        design_guide: Design Guide
         categories:
           submenu_title: Categories
           manage_categories: Manage Categories

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1571,6 +1571,7 @@ sv:
         shf_meeting_minutes: *member_pages_board_meetings
         manage_applications: Hantera ansökningar
         app_configuration: Appkonfiguration
+        design_guide: Designguide
         categories:
           submenu_title: Kategorier
           manage_categories: Hantera kategorier


### PR DESCRIPTION
## PT Story: Misaligned buttons in company show view & Misspelled item in admin menu
#### PT URL: https://www.pivotaltracker.com/story/show/171745643

#### PT URL: https://www.pivotaltracker.com/story/show/171745669


## Changes proposed in this pull request:
1. I also added "Design Guide" to the user menu if the user == Admin.

## Screenshots (Optional):

<img width="716" alt="Screen Shot 2020-03-13 at 3 39 30 PM" src="https://user-images.githubusercontent.com/9968213/76654376-2ff3ae00-6541-11ea-805b-9f518417937e.png">

---

<img width="183" alt="Screen Shot 2020-03-13 at 3 44 09 PM" src="https://user-images.githubusercontent.com/9968213/76654391-34b86200-6541-11ea-9174-8d19641323dc.png">

---
## Ready for review:
@AgileVentures/shf-project-team 
