### PR TITLE
Open 'real' guidelines in new tab; minor language fixes

### DIFF
--- a/app/views/users/_ethical_guidelines_link_or_checklist.html.haml
+++ b/app/views/users/_ethical_guidelines_link_or_checklist.html.haml
@@ -6,7 +6,9 @@
   %p
     = complete_check_icon(html_options: {class: 'is-complete'})
     = t('.agreed_to') + ' '
-    = link_to t('.membership_guidelines'), 'https://sverigeshundforetagare.se/medlemsatagande/'
+    = link_to  'https://sverigeshundforetagare.se/medlemsatagande/', target: '_blank' do
+      = t('.membership_guidelines')
+      %sup= external_link_icon
 - else
   - if UserChecklistManager.must_complete_membership_guidelines_checklist?(user)
     - user_checklist = UserChecklistManager.first_incomplete_membership_guideline_section_for(user)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1086,10 +1086,10 @@ en:
       not_found:  *user_checklist_not_found
 
     show_progress:
-      read_and_agree: Please read each one of these carefully. If you agree to the terms, check the box at the bottom. Then click 'Next' to go to the next list of terms.
+      read_and_agree: As a member of the Swedish Dog Company, you undertake to follow certain guidelines, called membership commitments. Below is the Member Commitment broken down by heading. You need to tick each heading, and thus verify that you have read, understood, and intend to follow these guidelines.
       scroll_down_to_read_all: Scroll down to read all items and see the button to go to the next group.
-      read_and_agree_start: I have read and agree to all of the
-      read_and_agree_end: terms.
+      read_and_agree_start: ""
+      read_and_agree_end: I have read and understood these guidelines.
       contact_if_questions: *if_you_have_qs_email_us
       email_display_name: Membership Chair
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -963,7 +963,7 @@ sv:
 
     ethical_guidelines_link_or_checklist:
       agree_to_guidelines: Skriv under medlemsåtagandet
-      agreed_to: Skrivit under 
+      agreed_to: Skrivit under
       membership_guidelines: Alla medlemsåtaganden
 
     show_member_images_row_cols:
@@ -1060,7 +1060,7 @@ sv:
 
   user_checklists:
     all_list_items: &user_checklists_all_items Tillbaka till medlemsåtagandet
-    all_list_items_for_user: &user_checklists_all_items_for_user Tillbaka till alla listor för %{name} 
+    all_list_items_for_user: &user_checklists_all_items_for_user Tillbaka till alla listor för %{name}
 
     if_you_have_qs_email_us: &if_you_have_qs_email_us "Om du har några frågor om dessa, maila oss till "
 
@@ -1097,7 +1097,7 @@ sv:
     show_progress:
       read_and_agree: "Som medlem i Sveriges Hundföretagare förbinder du dig att följa vissa riktlinjer, kallade medlemsåtaganden. Här nedan följer Medlemsåtagandet uppdelat per rubrik. Du behöver kryssa för varje rubrik, och på så sätt verifiera att du läst, förstått, och avser att följa dessa riktlinjer."
       scroll_down_to_read_all: Scrolla ner för att läsa alla åtaganden och för att se knappen för att gå vidare.
-      read_and_agree_start: " - " 
+      read_and_agree_start: ""
       read_and_agree_end: Jag har läst och förstått dessa riktlinjer.
       contact_if_questions: *if_you_have_qs_email_us
       email_display_name: Ordförande

--- a/db/seeders/yaml-data/master-checklists.yml
+++ b/db/seeders/yaml-data/master-checklists.yml
@@ -350,8 +350,8 @@
       :children: []
     - id: 12
       name: Follow the hierarchy of behavior change procedures
-      displayed_text: följa <a href="http://www.behaviorworks.org/files/downloadable_art/Hierarchy%20Road%20Map%20curve-Swedish.png" target="_blank">"Hierarki för procedurer för beteendeförändring"</a> (2016 Friedman, Fritzler) vid samtliga tillfällen då jag medvetet påverkar hundars beteende.
-      description: Follow the <a href="http://www.behaviorworks.org/files/downloadable_art/Hierarchy%20Road%20Map%20curve-Swedish.png" target="_blank">"Hierarchy of behavior change procedures"</a> (2016 Friedman, Fritzler) on all occasions when I consciously influence the behavior of dogs. http://www.behaviorworks.org/files/downloadable_art/Hierarchy%20Road%20Map%20curve-Swedish.png
+      displayed_text: följa <a href="http://www.behaviorworks.org/files/downloadable_art/Hierarchy%20Road%20Map%20curve-Swedish.png" target="_blank">"Hierarki för procedurer för beteendeförändring"<sup><i class="fas fa-external-link-alt"></i></sup></a> (2016 Friedman, Fritzler) vid samtliga tillfällen då jag medvetet påverkar hundars beteende.
+      description: Follow the <a href="http://www.behaviorworks.org/files/downloadable_art/Hierarchy%20Road%20Map%20curve-Swedish.png" target="_blank">"Hierarki för procedurer för beteendeförändring"<sup><i class="fas fa-external-link-alt"></i></sup></a> (2016 Friedman, Fritzler) on all occasions when I consciously influence the behavior of dogs. http://www.behaviorworks.org/files/downloadable_art/Hierarchy%20Road%20Map%20curve-Swedish.png
       list_position: 2
       ancestry: 8/9
       notes:


### PR DESCRIPTION
## PT Story: link to membership guidelines open in new tab (_blank)
#### PT URL: https://www.pivotaltracker.com/story/show/173002671


## Changes proposed in this pull request:
1.  use "" instead of ' - ' in user_checklists...  locale for start of 'I have read...' tag
2. Open new tab (use `_blank`) for link to "real" membership guidelines (shown when a user has completed agreeing to all of them); show the external link icon
3. also show the 'external link' icon with the guideline that links to the "follow heirarchy of beh. ..."

---
## Ready for review:
@
