### PR TITLE
Payor deleted: keep payments and make a note

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -28,7 +28,8 @@ class Company < ApplicationRecord
   has_many :users, through: :shf_applications
   has_many :events, dependent: :destroy
 
-  has_many :payments, dependent: :destroy
+  has_many :payments, dependent: :nullify
+  # ^^ need to retain h-branding payment(s) so that the total amount of $ paid to SHF is correct
   accepts_nested_attributes_for :payments
 
   has_many :business_categories,
@@ -220,6 +221,7 @@ class Company < ApplicationRecord
 
     error_if_has_applications?
 
+    record_deleted_payorinfo_in_payment_notes
   end
 
 

--- a/app/models/concerns/payment_utility.rb
+++ b/app/models/concerns/payment_utility.rb
@@ -177,6 +177,20 @@ module PaymentUtility
 
   end
 
+
+  # record info about this user in any associated payments so payment history for this user is not lost
+  def record_deleted_payorinfo_in_payment_notes(payor_class = self.class::THIS_PAYMENT_TYPE,
+                                                email = self.email,
+                                                time_deleted = Time.now.utc)
+    payments.each do |payment|
+      payment.note_payor_deleted(payor_class, email, time_deleted)
+    end
+  end
+
+
+  # ===========================================================================
+
+
   #   - FIXME how to store this date if/when the member is no longer a current member?
   #
   class_methods do

--- a/app/models/concerns/payment_utility.rb
+++ b/app/models/concerns/payment_utility.rb
@@ -179,9 +179,9 @@ module PaymentUtility
 
 
   # record info about this user in any associated payments so payment history for this user is not lost
-  def record_deleted_payorinfo_in_payment_notes(payor_class = self.class::THIS_PAYMENT_TYPE,
+  def record_deleted_payorinfo_in_payment_notes(payor_class = self.class,
                                                 email = self.email,
-                                                time_deleted = Time.now.utc)
+                                                time_deleted = Time.zone.now)
     payments.each do |payment|
       payment.note_payor_deleted(payor_class, email, time_deleted)
     end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -17,6 +17,11 @@ class Payment < ApplicationRecord
   PAYMENT_TYPE_MEMBER   = 'member_fee'
   PAYMENT_TYPE_BRANDING = 'branding_fee'
 
+  NOTES_DEFAULT_PAYOR = 'User'
+  NOTES_UNKNOWN_EMAIL = '<email unknown>'
+  NOTES_SEPARATOR = '; '  unless defined?(NOTES_SEPARATOR)
+
+
   # This hash maps a HIPS order status to an SHF payment status.
   # The payment values are stored in the DB and exposed to the user.
   # (The user is paying a fee to SHF (payment).  In order to process that
@@ -98,6 +103,14 @@ class Payment < ApplicationRecord
     self.update(status: SUCCESSFUL)
     changed
     notify_observers(self)
+  end
+
+
+  def note_payor_deleted(payor_type = NOTES_DEFAULT_PAYOR,
+                         payor_email = NOTES_UNKNOWN_EMAIL,
+                         deleted_time = Time.now.utc)
+    deleted_note = "#{payor_type} #{payor_email} for this payment was deleted on #{deleted_time}"
+    update(notes: (notes.nil? ? deleted_note : "#{notes}#{NOTES_SEPARATOR}#{deleted_note}") )
   end
 
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -108,7 +108,7 @@ class Payment < ApplicationRecord
 
   def note_payor_deleted(payor_type = NOTES_DEFAULT_PAYOR,
                          payor_email = NOTES_UNKNOWN_EMAIL,
-                         deleted_time = Time.now.utc)
+                         deleted_time = Time.zone.now)
     deleted_note = "#{payor_type} #{payor_email} for this payment was deleted on #{deleted_time}"
     update(notes: (notes.nil? ? deleted_note : "#{notes}#{NOTES_SEPARATOR}#{deleted_note}") )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  before_destroy { self.member_photo = nil } # remove photo file from file system
+  before_destroy :adjust_related_info_for_destroy
 
   has_one :shf_application, dependent: :destroy
   accepts_nested_attributes_for :shf_application, update_only: true
@@ -296,6 +296,12 @@ class User < ApplicationRecord
   end
 
 
+  def adjust_related_info_for_destroy
+    remove_photo_from_filesystem
+    record_deleted_payorinfo_in_payment_notes(self.class, email)
+  end
+
+
   private
 
 
@@ -304,5 +310,10 @@ class User < ApplicationRecord
     self.class.connection.execute("SELECT nextval('membership_number_seq')").getvalue(0, 0).to_s
   end
 
+
+  # remove the associated member photo from the file system by setting it to nil
+  def remove_photo_from_filesystem
+    member_photo = nil
+  end
 
 end

--- a/spec/models/concerns/payment_utility_spec.rb
+++ b/spec/models/concerns/payment_utility_spec.rb
@@ -465,6 +465,36 @@ RSpec.describe User, type: :model do
 
   describe 'record_deleted_payorinfo_in_payment_notes' do
 
+    describe 'defaults' do
+
+      it 'payor class: class of the payor' do
+        u = member_paid_up
+        payment1 = u.payments.first
+        expect(payment1).to receive(:note_payor_deleted).with(u.class, anything, anything)
+
+        u.record_deleted_payorinfo_in_payment_notes
+      end
+
+      it 'email: email for the payor' do
+        u = member_paid_up
+        payment1 = u.payments.first
+        expect(payment1).to receive(:note_payor_deleted).with(anything, u.email, anything)
+
+        u.record_deleted_payorinfo_in_payment_notes
+      end
+
+      it 'time_deleted: Time.zone.now' do
+        u = member_paid_up
+        payment1 = u.payments.first
+        tz_now = Time.zone.now
+
+        Timecop.freeze(tz_now) do
+          expect(payment1).to receive(:note_payor_deleted).with(anything, anything, tz_now)
+          u.record_deleted_payorinfo_in_payment_notes
+        end
+      end
+    end
+
     it 'each payment records info in notes about this payor' do
       u = build(:user)
 

--- a/spec/models/concerns/payment_utility_spec.rb
+++ b/spec/models/concerns/payment_utility_spec.rb
@@ -461,4 +461,23 @@ RSpec.describe User, type: :model do
     end
 
   end
+
+
+  describe 'record_deleted_payorinfo_in_payment_notes' do
+
+    it 'each payment records info in notes about this payor' do
+      u = build(:user)
+
+      membership_payment = build(:membership_fee_payment)
+      hbranding_payment = build(:h_branding_fee_payment)
+
+      allow(u).to receive(:payments).and_return([membership_payment, hbranding_payment])
+
+      expect(membership_payment).to receive(:note_payor_deleted)
+      expect(hbranding_payment).to receive(:note_payor_deleted)
+
+      u.record_deleted_payorinfo_in_payment_notes
+    end
+
+  end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -332,11 +332,12 @@ RSpec.describe Payment, type: :model do
           expect(subject.notes).to match(/^\w+ <email unknown>/)
         end
 
-        it 'deleted_time: Time.now.utc' do
+        it 'deleted_time: Time.zone.now' do
           expect(subject.notes).to be_nil
-          Timecop.freeze(2020, 12, 1, 1, 2, 3) do
+          tz_now = Time.zone.now
+          Timecop.freeze(tz_now) do
             subject.note_payor_deleted
-            expect(subject.notes).to match(/2020-12-01 01:02:03 UTC$/)
+            expect(subject.notes).to match(/#{tz_now}$/)
           end
         end
       end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -310,4 +310,63 @@ RSpec.describe Payment, type: :model do
     end
 
   end
+
+
+  describe 'note_payor_deleted' do
+
+    let(:time_pattern) { '\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d UTC' }
+
+    describe "deleted payor info = <payor_type> <payor_email> for this payment was deleted on <deleted_time>" do
+
+      context 'defaults' do
+
+        it 'payor_type: User' do
+          expect(subject.notes).to be_nil
+          subject.note_payor_deleted
+          expect(subject.notes).to match(/^User /)
+        end
+
+        it 'payor_email: <email unknown>' do
+          expect(subject.notes).to be_nil
+          subject.note_payor_deleted
+          expect(subject.notes).to match(/^\w+ <email unknown>/)
+        end
+
+        it 'deleted_time: Time.now.utc' do
+          expect(subject.notes).to be_nil
+          Timecop.freeze(2020, 12, 1, 1, 2, 3) do
+            subject.note_payor_deleted
+            expect(subject.notes).to match(/2020-12-01 01:02:03 UTC$/)
+          end
+        end
+      end
+
+      it 'record the info passed in' do
+        expect(subject.notes).to be_nil
+        time_deleted = Time.now.utc
+        subject.note_payor_deleted('Some class', 'some-email@example.com', time_deleted)
+        expect(subject.notes).to match(/^Some class some-email@example.com for this payment was deleted on #{time_deleted}/)
+      end
+    end
+
+    context 'notes is nil' do
+      it 'notes is now just the deleted payor info' do
+        expect(subject.notes).to be_nil
+        subject.note_payor_deleted
+        expect(subject.notes).to match(/^User <email unknown> for this payment was deleted on #{time_pattern}/)
+      end
+    end
+
+    context 'notes is not nil' do
+      it 'the deleted payor info is appended to the existing notes' do
+        orig_notes = 'original notes'
+        subject.update(notes: orig_notes)
+        expect(subject.notes).to eq orig_notes
+
+        subject.note_payor_deleted
+        expect(subject.notes).to match(/^#{orig_notes}; User <email unknown> for this payment was deleted on #{time_pattern}/)
+      end
+
+    end
+  end
 end


### PR DESCRIPTION
## PT Story: Production system:  do NOT delete payments when user/co is deleted
#### PT URL: https://www.pivotaltracker.com/story/show/171424680


## Changes proposed in this pull request:
1. User and Company: if these are deleted, set the user_id/company_id for associated Payments to nil
2. add a note to any Payments if the associated user or company is to be deleted
   - the note has the time that the payor (User or Company) was deleted:
   ```
    "User <email> was deleted Thu, 04 Jun 2020 16:17:38 UTC +00:00"
   ```

---
## Ready for review:
@AgileVentures/shf-project-team 
