### PR TITLE
Add '... I commit to' text b4 ethical guideline subentries 

### DIFF
--- a/app/assets/stylesheets/user-checklists.scss
+++ b/app/assets/stylesheets/user-checklists.scss
@@ -93,6 +93,10 @@ $guideline-list-left-padding: 2rem;
       font-weight: bold;
     }
 
+    .agree-to-sub-guidelines {
+      padding-left: 2rem;
+    }
+
     .card-footer {
       text-align: center;
     }

--- a/app/views/user_checklists/show_progress.html.haml
+++ b/app/views/user_checklists/show_progress.html.haml
@@ -40,7 +40,7 @@
 
                 = @user_checklist.name
 
-              %div.agree-to-sub-guidelines
+              .agree-to-sub-guidelines
                 %p.i-commit-to= t('.i_commit_to')
 
                 = render partial: 'checklist_tree_as_list', locals: { user_checklist: @user_checklist }

--- a/app/views/user_checklists/show_progress.html.haml
+++ b/app/views/user_checklists/show_progress.html.haml
@@ -40,9 +40,12 @@
 
                 = @user_checklist.name
 
-              = render partial: 'checklist_tree_as_list', locals: { user_checklist: @user_checklist }
+              %div.agree-to-sub-guidelines
+                %p.i-commit-to= t('.i_commit_to')
 
-              %p.have-read-confirmation
+                = render partial: 'checklist_tree_as_list', locals: { user_checklist: @user_checklist }
+
+                %p.have-read-confirmation
 
                 = check_box_tag(checkbox_id, 'checked', @user_checklist.all_completed?,
                     { class: "fa-check-square",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1087,6 +1087,7 @@ en:
 
     show_progress:
       read_and_agree: As a member of the Swedish Dog Company, you undertake to follow certain guidelines, called membership commitments. Below is the Member Commitment broken down by heading. You need to tick each heading, and thus verify that you have read, understood, and intend to follow these guidelines.
+      i_commit_to: As a member of the Swedish Dog Company I commit to
       scroll_down_to_read_all: Scroll down to read all items and see the button to go to the next group.
       read_and_agree_start: ""
       read_and_agree_end: I have read and understood these guidelines.

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1096,6 +1096,7 @@ sv:
 
     show_progress:
       read_and_agree: "Som medlem i Sveriges Hundföretagare förbinder du dig att följa vissa riktlinjer, kallade medlemsåtaganden. Här nedan följer Medlemsåtagandet uppdelat per rubrik. Du behöver kryssa för varje rubrik, och på så sätt verifiera att du läst, förstått, och avser att följa dessa riktlinjer."
+      i_commit_to: Som medlem i Sveriges Hundföretagare förbinder jag mig
       scroll_down_to_read_all: Scrolla ner för att läsa alla åtaganden och för att se knappen för att gå vidare.
       read_and_agree_start: ""
       read_and_agree_end: Jag har läst och förstått dessa riktlinjer.


### PR DESCRIPTION
## PT Story: Initial text to be visible above headline on all "cards"
#### PT URL: https://www.pivotaltracker.com/story/show/173064532


## Changes proposed in this pull request:
1.  added "As a member of SHF I commit to" text above all guideline bullets ( = sub-guidelines)
2.  added CSS class to align everything below the main guideline name.  See the screenshot of the _original alignment_ and this _new alignment_ below:


## Screenshots (Optional):

#### Original alignment:
<img width="663" alt="orig-alignment" src="https://user-images.githubusercontent.com/673794/83444816-c75df400-a400-11ea-8d5f-0964fbe049c5.png">

---

#### with info aligned:

<img width="683" alt="added-i-commit-aligned-completed" src="https://user-images.githubusercontent.com/673794/83444820-c9c04e00-a400-11ea-90f1-1347d9a94847.png">


---
## Ready for review:
@
