### PR TITLE
Fix typo in seeders scripts

### DIFF
--- a/db/seeders/ancestry_ordered_seeder.rb
+++ b/db/seeders/ancestry_ordered_seeder.rb
@@ -68,7 +68,7 @@ module Seeders
     end
 
 
-    def self.create_ordered_entry(_yaml_entry, _parent_ordered_entry: nil, _log: nil)
+    def self.create_ordered_entry(_yaml_entry, _parent_ordered_entry: nil, log: nil)
       raise NoMethodError, "Subclass must define the #{__method__} method", caller
 
       # Example of how a subclass might implement this method:

--- a/db/seeders/ancestry_ordered_seeder.rb
+++ b/db/seeders/ancestry_ordered_seeder.rb
@@ -68,7 +68,7 @@ module Seeders
     end
 
 
-    def self.create_ordered_entry(_yaml_entry, _parent_ordered_entry: nil, log: nil)
+    def self.create_ordered_entry(_yaml_entry, _parent_ordered_entry: nil, _log: nil)
       raise NoMethodError, "Subclass must define the #{__method__} method", caller
 
       # Example of how a subclass might implement this method:

--- a/db/seeders/user_checklists_seeder.rb
+++ b/db/seeders/user_checklists_seeder.rb
@@ -21,7 +21,7 @@ module Seeders
     SEEDED_CLASS = UserChecklist
 
 
-    def self.create_ordered_entry(yaml_entry, parent_ordered_entry: nil, _log: nil)
+    def self.create_ordered_entry(yaml_entry, parent_ordered_entry: nil, log: nil)
       self::SEEDED_CLASS.create!(user_id: yaml_entry[:user_id],
                                  name: yaml_entry[:name],
                                  description: yaml_entry[:description],


### PR DESCRIPTION
Fixes a typo in two scripts used by `bin/rake db:seed` that caused the procedure to fail.

---
## Ready for review:
@AgileVentures/shf-project-team 
