### PR TITLE
Capistrano deployment: fix variable name

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -247,7 +247,7 @@ namespace :shf do
 
             unless test("[ -l #{linked_file} ]")
               # unless File.symlink?(linked_file)
-              execute :rm, target if test "[ -f #{linked_file} ]"
+              execute :rm, linked_file if test "[ -f #{linked_file} ]"
               # File.delete(linked_file) if File.exist?(linked_file)
 
               execute :ln, "-s", "#{relative_target_path}/#{source_fname}", linked_file


### PR DESCRIPTION
## PT Story: Capistrano: target should be linked_file
#### PT URL: https://www.pivotaltracker.com/story/show/173714740

Couldn't see (or catch) this error until we deployed.
This highlights the need for a staging server -- where this could have been caught.

## Changes proposed in this pull request:
1.  fix variable name

## Ready for review:
@
