### PR TITLE
fix: admin must be able to edit membership status for non-member 

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -8,14 +8,14 @@ $(function() {
     $('[data-toggle="tooltip"]').tooltip();
   });
 
-  $("#user-status-form").on("ajax:success", function(e, data) {
-    $("#user-member-status").html(data);
+  // Note that we must use javascript to remove the CSS fade class: https://stackoverflow.com/a/59871455/661471
+  $("body").on("ajax:success", "#user-status-form", function(e, data) {
+    $("#edit-status-modal").removeClass("fade");
+    $("#edit-status-modal").modal("hide");
+    $("#user-info").html(data);
     $('[data-toggle="tooltip"]').tooltip();
   });
 
-  $("#edit-user-status-submit").click(function() {
-    $("#edit-status-modal").modal("hide");
-  });
 
   $(".custom-context-menu").on("contextmenu", e => {
     e.preventDefault();

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -39,6 +39,13 @@
     margin-top: 0;
   }
 
+  .admin-only {
+    .membership-status-title {
+      font-family: 'Crimson Text', serif;
+      font-size: 150%;
+      //font-weight: bold;
+    }
+  }
 }
 
 #text {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
   LOG_FILE = LogfileNamer.name_for('users')
 
   before_action :set_user, except: [:index, :toggle_membership_package_sent]
-  before_action :set_app_config, only: [:show, :proof_of_membership, :update]
+  before_action :set_app_config, only: [:show, :proof_of_membership, :update, :edit_status]
   before_action :authorize_user, only: [:show]
   before_action :allow_iframe_request, only: [:proof_of_membership]
 
@@ -75,7 +75,12 @@ class UsersController < ApplicationController
     @user.update!(user_params) && (payment ?
                                        payment.update!(payment_params) : true)
 
-    render partial: 'membership_term_status', locals: { user: @user }
+    if @user.member?
+      render partial: 'show_for_member', locals: { user: @user, current_user: @current_user, app_config: @app_configuration }
+    else
+      render partial: 'show_for_applicant', locals: { user: @user, current_user: @current_user }
+    end
+
 
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved
     render partial: 'membership_term_status',

--- a/app/models/concerns/payment_utility.rb
+++ b/app/models/concerns/payment_utility.rb
@@ -170,7 +170,8 @@ module PaymentUtility
     end
 
 
-    # This is our current rule:  an admin cannot edit the  status if there are no payments [2019-12-05]
+    # This is our current rule:  an admin cannot edit the membership status if there are no successful payments in this system [2019-12-05];
+    #   reviewed in Team meeting 2020-06-18 (see the notes there)
     def admin_can_edit_status?
       has_successful_payments?
     end

--- a/app/views/payor/_admin_note_and_edit_status_row.html.haml
+++ b/app/views/payor/_admin_note_and_edit_status_row.html.haml
@@ -3,10 +3,12 @@
 -#   button_text - text for the button that opens the modal
 -#   target_id - id string, including the '#', for the data-target   ex: #editUserStatusModal
 
-.row.mt-2.admin-only
-  .col.d-flex.pt-2
-    .flex.pr-3.admin-note
-      = payment_notes_label_and_value(entity)
+.admin-only
+
+  .row.mt-2
+    .col.d-flex.pt-2
+      .flex.pr-3
+        = payment_notes_label_and_value(entity)
 
 .row.mt-2
   .col.d-flex.pt-2.pr-3

--- a/app/views/users/_show_for_applicant.html.haml
+++ b/app/views/users/_show_for_applicant.html.haml
@@ -44,11 +44,22 @@
           - else
             = link_to t('.pay_membership'), '#', class: 'btn btn-sm disabled btn-primary'
             %p.step-info= t('.when_can_pay')
-            - if current_user.admin?
-              .admin-only
-                - unless user.admin_can_edit_status?
+
+        - if current_user.admin?
+          .admin-only
+            .row.mt-2
+              .col
+                .membership-status-title= t('users.show.membership_status')
+            .row.ml-2
+              .col
+                - if user.admin_can_edit_status?
+                  = render partial: 'payor/admin_note_and_edit_status_row',
+                   locals: { entity: user,
+                   target_id: '#edit-status-modal',
+                   button_text: t('users.show.edit_member_status') }
+                - else
                   %p.small.admin-cant-edit-status= t('payors.admin_cant_edit')
 
 .row
   .col
-    = render partial: 'show_info_for_admin_only', locals: { current_user: current_user, user: user,  }
+    = render partial: 'show_info_for_admin_only', locals: { current_user: current_user, user: user }

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -12,7 +12,8 @@
 
 
 .entry-content.container
-  - if @user.member?
-    = render partial: 'show_for_member', locals: { user: @user, current_user: @current_user, app_config: @app_configuration }
-  - else
-    = render partial: 'show_for_applicant', locals: { user: @user, current_user: @current_user }
+  #user-info
+    - if @user.member?
+      = render partial: 'show_for_member', locals: { user: @user, current_user: @current_user, app_config: @app_configuration }
+    - else
+      = render partial: 'show_for_applicant', locals: { user: @user, current_user: @current_user }

--- a/features/admin_only/admin_edit_membership_status.feature
+++ b/features/admin_only/admin_edit_membership_status.feature
@@ -63,6 +63,7 @@ Feature: Admin edits membership status, dates, notes (membership info)
 #    Then I should see "Extended their membership to 1 juni 2018."
     And user "emma@mutts.com" is paid through "2018-06-01"
 
+
   @selenium @time_adjust
   Scenario: Admin changes membership status from member to not a member
     Given I am on the "user details" page for "bad-member@mutts.com"
@@ -72,19 +73,31 @@ Feature: Admin edits membership status, dates, notes (membership info)
     And I should see t("activerecord.attributes.payment.expire_date")
     And I should see t("activerecord.attributes.payment.notes")
     When I select radio button t("No")
-    And I fill in t("activerecord.attributes.payment.notes") with "Changed to not a member."
+    And I fill in t("activerecord.attributes.payment.notes") with "Changed to NOT a member."
     And I click on t("users.user.submit_button_label")
     And I wait for all ajax requests to complete
-    And I reload the page
+#    And I reload the page
     # ^^ should not have to do this - check later after upgrades. (DOM/page partial _is_ updated in real life, but not with capybara)
 
     Then I should be on the "user account" page for "bad-member@mutts.com"
+    And I should see t("users.show_for_applicant.title")
     And I should see t("users.show_for_applicant.pay_membership")
+    And I should see "Changed to NOT a member."
 
 
-  @selenium @time_adjust
-  Scenario: Admin cannot change member status for someone that has never made a payment
-    Given I am on the "user account" page for "never-paid-user@mutts.com"
-    Then the link button t("users.show_for_applicant.pay_membership") should be disabled
-    And I should see t("payors.admin_cant_edit")
+  @selenium
+  Scenario: Admin changes not a member to a member
+    Given I am on the "user account" page for "bad-member@mutts.com"
+    When I click on t("users.user.edit_member_status")
+    Then I should see t("users.user.edit_member_status")
+    And I should see t("users.show.member")
+    When I select radio button t("Yes")
+    And I fill in t("activerecord.attributes.payment.notes") with "Changed to IS a member."
+    And I click on t("users.user.submit_button_label")
+    And I wait for all ajax requests to complete
+#    And I reload the page
+    # ^^ should not have to do this - check later after upgrades. (DOM/page partial _is_ updated in real life, but not with capybara)
 
+    Then I should be on the "user account" page for "bad-member@mutts.com"
+    And I should see t("users.show.is_a_member")
+    And I should see "Changed to IS a member."

--- a/features/admin_only/admin_edits_user_account.feature
+++ b/features/admin_only/admin_edits_user_account.feature
@@ -8,11 +8,35 @@ Feature: Admin edits a user account
     Given the App Configuration is not mocked and is seeded
     And the Membership Ethical Guidelines Master Checklist exists
 
+    Given the date is set to "2020-11-01"
+
     Given the following users exist
-      | email                | password       | admin | member | first_name | last_name | membership_number |
-      | admin@shf.se         | admin_password | true  | false  | emma       | admin     |                   |
-      | member@shf.com       | password       | false | true   | mary       | member    |  9                 |
-      | lars-member2@shf.com | password       | false | true   | Lars       | Member2   |                   |
+      | email                               | password       | admin | member | first_name | last_name | membership_number |
+      | admin@shf.se                        | admin_password | true  | false  | emma       | admin     |                   |
+      | member@shf.com                      | password       | false | true   | mary       | member    | 9                 |
+      | applicant@example.com               | password       | false | false  | Alf        | Applicant |                   |
+      | applicant-with-old-pays@example.com | password       | false | false  | OldPays    | Applicant |                   |
+      | user@example.com                    | password       | false | false  | Ursa       | User      |                   |
+      | user-with-old-pays@example.com      | password       | false | false  | OldPays    | User      |                   |
+
+
+    Given the following business categories exist
+      | name         | description                     |
+      | dog grooming | grooming dogs from head to tail |
+
+    And the following applications exist:
+      | user_email                          | company_number | categories   | state    |
+      | member@shf.com                      | 5562252998     | dog grooming | accepted |
+      | applicant@example.com               | 5562252998     | dog grooming | new      |
+      | applicant-with-old-pays@example.com | 5562252998     | dog grooming | new      |
+
+
+    And the following payments exist
+      | user_email                          | start_date | expire_date | payment_type | status | hips_id |
+      | applicant-with-old-pays@example.com | 2019-01-01 | 2019-12-31  | member_fee   | betald | none    |
+      | user-with-old-pays@example.com      | 2018-10-31 | 2019-10-30  | member_fee   | betald | none    |
+      | member@shf.com                      | 2020-09-01 | 2021-08-30  | member_fee   | betald | none    |
+
 
     Given I am logged in as "admin@shf.se"
 
@@ -27,3 +51,47 @@ Feature: Admin edits a user account
     Then I should see t("admin_only.user_account.update.success")
     And I should see "mary Member"
     And I should see "1010101"
+
+
+  @selenium
+  Scenario: Admin sees button to change member status for a member
+    Given I am on the "user account" page for "member@shf.com"
+    Then I should see t("users.show.is_a_member")
+    And I should see t("users.show.edit_member_status")
+
+
+  @selenium
+  Scenario: Admin sees button to change member status for an applicant that has past payments
+    Given I am on the "user account" page for "applicant-with-old-pays@example.com"
+    Then I should not see t("users.show.is_a_member")
+    And I should see t("users.show_for_applicant.app_status_new")
+    And I should see t("users.show.edit_member_status")
+
+
+  @selenium
+  Scenario: Admin does not see button to change member status for an applicant that has no past payments
+    Given I am on the "user account" page for "applicant@example.com"
+    Then I should not see t("users.show.is_a_member")
+    And I should see t("users.show_for_applicant.app_status_new")
+    And I should not see t("users.show.edit_member_status")
+    And I should see t("payors.admin_cant_edit")
+
+
+  @selenium
+  Scenario: Admin sees button to change member status for a user with past payments
+    Given I am on the "user account" page for "user-with-old-pays@example.com"
+    Then I should not see t("users.show.is_a_member")
+    And I should not see t("users.show_for_applicant.app_status_new")
+    And I should see t("users.show.edit_member_status")
+
+
+  @selenium
+  Scenario: Admin does not see button to change member status for a user with no past payments
+    Given I am on the "user account" page for "user@example.com"
+    Then I should not see t("users.show.is_a_member")
+    And I should not see t("users.show_for_applicant.app_status_new")
+    And I should not see t("users.show.edit_member_status")
+    And I should see t("payors.admin_cant_edit")
+
+
+


### PR DESCRIPTION
## PT Story: Admin edit membership status for non member
#### PT URL: https://www.pivotaltracker.com/story/show/173390554


## Changes proposed in this pull request:
1.   added `.admin-only` section to the "applicant" (non-member) user account page, including a button to edit the membership status
2. cleaned up the javascript (required because of modal / redisplay problems)
3.  added a div with an id so that when the status is changed, the right partial is displayed:  if a non-member is changed to a member, then the 'member' information should be displayed where previously the 'non-member' info was displayed and v. versa.

---
## Screenshots

<img width="579" alt="Screen Shot 2020-06-17 at 6 18 28 PM" src="https://user-images.githubusercontent.com/673794/84966711-09588c80-b0c7-11ea-92f3-e866c7b902b2.png">

---
## Ready for review:
@AgileVentures/shf-project-team 
