### PR TITLE
skip scenarios that always pass locally but fail on Semaphore CI

### DIFF
--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -369,7 +369,7 @@ Feature: Create a new membership application
 
 
 
-  @selenium
+  @selenium @skip_ci_test
   Scenario Outline: Apply for membership - when things go wrong with company create [SAD PATH]
     Given I am on the "new application" page
     And I fill in the translated form with data:

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -240,7 +240,7 @@ Feature: Visitor sees all companies
     And I should not see "Verksamhetslän"
     And I should not see "Kategori"
 
-  @selenium @time_adjust
+  @selenium @time_adjust @skip_ci_test
   Scenario: Pagination: Set number of items per page
     Given the date is set to "2017-10-01"
     Given I am Logged out


### PR DESCRIPTION
## PT Story: skip js features failing only on Semaphore (tag them)
#### PT URL: https://www.pivotaltracker.com/story/show/172770570


## Changes proposed in this pull request:
1.  added @skip_ci_test tag to company pagination scenario that often fails on Semaphore but passes locally
2.  added @skip_ci_test tag to application - when things go wrong with the company scenario that often fails on Semaphore but passes locally

---
## Ready for review:
@AgileVentures/shf-project-team 
