### PR TITLE
Cucumber: find radio btns based on their label

### DIFF
--- a/app/views/companies/_company_addresses.html.haml
+++ b/app/views/companies/_company_addresses.html.haml
@@ -20,8 +20,10 @@
             %tbody
               %tr.address
                 - if user_can_edit
+                  - radio_btn_id =  "cb_address_#{address.id}"
                   %td
-                    = link_to address.entire_address(full_visibility: true),
+                    = label_tag(radio_btn_id) do
+                      = link_to address.entire_address(full_visibility: true),
                               edit_company_address_path(company.id, address.id)
                   %td
                     %span{ class: (address.visibility == 'none' ? 'maybe' : 'yes') }
@@ -29,7 +31,7 @@
                   %td
                     = radio_button_tag('mail', '1', address.mail,
                         class: 'cb_address',
-                        id: "cb_address_#{address.id}",
+                        id: radio_btn_id,
                         data: { remote: true,
                                 url: company_address_type_path(company.id, address.id),
                                 params: 'type=mail',

--- a/features/companies/member_edits_company_page.feature
+++ b/features/companies/member_edits_company_page.feature
@@ -31,14 +31,10 @@ Feature: Member edits a company attribute
 
     And the following companies exist:
       | name                 | company_number | email                  |
-      | No More Snarky Barky | 2120000142     | snarky@snarkybarky.com |
       | Woof Woof            | 5560360793     | emma@happymutts.com    |
 
     And the following business categories exist
       | name         |
-      | Groomer      |
-      | Psychologist |
-      | Trainer      |
       | Awesome      |
 
     And the following applications exist:
@@ -82,36 +78,45 @@ Feature: Member edits a company attribute
     And I click on t("submit")
     Then I should see t("addresses.create.success")
 
-    Then I click the radio button with id "cb_address_3"
-    And I should not see the radio button with id "cb_address_3" unchecked
-    And I should see the radio button with id "cb_address_4" unchecked
-    And I should see the radio button with id "cb_address_5" unchecked
+    When I select the radio button with label "Hundforetagarevägen 1, 310 40, Harplinge, Ale, Sverige"
+    Then I should see the radio button with label "Hundforetagarevägen 1, 310 40, Harplinge, Ale, Sverige" checked
+    And I should see the radio button with label "Ålstensgatan 4, 123 45, Bromma, Alingsås, Sverige" unchecked
+    And I should see the radio button with label "Acksjö Gräsbacken 1, 441 94, Alingsås, Alingsås, Sverige" unchecked
 
-    Then I click the radio button with id "cb_address_5"
-    And I should not see the radio button with id "cb_address_5" unchecked
-    And I should see the radio button with id "cb_address_3" unchecked
-    And I should see the radio button with id "cb_address_4" unchecked
+    When I select the radio button with label "Acksjö Gräsbacken 1, 441 94, Alingsås, Alingsås, Sverige"
+    Then I should see the radio button with label "Acksjö Gräsbacken 1, 441 94, Alingsås, Alingsås, Sverige" checked
+    And I should see the radio button with label "Hundforetagarevägen 1, 310 40, Harplinge, Ale, Sverige" unchecked
+    And I should see the radio button with label "Ålstensgatan 4, 123 45, Bromma, Alingsås, Sverige" unchecked
 
-    And I click the first address for company "Happy Mutts"
+
+    When I click the first address for company "Happy Mutts"
     And I select t("address_visibility.none") in select list t("companies.address_visibility")
     And I click on t("submit")
-    And I should see "3" addresses
+    Then I should see "3" addresses
 
-    Then I click the third address for company "Happy Mutts"
-    And I should see t("addresses.edit.cannot_delete_address")
+    When I click the third address for company "Happy Mutts"
+    Then I should see t("addresses.edit.cannot_delete_address")
     And I should not see t("'addresses.edit.delete'")
-    And I click on the t("companies.view_company") link
 
+    When I click on the t("companies.view_company") link
     And I click the second address for company "Happy Mutts"
-    And I should not see t("addresses.edit.cannot_delete_address")
-    And I click on and accept the t("addresses.edit.delete") link
+    Then I should not see t("addresses.edit.cannot_delete_address")
+
+    When I click on and accept the t("addresses.edit.delete") link
     Then I should see t("addresses.destroy.success")
     And I should see "2" addresses
 
-    And I am Logged out
+    When I am Logged out
     And I am on the "landing" page
     And I click on "Happy Mutts"
-    And I should see "1" address
+    Then I should see "1" address
+
+
+    Scenario: Member enters invalid facebook URL
+
+
+
+  # Authorization/Access (who can/cannot edit a company page)
 
   @time_adjust
   Scenario: Another tries to edit your company page (gets rerouted)

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -60,6 +60,17 @@ Then(/^I should( not)? see the (?:checkbox|radio button) with id "([^"]*)" unche
   expect(page).send (negate ? :not_to : :to), have_unchecked_field(checkbox_id)
 end
 
+Then(/^I should( not)? see the (?:checkbox|radio button) with label "([^"]*)" checked$/) do |negate,  label_str|
+  for_id = for_value_of_label(label_str)
+  expect(page).send (negate ? :not_to : :to), have_checked_field(for_id)
+end
+
+Then(/^I should( not)? see the (?:checkbox|radio button) with label "([^"]*)" unchecked$/) do |negate,  label_str|
+  for_id = for_value_of_label(label_str)
+  expect(page).send (negate ? :not_to : :to), have_unchecked_field(for_id)
+end
+
+
 Then(/^I should be on (?:the )*"([^"]*)" page(?: for "([^"]*)")?$/) do |page, email|
   user = email == nil ? @user : User.find_by(email: email)
   expect(current_path_without_locale(current_path)).to eq get_path(page, user)

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -87,6 +87,11 @@ When "I select radio button {capture_string}" do |label_text|
   find(:xpath, "//label[contains(.,'#{label_text}')]//input[@type='radio']").click
 end
 
+When "I select the radio button with( the) label {capture_string}" do | label_text|
+  for_id = for_value_of_label(label_text)
+  find(:xpath, "//input[@id='#{for_id}']").click
+end
+
 When "I click the {capture_string} action for the row with {capture_string}" do |action, row_content|
   find(:xpath, "//tr[contains(.,'#{row_content}')]/td/a", :text => "#{action}").click
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -18,6 +18,9 @@ require_relative '../../spec/shared_context/mock_app_configuration.rb'
 require 'show_me_the_cookies'
 World(ShowMeTheCookies)
 
+# add the FindHelpers module
+require_relative './find_helpers'
+World(FindHelpers)
 
 #
 # Configurations

--- a/features/support/find_helpers.rb
+++ b/features/support/find_helpers.rb
@@ -1,0 +1,10 @@
+# Helper methods for finding nodes
+
+module FindHelpers
+
+  def for_value_of_label(label_text)
+    find(:xpath, "//label[contains(.,'#{label_text}')]")[:for]
+  end
+
+end
+


### PR DESCRIPTION
## PT Story: cuke: find radio buttons by label
#### PT URL: https://www.pivotaltracker.com/story/show/173720845


## Changes proposed in this pull request:
1.  add helper methods, steps for finding a radio button based on its associated label
2. clean up `member_edits_company_page.feature' (can now remove unused data since radio buttons CSS ids are no longer hard-coded to the database id)


## Ready for review:
@
