### PR TITLE
proof of membership user authorization; i18n

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,8 @@ class UsersController < ApplicationController
   end
 
   def proof_of_membership
+    authorize_user
+
     image_html = image_html('proof_of_membership', @app_configuration, @user)
     if params[:render_to] == 'jpg'
       download_image('proof_of_membership', 260, image_html)

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -15,4 +15,7 @@ class UserPolicy < ApplicationPolicy
     user.admin?
   end
 
+  def proof_of_membership?
+    show?
+  end
 end

--- a/app/views/users/_proof_of_membership.html.haml
+++ b/app/views/users/_proof_of_membership.html.haml
@@ -12,8 +12,7 @@
         = image_tag(paperclip_path_str(app_config.shf_logo, :standard, render_to),
                     class: 'shf-logo')
 
-      %p.proof-banner
-        BEHÖRIGHETSBEVIS
+      %p.proof-banner=t('.proof_title').upcase
 
       .member-photo-div
         - if user.member_photo
@@ -25,8 +24,9 @@
           = user.full_name
         %br
         - if user.membership_current?
+          = succeed ':' do
+            =t('.member_number')
 
-          Medlemsnr.:
           %span.membership-number
             #{user.membership_number}
           %br
@@ -35,20 +35,21 @@
 
           %br
           %span.issued-by
-            Utfärdat av:
+            = succeed ':' do
+              =t('.issued_by')
+
           %br
           - if app_config.chair_signature
             = image_tag(paperclip_path_str(app_config.chair_signature,
                                        :standard, render_to))
           %br
-          Giltigt till #{user.membership_expire_date}
+          =t('.valid_thru', expire_date: user.membership_expire_date)
           %br
           -# Kategorier: #{list_app_categories(user.shf_application)}
         - else
-          Medlemskapet löpte ut
+          = t('.expired')
 
-      %p.proof-footer
-        sverigeshundforetagare.se
+      %p.proof-footer=t('.footer')
 
     - if render_to == :html && context == :internal
       %div

--- a/app/views/users/_proof_of_membership.html.haml
+++ b/app/views/users/_proof_of_membership.html.haml
@@ -49,7 +49,7 @@
         - else
           = t('.expired')
 
-      %p.proof-footer=t('.footer')
+      %p.proof-footer= t('.footer')
 
     - if render_to == :html && context == :internal
       %div

--- a/app/views/users/_proof_of_membership.html.haml
+++ b/app/views/users/_proof_of_membership.html.haml
@@ -12,7 +12,7 @@
         = image_tag(paperclip_path_str(app_config.shf_logo, :standard, render_to),
                     class: 'shf-logo')
 
-      %p.proof-banner=t('.proof_title').upcase
+      %p.proof-banner= t('.proof_title').upcase
 
       .member-photo-div
         - if user.member_photo
@@ -25,7 +25,7 @@
         %br
         - if user.membership_current?
           = succeed ':' do
-            =t('.member_number')
+            = t('.member_number')
 
           %span.membership-number
             #{user.membership_number}
@@ -36,14 +36,14 @@
           %br
           %span.issued-by
             = succeed ':' do
-              =t('.issued_by')
+              = t('.issued_by')
 
           %br
           - if app_config.chair_signature
             = image_tag(paperclip_path_str(app_config.chair_signature,
                                        :standard, render_to))
           %br
-          =t('.valid_thru', expire_date: user.membership_expire_date)
+          = t('.valid_thru', expire_date: user.membership_expire_date)
           %br
           -# Kategorier: #{list_app_categories(user.shf_application)}
         - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,7 @@ en:
   shf_facebook_url: &shf_facebook_url https://www.facebook.com/sverigeshundforetagare
   shf_facebook_group_url: &shf_facebook_group_url https://www.facebook.com/groups/sverigeshundforetagare/
   shf_instagram_url: &shf_instagram_url https://instagram.com/sverigeshundforetagare
+  shf_short_url: &shf_short_url sverigeshundforetagare.se
 
   login_page: login page
 
@@ -981,6 +982,13 @@ en:
                                   Use this link in an external website:
                                   </span>"
 
+    proof_of_membership:
+      proof_title: *proof_of_membership
+      member_number: Medlemsnr.
+      issued_by: Utfärdat av
+      valid_thru: Giltigt till %{expire_date}
+      expired: Medlemskapet löpte ut
+      footer: *shf_short_url
 
     update:
       passwords_dont_match: "The two passwords entered don't match."

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -70,7 +70,7 @@ sv:
   shf_facebook_url: &shf_facebook_url https://www.facebook.com/sverigeshundforetagare
   shf_facebook_group_url: &shf_facebook_group_url https://www.facebook.com/groups/sverigeshundforetagare/
   shf_instagram_url: &shf_instagram_url https://instagram.com/sverigeshundforetagare
-
+  shf_short_url: &shf_short_url sverigeshundforetagare.se
 
   login_page: login sida
 
@@ -990,6 +990,14 @@ sv:
       show_image: &show_image Visa bild
       copy_image_url: &copy_image_url Kopiera bildadress
       copied:  &copied Kopierat
+
+    proof_of_membership:
+      proof_title: *proof_of_membership
+      member_number: Medlemsnr.
+      issued_by: Utfärdat av
+      valid_thru: Giltigt till %{expire_date}
+      expired: Medlemskapet löpte ut
+      footer: *shf_short_url
 
     update:
       passwords_dont_match: De två lösenord du angivit matchar inte.

--- a/features/support/path_helpers.rb
+++ b/features/support/path_helpers.rb
@@ -47,6 +47,8 @@ module PathHelpers
         path = user_path(user)
       when 'edit user account'
         path = admin_only_edit_user_account_path(user)
+      when 'proof of membership image'
+        path = proof_of_membership_path(user)
 
       # SHF application pages
       when 'new application', 'submit new membership application'

--- a/features/user_account/proof-of-members-access.feature
+++ b/features/user_account/proof-of-members-access.feature
@@ -1,0 +1,47 @@
+Feature: Who can access a member's Proof of Membership download page
+
+
+  Background:
+    Given the App Configuration is not mocked and is seeded
+    Given the Membership Ethical Guidelines Master Checklist exists
+
+    Given the following users exist
+      | email                | admin | member | membership_number | first_name | last_name |
+      | admin@shf.se         | true  |        |                   | Admin      | Admin     |
+      | member-emma@mutts.se |       | true   | 1001              | Emma       | Member    |
+      | member-lars@mutts.se |       | true   | 1002              | Lars       | Member    |
+
+
+    Given the following business categories exist
+      | name  | description                                    |
+      | groom | grooming dogs from head to tail and back again |
+
+    Given the following applications exist:
+      | user_email           | company_number | categories | state    |
+      | member-emma@mutts.se | 5562252998     | groom      | accepted |
+      | member-lars@mutts.se | 5562252998     | groom      | accepted |
+
+    Given the date is set to "2017-11-01"
+
+    Given the following payments exist
+      | user_email           | start_date | expire_date | payment_type | status | hips_id |
+      | member-emma@mutts.se | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |
+      | member-lars@mutts.se | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |
+
+
+  Scenario: An admin can see a member's proof of membership
+    Given I am logged in as "admin@shf.se"
+
+
+  Scenario: A member can access their own proof of membership download page
+    Given I am logged in as "member-emma@mutts.se"
+
+
+  Scenario: A member cannot access someone else's proof of membership download page
+    Given I am logged in as "member-emma@mutts.se"
+
+
+  Scenario: A visitor cannot access the proof of membership download image for a member
+    Given I am logged out
+
+

--- a/features/user_account/proof-of-membership-imagepage-access.feature
+++ b/features/user_account/proof-of-membership-imagepage-access.feature
@@ -2,7 +2,6 @@ Feature: Who can access a member's Proof of Membership download page
 
 
   Background:
-    Given the App Configuration is not mocked and is seeded
     Given the Membership Ethical Guidelines Master Checklist exists
 
     Given the following users exist
@@ -31,17 +30,26 @@ Feature: Who can access a member's Proof of Membership download page
 
   Scenario: An admin can see a member's proof of membership
     Given I am logged in as "admin@shf.se"
-
+    And I am on the "proof of membership image" page for "member-emma@mutts.se"
+    Then I should see t("users.proof_of_membership.proof_title")
+    And I should see "1001"
+    When I am on the "proof of membership image" page for "member-lars@mutts.se"
+    Then I should see t("users.proof_of_membership.proof_title")
+    And I should see "1002"
 
   Scenario: A member can access their own proof of membership download page
     Given I am logged in as "member-emma@mutts.se"
-
+    And I am on the "proof of membership image" page for "member-emma@mutts.se"
+    Then I should see t("users.proof_of_membership.proof_title")
+    And I should see "1001"
 
   Scenario: A member cannot access someone else's proof of membership download page
     Given I am logged in as "member-emma@mutts.se"
-
+    And I am on the "proof of membership image" page for "member-lars@mutts.se"
+    Then I should see a message telling me I am not allowed to see that page
 
   Scenario: A visitor cannot access the proof of membership download image for a member
     Given I am logged out
-
+    And I am on the "proof of membership image" page for "member-lars@mutts.se"
+    Then I should see a message telling me I am not allowed to see that page
 

--- a/features/user_account/proof_of_membership.feature
+++ b/features/user_account/proof_of_membership.feature
@@ -10,8 +10,9 @@ Feature: Member gets their customized SHF membership card (proof of membership)
     Given the Membership Ethical Guidelines Master Checklist exists
 
     Given the following users exist
-      | email         | admin | member | membership_number | first_name | last_name |
-      | emma@mutts.se |       | true   | 1001              | Emma       | Edmond    |
+      | email                   | admin | member | membership_number | first_name  | last_name |
+      | emma@mutts.se           |       | true   | 1001              | Emma        | Edmond    |
+      | member-expired@mutts.se |       | false  | 999               | ExpiredLars | Member    |
 
     Given the following business categories exist
       | name  | description                     |
@@ -19,41 +20,58 @@ Feature: Member gets their customized SHF membership card (proof of membership)
       | rehab | physical rehabilitation         |
 
     Given the following applications exist:
-      | user_email    | company_number | categories   | state    |
-      | emma@mutts.se | 5562252998     | rehab, groom | accepted |
+      | user_email              | company_number | categories   | state    |
+      | emma@mutts.se           | 5562252998     | rehab, groom | accepted |
+      | member-expired@mutts.se | 5562252998     | groom        | accepted |
 
     Given the date is set to "2017-11-01"
 
     Given the following payments exist
-      | user_email    | start_date | expire_date | payment_type | status | hips_id |
-      | emma@mutts.se | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |
+      | user_email              | start_date | expire_date | payment_type | status | hips_id |
+      | emma@mutts.se           | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |
+      | member-expired@mutts.se | 2016-10-1  | 2016-12-31  | member_fee   | betald | none    |
 
-
-    Given I am logged in as "emma@mutts.se"
 
   @time_adjust
   Scenario: Member downloads proof-of-membership image
-    Given I am on the "landing" page for "emma@mutts.se"
-    And I should see t("hello", name: 'Emma')
-    Then I click on the t("menus.nav.users.your_account") link
-    And I should see t("users.show_member_images_row_cols.proof_of_membership")
+    Given I am logged in as "emma@mutts.se"
+    And I am on the "landing" page for "emma@mutts.se"
+    Then I should see t("hello", name: 'Emma')
+    When I click on the t("menus.nav.users.your_account") link
+    Then I should see t("users.show_member_images_row_cols.proof_of_membership")
     And I should see "groom, rehab"
-    And I click on the t("users.show_member_images_row_cols.download_image") link
+    When I click on the t("users.show_member_images_row_cols.download_image") link
     Then I should get a downloaded image with the filename "proof_of_membership.jpeg"
 
   @time_adjust
   Scenario: Member views proof-of-membership image
-    Given I am on the "landing" page for "emma@mutts.se"
-    And I should see t("hello", name: 'Emma')
-    Then I click on the t("menus.nav.users.your_account") link
-    And I should see t("users.show_member_images_row_cols.proof_of_membership")
+    Given I am logged in as "emma@mutts.se"
+    And I am on the "proof of membership image" page for "emma@mutts.se"
+    Then I should see t("users.proof_of_membership.proof_title")
+    And I should see t("users.proof_of_membership.member_number")
+    And I should see "1001"
     And I should see "groom, rehab"
-    And I click on the t("users.show_member_images_row_cols.show_image") link
-    And I should see t("users.show_member_images_row_cols.use_this_image_link_html")
+    And I should see t("users.proof_of_membership.issued_by")
+    And I should see t("users.proof_of_membership.valid_thru", expire_date: )
+    And I should see t("users.proof_of_membership.footer")
+
+  @selenium
+  Scenario: Expired Membership says 'Expired'
+    Given I am logged in as "member-expired@mutts.se"
+    And I am on the "proof of membership image" page for "member-expired@mutts.se"
+    Then I should see t("users.proof_of_membership.proof_title")
+    And I should not see t("users.proof_of_membership.member_number")
+    And I should not see "999"
+    And I should not see "groom, rehab"
+    And I should not see t("users.proof_of_membership.issued_by")
+    And I should not see t("users.proof_of_membership.valid_thru", expire_date: )
+    And I should see t("users.proof_of_membership.expired")
+    And I should see t("users.proof_of_membership.footer")
 
   @selenium @time_adjust
   Scenario: Member sees custom context menu instead of normal browser context menu
-    Given I am on the "user account" page for "emma@mutts.se"
+    Given I am logged in as "emma@mutts.se"
+    And I am on the "user account" page for "emma@mutts.se"
     When I right click on "#proof-of-membership"
     Then I should see t("users.show_member_images_row_cols.download_image")
     And I should see t("users.show_member_images_row_cols.show_image")


### PR DESCRIPTION
## PT Story:  error for URL anvandare/208/proof_of_membership
#### PT URL: https://www.pivotaltracker.com/story/show/173628543

No language was changed:  I just copied the hard-coded string that were being used and put them into the locale files.  (So no locale entries need to be reviewed.)

## Changes proposed in this pull request:
1. check the user before displaying the proof of membership image page (`authorize_user`)
2. added feature for checking the authorization/access for the proof of membership image page
3. changed hard-coded strings in the proof of membership view to i18n
4. added scenario for specifying/testing what should be displayed for an expired proof of membership image

---
## Ready for review:
@AgileVentures/shf-project-team 
