### PR TITLE
Remove '.members_just_need_to_pay' from applicant welcome and locales

### DIFF
--- a/app/views/users/_show_for_applicant.html.haml
+++ b/app/views/users/_show_for_applicant.html.haml
@@ -7,7 +7,6 @@
       %p= t('.welcome_want_to_have_benefits')
       %p
         %b= t('.welcome')
-      %p= t('.members_just_need_to_pay')
       %hr
 .row
   .col

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1881,7 +1881,6 @@ en:
         design_guide: Design Guide
         master_checklists: Master Checklists
         dashboard: Dashboard
-        design_guide: Design Guide
 
         categories:
           submenu_title: Categories

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -937,7 +937,6 @@ en:
       title: "Steps to SHF Membership:"
       welcome: "Welcome to Sveriges Hundföretagare!"
       welcome_want_to_have_benefits: "Do you want to be included in a context that confirms that your qualifications, dedication and dog knowledge are counted?"
-      members_just_need_to_pay: "This text is currently displayed both for you who want to become a member and for you who are a member but not yet paid membership fee. You who are already a member but not paid just need to press the pay button."
 
       apply_4_membership: *apply_for_membership
       my_application: &my_application My Application

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -947,7 +947,6 @@ sv:
       title: "Steg mot medlemskap:"
       welcome: Välkommen till Sveriges Hundföretagare!
       welcome_want_to_have_benefits: "Vill du finnas med i ett sammanhang som innebär en bekräftelse på att dina meriter, engagemang och hundkunskaper räknas?"
-      members_just_need_to_pay: Denna text visas just nu både för dig som vill bli medlem, och för dig som är medlem men ännu inte betalt medlemsavgift.  Du som redan är medlem men inte betalt behöver bara trycka på betala-knappen.
       submit_application: Fyll i och skicka in din ansökan.
       my_application: &my_application Min ansökan
       apply_4_membership: *apply_for_membership


### PR DESCRIPTION
## PT Story:  Applicant welcome: don't show 'members need to pay...'
#### PT URL: https://www.pivotaltracker.com/story/show/173064555


## Changes proposed in this pull request:
1.  removed from Applicant welcome view
2. removed no longer used entry from locale files


## Screenshots (Optional):

<img width="606" alt="app-welcome-removed-paystatement" src="https://user-images.githubusercontent.com/673794/83442352-e064a600-a3fc-11ea-8753-b630b3ba1524.png">

---
## Ready for review:
@thesuss 
