### PR TITLE
Fix cuke fails: view Co (add AJAX wait); member status change (reload page)

### DIFF
--- a/features/admin_only/admin_edit_membership_status.feature
+++ b/features/admin_only/admin_edit_membership_status.feature
@@ -76,7 +76,7 @@ Feature: Admin edits membership status, dates, notes (membership info)
     And I fill in t("activerecord.attributes.payment.notes") with "Changed to NOT a member."
     And I click on t("users.user.submit_button_label")
     And I wait for all ajax requests to complete
-#    And I reload the page
+    And I reload the page
     # ^^ should not have to do this - check later after upgrades. (DOM/page partial _is_ updated in real life, but not with capybara)
 
     Then I should be on the "user account" page for "bad-member@mutts.com"
@@ -95,7 +95,7 @@ Feature: Admin edits membership status, dates, notes (membership info)
     And I fill in t("activerecord.attributes.payment.notes") with "Changed to IS a member."
     And I click on t("users.user.submit_button_label")
     And I wait for all ajax requests to complete
-#    And I reload the page
+    And I reload the page
     # ^^ should not have to do this - check later after upgrades. (DOM/page partial _is_ updated in real life, but not with capybara)
 
     Then I should be on the "user account" page for "bad-member@mutts.com"

--- a/features/view_all_companies.feature
+++ b/features/view_all_companies.feature
@@ -188,6 +188,7 @@ Feature: Visitor sees all companies
     And I should see "Alvesta" in the row for "Company02"
     And I should see "Årsta" in the row for "Company02"
     And I should see "Kolbäck" in the row for "Company02"
+    And I wait for all ajax requests to complete
 
   @time_adjust
   Scenario: User sees all the companies


### PR DESCRIPTION
## PT Story: cuke cleanup: fix View All Co by waiting for AJAX, reload membership page
#### PT URL: https://www.pivotaltracker.com/story/show/173456146

Trying to fix intermittent failures for cucumber features.

## Changes proposed in this pull request:
1.  add `And I wait for all AJAX requests to complete` at end of "View all companies..." scenario
2. reload pages after the admin changes the membership status scenarios

---
## Ready for review:
@
