### PR TITLE
don't display UserChecklist root description

### DIFF
--- a/app/views/user_checklists/_checklist_top_desc.html.haml
+++ b/app/views/user_checklists/_checklist_top_desc.html.haml
@@ -1,0 +1,7 @@
+-# Display the description of the root of the user_checklist
+    This partial expects these locals (required):
+      user_checklist [UserChecklist] - the UserChecklist that is used
+
+-#%p.description= local_assigns[:user_checklist].root.description
+-# Do not display this for now.  Will display this later. (Uncomment out the statement above and remove these comments)
+    See PT story https://www.pivotaltracker.com/story/show/172961791

--- a/app/views/user_checklists/membership_guidelines_completed.html.haml
+++ b/app/views/user_checklists/membership_guidelines_completed.html.haml
@@ -5,13 +5,15 @@
 
   .entry-content.container
     .user-checklist.membership-guidelines-completed
-      %p.description= @user_checklist.root.description
+      = render partial: 'user_checklists/checklist_top_desc', locals: {user_checklist: @user_checklist}
 
       .completed-progress-bar
         = render partial: 'shared/progress_bar', locals: {  percent_complete: overall_progress }
 
       .row
         .col
+          -# Can't make the card a shared partial because the other view that uses this card needs to update the progress bar.
+          -# This is an excellent use case for using Vue or React (to take advantage of components automatically reacting to change)
           .card
             .card-body
               %h3.card-title= t('.i_commit_to')

--- a/app/views/user_checklists/show_progress.html.haml
+++ b/app/views/user_checklists/show_progress.html.haml
@@ -18,7 +18,7 @@
 
   .entry-content.container
     .user-checklist
-      %p.description= @checklist_root.description
+      = render partial: 'user_checklists/checklist_top_desc', locals: {user_checklist: @user_checklist}
 
       = render partial: 'shared/progress_bar', locals: {  percent_complete: overall_progress }
 


### PR DESCRIPTION
## PT Story: Do not display main Membership Guideline description
#### PT URL:  https://www.pivotaltracker.com/story/show/172963806


## Changes proposed in this pull request:
1.  refactored the `description` to a shared partial
2.  comment out the description + add text referring to the PT task to get the right text and then display the description at a later date


## Screenshots (Optional):
  #### No description is shown above the progress bar.


<img width="823" alt="not-completed-guidelines-view" src="https://user-images.githubusercontent.com/673794/82590913-60645380-9b53-11ea-81dc-d13bbcf30695.png">

---

<img width="801" alt="completed-guidelines-view" src="https://user-images.githubusercontent.com/673794/82590919-62c6ad80-9b53-11ea-9b73-a86b0894d4d0.png">


---
## Ready for review:
@thesuss 
