### PR TITLE
Validate social meda urls

### DIFF
--- a/app/assets/stylesheets/companies.scss
+++ b/app/assets/stylesheets/companies.scss
@@ -224,3 +224,7 @@ label,
   font-weight: bold;
   margin: 20px 0;
 }
+
+.url-example {
+  font-size: smaller;
+}

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -574,6 +574,18 @@ input.checklist-checkbox-small {
   width: 14px;
 }
 
+form {
+  .error {
+    color: $warn-red;
+  }
+
+  label {
+    &.error {
+      font-weight: bold;
+    }
+  }
+}
+
 @media only screen and (max-width: 600px) {
   .entry-title {
     font-size: 36px;

--- a/app/views/companies/_form.html.haml
+++ b/app/views/companies/_form.html.haml
@@ -20,7 +20,7 @@
     .row
       .col.form-group
         = f.label :website, t('companies.website_include_http')
-        = f.text_field :website,  class: 'form-control'
+        = f.url_field :website,  class: 'form-control'
       .col.form-group.dinkurs-company-id
         = f.label :dinkurs_company_id, t('companies.show.dinkurs_key')
         = fas_tooltip(t('.dinkurs_id_tooltip'))
@@ -37,13 +37,13 @@
     .row
       .col.form-group
         = f.label :facebook_url, t('activerecord.attributes.company.facebook_url')
-        = f.text_field :facebook_url,  class: 'form-control'
+        = f.url_field :facebook_url,  class: 'form-control'
       .col.form-group
         = f.label :instagram_url, t('activerecord.attributes.company.instagram_url')
-        = f.text_field :instagram_url,  class: 'form-control'
+        = f.url_field :instagram_url,  class: 'form-control'
       .col.form-group
         = f.label :youtube_url, t('activerecord.attributes.company.youtube_url')
-        = f.text_field :youtube_url,  class: 'form-control'
+        = f.url_field :youtube_url,  class: 'form-control'
 
     .row
       .col.form-group

--- a/app/views/companies/_form.html.haml
+++ b/app/views/companies/_form.html.haml
@@ -2,6 +2,16 @@
 - content_for :javascript_for_view do
   = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.19.2/jquery.validate.min.js'
 
+:ruby
+  protocol_https = "https:"
+  facebook_host = "facebook.com"
+  instagram_host = "instagram.com"
+  youtube_host = "youtube.com"
+
+  facebook_url_start = protocol_https + "//" + facebook_host
+  instagram_url_start = protocol_https + "//" + instagram_host
+  youtube_url_start = protocol_https + "//" + youtube_host
+
 
 = form_for @company, html: { class: "#{class_name}" } do |f|
 
@@ -43,15 +53,15 @@
       .col.form-group
         = f.label :facebook_url, t('.facebook_url')
         = f.url_field :facebook_url,  class: 'form-control'
-        .url-example= t('.facebook_url_ex')
+        .url-example= t('.social_url_ex', example_url: "#{facebook_url_start}/#{t('.facebook_url_ex_path')}")
       .col.form-group
         = f.label :instagram_url, t('.instagram_url')
         = f.url_field :instagram_url,  class: 'form-control'
-        .url-example= t('.instagram_url_ex')
+        .url-example= t('.social_url_ex', example_url: "#{instagram_url_start}/#{t('.instagram_url_ex_path')}")
       .col.form-group
         = f.label :youtube_url, t('.youtube_url')
         = f.url_field :youtube_url,  class: 'form-control'
-        .url-example= t('.youtube_url_ex')
+        .url-example= t('.social_url_ex', example_url: "#{youtube_url_start}/#{t('.youtube_url_ex_path')}")
 
     .row
       .col.form-group
@@ -66,19 +76,21 @@
     $('input[type="checkbox"].toggle').bootstrapToggle(); // assumes the checkboxes have the class "toggle"
   });
 
-  const FacebookHost = "facebook.com";
-  const InstagramHost = "instagram.com";
-  const YouTubeHost = "youtube.com";
-  const FacebookURLError = '#{ I18n.t('companies.form.bad_url_must_start_with', url_start: 'http://facebook.com/') }';
-  const InstagramURLError = '#{ I18n.t('companies.form.bad_url_must_start_with', url_start: 'http://instagram.com/') }';
-  const YouTubeURLError = '#{ I18n.t('companies.form.bad_url_must_start_with', url_start: 'http://youtube.com/') }';
+  const ProtocolHTTPS = "#{protocol_https}";
+  const FacebookHost = "#{facebook_host}";
+  const InstagramHost = "#{instagram_host}";
+  const YouTubeHost = "#{youtube_host}";
+
+  const FacebookURLError = '#{ I18n.t('companies.form.bad_url_must_start_with', url_start: facebook_url_start) }';
+  const InstagramURLError = '#{ I18n.t('companies.form.bad_url_must_start_with', url_start: instagram_url_start) }';
+  const YouTubeURLError = '#{ I18n.t('companies.form.bad_url_must_start_with', url_start: youtube_url_start) }';
 
 
   // ensure that the url has the expected host and that the pathname is not empty
   function urlHasHostAndSomePath(urlString = "", expectedHost = FacebookHost) {
     let urlObj = new URL(urlString);
     let path = urlObj.pathname.replace("/", "").trim(); // replace the first '/' with ''
-    return (urlObj.hostname === expectedHost && path.length != 0);
+    return (urlObj.protocol === ProtocolHTTPS && urlObj.hostname === expectedHost && path.length != 0);
   }
 
   // Add a custom validator method that calls the urlHasHostAndSomePath function, with a name and error message

--- a/app/views/companies/_form.html.haml
+++ b/app/views/companies/_form.html.haml
@@ -1,3 +1,8 @@
+-# jQuery validate plugin:
+- content_for :javascript_for_view do
+  = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.19.2/jquery.validate.min.js'
+
+
 = form_for @company, html: { class: "#{class_name}" } do |f|
 
   != model_errors_helper(@company)
@@ -36,14 +41,17 @@
     %hr
     .row
       .col.form-group
-        = f.label :facebook_url, t('activerecord.attributes.company.facebook_url')
+        = f.label :facebook_url, t('.facebook_url')
         = f.url_field :facebook_url,  class: 'form-control'
+        .url-example= t('.facebook_url_ex')
       .col.form-group
-        = f.label :instagram_url, t('activerecord.attributes.company.instagram_url')
+        = f.label :instagram_url, t('.instagram_url')
         = f.url_field :instagram_url,  class: 'form-control'
+        .url-example= t('.instagram_url_ex')
       .col.form-group
-        = f.label :youtube_url, t('activerecord.attributes.company.youtube_url')
+        = f.label :youtube_url, t('.youtube_url')
         = f.url_field :youtube_url,  class: 'form-control'
+        .url-example= t('.youtube_url_ex')
 
     .row
       .col.form-group
@@ -53,6 +61,60 @@
     = f.submit t('submit'), class: 'btn btn-primary mb-2 form-control'
 
 :javascript
+  "use strict";
   $(document).on('ready page:change', function() {
     $('input[type="checkbox"].toggle').bootstrapToggle(); // assumes the checkboxes have the class "toggle"
+  });
+
+  const FacebookHost = "facebook.com";
+  const InstagramHost = "instagram.com";
+  const YouTubeHost = "youtube.com";
+  const FacebookURLError = '#{ I18n.t('companies.form.bad_url_must_start_with', url_start: 'http://facebook.com/') }';
+  const InstagramURLError = '#{ I18n.t('companies.form.bad_url_must_start_with', url_start: 'http://instagram.com/') }';
+  const YouTubeURLError = '#{ I18n.t('companies.form.bad_url_must_start_with', url_start: 'http://youtube.com/') }';
+
+
+  // ensure that the url has the expected host and that the pathname is not empty
+  function urlHasHostAndSomePath(urlString = "", expectedHost = FacebookHost) {
+    let urlObj = new URL(urlString);
+    let path = urlObj.pathname.replace("/", "").trim(); // replace the first '/' with ''
+    return (urlObj.hostname === expectedHost && path.length != 0);
+  }
+
+  // Add a custom validator method that calls the urlHasHostAndSomePath function, with a name and error message
+  function addCustomValidator(validatorInfo) {
+     jQuery.validator.addMethod(validatorInfo.name, function(value, element){
+      let isValidURL = $.validator.methods.url.call(this, value, element);
+      return (isValidURL ? urlHasHostAndSomePath(value, validatorInfo.expectedHost) : false);
+    }, validatorInfo.errorMsg);
+  }
+
+  // Add custom validation methods to the jQuery validator plugin  https://jqueryvalidation.org/
+  [
+    {name: "facebookURL", expectedHost: FacebookHost, errorMsg: FacebookURLError},
+    {name: "instagramURL", expectedHost: InstagramHost, errorMsg: InstagramURLError},
+    {name: "youtubeURL", expectedHost: YouTubeHost, errorMsg: YouTubeURLError}
+  ].forEach(addCustomValidator);
+
+
+  let form_id = "#" + $('form').attr('id');
+  // validate() method used by the jQuery-validation plugin https://jqueryvalidation.org/
+  $(form_id).validate({
+    rules: {
+      "company[facebook_url]": {
+        facebookURL: true
+      },
+      "company[instagram_url]": {
+        instagramURL: true
+      },
+      "company[youtube_url]": {
+        youtubeURL: true
+      }
+    },
+    messages: {
+      "company[facebook_url]": FacebookURLError,
+      "company[instagram_url]": InstagramURLError,
+      "company[youtube_url]": YouTubeURLError
+    },
+    errorLabelContainer: ".validation-error"
   });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -777,13 +777,14 @@ en:
       dinkurs_id_tooltip: If you have a Dinkurs.se account and want to also show
                           the company events here, enter the Dinkurs.se company key.
                           (You can leave it blank if you don't have a Dinkurs.se account.)
+      social_url_ex: "Ex: %{example_url}"
       facebook_url: URL for your Facebook page
-      facebook_url_ex: "Ex: http://facebook.com/YourFacebookName"
-      bad_url_must_start_with: 'Invalid url. It must start with %{url_start} and specify your page'
+      facebook_url_ex_path: "YourFacebookName"
+      bad_url_must_start_with: 'Invalid url. It must start with %{url_start}/ and specify your page'
       instagram_url: URL for your Instagram page
-      instagram_url_ex: "Ex: http://instagram.com/YourInstagramName"
+      instagram_url_ex_path: "YourInstagramName"
       youtube_url: URL for your YouTube page
-      youtube_url_ex: "Ex: http://youtube.com/YourYouTubePage"
+      youtube_url_ex_path: "YourChannel"
 
     company:
       submit_button_label: Update Status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -776,6 +776,14 @@ en:
       dinkurs_id_tooltip: If you have a Dinkurs.se account and want to also show
                           the company events here, enter the Dinkurs.se company key.
                           (You can leave it blank if you don't have a Dinkurs.se account.)
+      facebook_url: URL for your Facebook page
+      facebook_url_ex: "Ex: http://facebook.com/YourFacebookName"
+      bad_url_must_start_with: 'Invalid url. It must start with %{url_start} and specify your page'
+      instagram_url: URL for your Instagram page
+      instagram_url_ex: "Ex: http://instagram.com/YourInstagramName"
+      youtube_url: URL for your YouTube page
+      youtube_url_ex: "Ex: http://youtube.com/YourYouTubePage"
+
     company:
       submit_button_label: Update Status
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -782,13 +782,14 @@ sv:
       dinkurs_id_tooltip: Om du har ett Dinkurs.se konto och vill visa
                           företagshändelser här, ange Dinkurs.se företagsnyckel.
                           (Du kan lämna den tom om du inte har ett Dinkurs.se konto.)
+      social_url_ex: "Ex: %{example_url}"
       facebook_url: URL till din Facebook-sida
-      facebook_url_ex: "Ex: http://facebook.com/YourFacebookName"
-      bad_url_must_start_with: 'Ogiltig url. Det måste börja med %{url_start} och ange din sida'
+      facebook_url_ex_path: "YourFacebookName"
+      bad_url_must_start_with: 'Ogiltig url. Det måste börja med %{url_start}/ och ange din sida'
       instagram_url: URL till din Instagram-sida
-      instagram_url_ex: "Ex: http://instagram.com/YourInstagramName"
+      instagram_url_ex_path: "YourInstagramName"
       youtube_url: URL till din YouTube-sida
-      youtube_url_ex: "Ex: http://youtube.com/YourYouTubePage"
+      youtube_url_ex_path: "YourChannel"
 
     company:
       submit_button_label: Uppdatera status

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -782,6 +782,13 @@ sv:
       dinkurs_id_tooltip: Om du har ett Dinkurs.se konto och vill visa
                           företagshändelser här, ange Dinkurs.se företagsnyckel.
                           (Du kan lämna den tom om du inte har ett Dinkurs.se konto.)
+      facebook_url: URL till din Facebook-sida
+      facebook_url_ex: "Ex: http://facebook.com/YourFacebookName"
+      bad_url_must_start_with: 'Ogiltig url. Det måste börja med %{url_start} och ange din sida'
+      instagram_url: URL till din Instagram-sida
+      instagram_url_ex: "Ex: http://instagram.com/YourInstagramName"
+      youtube_url: URL till din YouTube-sida
+      youtube_url_ex: "Ex: http://youtube.com/YourYouTubePage"
 
     company:
       submit_button_label: Uppdatera status

--- a/features/companies/company-edit-social-media-links.feature
+++ b/features/companies/company-edit-social-media-links.feature
@@ -25,17 +25,48 @@ Feature: Edit the social media urls (links) for a company
     Given the date is set to "2019-10-10"
 
 
-  Scenario: All social media urls are changed
+  Scenario: All social media urls are changed successfully
     Given I am logged in as "member@mutts.com"
     And I am on the edit company page for "2120000142"
-    Then I should see t("activerecord.attributes.company.facebook_url")
-    And I should see t("activerecord.attributes.company.youtube_url")
-    And I should see t("activerecord.attributes.company.instagram_url")
-    When I fill in t("activerecord.attributes.company.facebook_url") with "http://example.com/facebook"
-    And I fill in t("activerecord.attributes.company.youtube_url") with "http://example.com/youtube"
-    And I fill in t("activerecord.attributes.company.instagram_url") with "http://example.com/instagram"
+    Then I should see t("companies.form.facebook_url")
+    And I should see t("companies.form.instagram_url")
+    And I should see t("companies.form.youtube_url")
+    When I fill in t("companies.form.facebook_url") with "http://facebook.com/example"
+    And I fill in t("companies.form.youtube_url") with "http://youtube.com/example"
+    And I fill in t("companies.form.instagram_url") with "http://instagram.com/example"
     And I click on t("submit")
     Then I should see t("companies.update.success")
-    And I should see an icon with CSS class "fa-facebook" that is linked to "http://example.com/facebook"
-    And I should see an icon with CSS class "fa-youtube" that is linked to "http://example.com/youtube"
-    And I should see an icon with CSS class "fa-instagram" that is linked to "http://example.com/instagram"
+    And I should see an icon with CSS class "fa-facebook" that is linked to "http://facebook.com/example"
+    And I should see an icon with CSS class "fa-youtube" that is linked to "http://youtube.com/example"
+    And I should see an icon with CSS class "fa-instagram" that is linked to "http://instagram.com/example"
+
+
+  # -------------------------------------------------------------------
+  # Javascript validation error message should show for invalid entries
+
+  @selenium
+  Scenario: Error message shows if Facebook url is invalid
+    Given I am logged in as "member@mutts.com"
+    And I am on the edit company page for "2120000142"
+    When I fill in t("companies.form.facebook_url") with "http://blorf.com/example"
+    # Need to move to another field in order to get the javascript validation error message to show
+    And I fill in t("companies.form.instagram_url") with "http://instagram.com/example"
+    Then I should see t("companies.form.bad_url_must_start_with", url_start: "http://facebook.com/")
+
+  @selenium
+  Scenario: Error message shows if Instagram url is invalid
+    Given I am logged in as "member@mutts.com"
+    And I am on the edit company page for "2120000142"
+    When I fill in t("companies.form.instagram_url") with "http://blorf.com/example"
+    # Need to move to another field in order to get the javascript validation error message to show
+    And I fill in t("companies.form.youtube_url") with "http://youtube.com/example"
+    Then I should see t("companies.form.bad_url_must_start_with", url_start: "http://instagram.com/")
+
+  @selenium
+  Scenario: Error message shows if YouTube url is invalid
+    Given I am logged in as "member@mutts.com"
+    And I am on the edit company page for "2120000142"
+    When I fill in t("companies.form.youtube_url") with "http://blorf.com/example"
+    # Need to move to another field in order to get the javascript validation error message to show
+    And I fill in t("companies.form.facebook_url") with "http://facebook.com/example"
+    Then I should see t("companies.form.bad_url_must_start_with", url_start: "http://youtube.com/")

--- a/features/companies/company-edit-social-media-links.feature
+++ b/features/companies/company-edit-social-media-links.feature
@@ -10,8 +10,8 @@ Feature: Edit the social media urls (links) for a company
       | admin@shf.se     | true  | true   |
 
     And the following companies exist:
-      | name    | company_number | email              | facebook_url          | youtube_url          | instagram_url          |
-      | Bowsers | 2120000142     | bowwow@bowsers.com | original-facebook-url | original-youtube-url | original-instagram-url |
+      | name    | company_number | email              |
+      | Bowsers | 2120000142     | bowwow@bowsers.com |
 
     And the following applications exist:
       | user_email       | company_number | state    |
@@ -31,14 +31,14 @@ Feature: Edit the social media urls (links) for a company
     Then I should see t("companies.form.facebook_url")
     And I should see t("companies.form.instagram_url")
     And I should see t("companies.form.youtube_url")
-    When I fill in t("companies.form.facebook_url") with "http://facebook.com/example"
-    And I fill in t("companies.form.youtube_url") with "http://youtube.com/example"
-    And I fill in t("companies.form.instagram_url") with "http://instagram.com/example"
+    When I fill in t("companies.form.facebook_url") with "https://facebook.com/example"
+    And I fill in t("companies.form.youtube_url") with "https://youtube.com/example"
+    And I fill in t("companies.form.instagram_url") with "https://instagram.com/example"
     And I click on t("submit")
     Then I should see t("companies.update.success")
-    And I should see an icon with CSS class "fa-facebook" that is linked to "http://facebook.com/example"
-    And I should see an icon with CSS class "fa-youtube" that is linked to "http://youtube.com/example"
-    And I should see an icon with CSS class "fa-instagram" that is linked to "http://instagram.com/example"
+    And I should see an icon with CSS class "fa-facebook" that is linked to "https://facebook.com/example"
+    And I should see an icon with CSS class "fa-youtube" that is linked to "https://youtube.com/example"
+    And I should see an icon with CSS class "fa-instagram" that is linked to "https://instagram.com/example"
 
 
   # -------------------------------------------------------------------
@@ -48,25 +48,69 @@ Feature: Edit the social media urls (links) for a company
   Scenario: Error message shows if Facebook url is invalid
     Given I am logged in as "member@mutts.com"
     And I am on the edit company page for "2120000142"
-    When I fill in t("companies.form.facebook_url") with "http://blorf.com/example"
+
+    # Invalid Protocol
+    When I fill in t("companies.form.facebook_url") with "http://facebook.com/example"
     # Need to move to another field in order to get the javascript validation error message to show
-    And I fill in t("companies.form.instagram_url") with "http://instagram.com/example"
-    Then I should see t("companies.form.bad_url_must_start_with", url_start: "http://facebook.com/")
+    And I fill in t("companies.form.instagram_url") with "https://instagram.com/example"
+    Then I should see t("companies.form.bad_url_must_start_with", url_start: "https://facebook.com")
+
+    # Clear the error message by entering a valid url
+    When I fill in t("companies.form.facebook_url") with "https://facebook.com/example"
+    # Need to move to another field in order to get the javascript validation error message to show
+    And I fill in t("companies.form.instagram_url") with "https://instagram.com/example"
+    Then I should not see t("companies.form.bad_url_must_start_with", url_start: "https://facebook.com")
+
+    # Invalid host name
+    When I fill in t("companies.form.facebook_url") with "https://blorf.com/example"
+    # Need to move to another field in order to get the javascript validation error message to show
+    And I fill in t("companies.form.instagram_url") with "https://instagram.com/example"
+    Then I should see t("companies.form.bad_url_must_start_with", url_start: "https://facebook.com")
+
 
   @selenium
   Scenario: Error message shows if Instagram url is invalid
     Given I am logged in as "member@mutts.com"
     And I am on the edit company page for "2120000142"
-    When I fill in t("companies.form.instagram_url") with "http://blorf.com/example"
+
+    # Invalid Protocol
+    When I fill in t("companies.form.instagram_url") with "http://instagram.com/example"
     # Need to move to another field in order to get the javascript validation error message to show
-    And I fill in t("companies.form.youtube_url") with "http://youtube.com/example"
-    Then I should see t("companies.form.bad_url_must_start_with", url_start: "http://instagram.com/")
+    And I fill in t("companies.form.facebook_url") with "https://facebook.com/example"
+    Then I should see t("companies.form.bad_url_must_start_with", url_start: "https://instagram.com")
+
+    # Clear the error message by entering a valid url
+    When I fill in t("companies.form.instagram_url") with "https://instagram.com/example"
+    # Need to move to another field in order to get the javascript validation error message to show
+    And I fill in t("companies.form.facebook_url") with "https://facebook.com/example"
+    Then I should not see t("companies.form.bad_url_must_start_with", url_start: "https://instagram.com")
+
+    # Invalid host name
+    When I fill in t("companies.form.instagram_url") with "https://blorf.com/example"
+    # Need to move to another field in order to get the javascript validation error message to show
+    And I fill in t("companies.form.facebook_url") with "https://facebook.com/example"
+    Then I should see t("companies.form.bad_url_must_start_with", url_start: "https://instagram.com")
+
 
   @selenium
   Scenario: Error message shows if YouTube url is invalid
     Given I am logged in as "member@mutts.com"
     And I am on the edit company page for "2120000142"
-    When I fill in t("companies.form.youtube_url") with "http://blorf.com/example"
+
+    # Invalid Protocol
+    When I fill in t("companies.form.youtube_url") with "http://youtube.com/example"
     # Need to move to another field in order to get the javascript validation error message to show
-    And I fill in t("companies.form.facebook_url") with "http://facebook.com/example"
-    Then I should see t("companies.form.bad_url_must_start_with", url_start: "http://youtube.com/")
+    And I fill in t("companies.form.facebook_url") with "https://facebook.com/example"
+    Then I should see t("companies.form.bad_url_must_start_with", url_start: "https://youtube.com")
+
+    # Clear the error message by entering a valid url
+    When I fill in t("companies.form.youtube_url") with "https://youtube.com/example"
+    # Need to move to another field in order to get the javascript validation error message to show
+    And I fill in t("companies.form.facebook_url") with "https://facebook.com/example"
+    Then I should not see t("companies.form.bad_url_must_start_with", url_start: "https://youtube.com")
+
+    # Invalid host name
+    When I fill in t("companies.form.youtube_url") with "https://blorf.com/example"
+    # Need to move to another field in order to get the javascript validation error message to show
+    And I fill in t("companies.form.facebook_url") with "https://facebook.com/example"
+    Then I should see t("companies.form.bad_url_must_start_with", url_start: "https://youtube.com")

--- a/features/companies/company-show-social-media-links.feature
+++ b/features/companies/company-show-social-media-links.feature
@@ -14,10 +14,10 @@ Feature: Show social media links for a company
       | admin@shf.se                | true  | true   |
 
     And the following companies exist:
-      | name             | company_number | email                      | facebook_url                | youtube_url                | instagram_url                     |
-      | All Social Media | 2120000142     | hello@all-social-media.com | http://example.com/facebook | http://example.com/youtube | http://example.com/instagram      |
-      | Only Instagram   | 5560360793     | hello@only-instagram.com   |                             |                            | http://example.com/only-instagram |
-      | No Social Media  | 7661057765     | hello@no-social-media.com  |                             |                            |                                   |
+      | name             | company_number | email                      | facebook_url                 | youtube_url                   | instagram_url                     |
+      | All Social Media | 2120000142     | hello@all-social-media.com | https://facebook.com/example | https://youtube.com/mychannel | https://instagram.com/example      |
+      | Only Instagram   | 5560360793     | hello@only-instagram.com   |                              |                               | https://instagram.com/only-instagram |
+      | No Social Media  | 7661057765     | hello@no-social-media.com  |                              |                               |                                   |
 
     And the following applications exist:
       | user_email                  | company_number | state    |
@@ -39,16 +39,16 @@ Feature: Show social media links for a company
   Scenario: Company has all social media urls; all social media icons are shown
     Given I am logged in as "member@all-social-media.com"
     And I am on the page for company number "2120000142"
-    Then I should see an icon with CSS class "fa-facebook" that is linked to "http://example.com/facebook"
-    And I should see an icon with CSS class "fa-youtube" that is linked to "http://example.com/youtube"
-    And I should see an icon with CSS class "fa-instagram" that is linked to "http://example.com/instagram"
+    Then I should see an icon with CSS class "fa-facebook" that is linked to "https://facebook.com/example"
+    And I should see an icon with CSS class "fa-youtube" that is linked to "https://youtube.com/mychannel"
+    And I should see an icon with CSS class "fa-instagram" that is linked to "https://instagram.com/example"
 
   Scenario: Company only has Instagram; only that icon is shown
     Given I am logged in as "member@only-instagram.com"
     And I am on the page for company number "5560360793"
     Then I should not see an icon with CSS class "fa-facebook"
     And I should not see an icon with CSS class "fa-youtube"
-    And I should see an icon with CSS class "fa-instagram" that is linked to "http://example.com/only-instagram"
+    And I should see an icon with CSS class "fa-instagram" that is linked to "https://instagram.com/only-instagram"
 
   Scenario: Company has no social media urls; no social media icons are shown
     Given I am logged in as "member@no-social-media.com"

--- a/features/support/parameter_types.rb
+++ b/features/support/parameter_types.rb
@@ -74,10 +74,13 @@ def parse_i18n_string(i18n_string)
   separator = i18n_string.index(',')
   if separator
     i18n_key = i18n_string[0..separator-1]
-    parameters_array = i18n_string[separator+1..-1].split(',')
+    parameters_array = i18n_string[separator+1..-1].strip.split(',')
 
     parameters_array.each do |e|
-      keyvalue = e.sub(' :', ' ').split(':')
+      keyvalue = e.sub(' :', ' ').split(':', 2)
+      # Only split on the first ':', in case the value string includes a ':'
+      #  Ex:  "url_start: 'http://facebook.com'"
+      #   We don't want to also split on the ':' in the url (http://facebook.com)
       key = keyvalue[0].strip.to_sym
       value = keyvalue[1].strip
 

--- a/public/javascripts/i18n.js
+++ b/public/javascripts/i18n.js
@@ -615,7 +615,7 @@
 
   // This function interpolates the all variables in the given message.
   I18n.interpolate = function(message, options) {
-    if (message === null) {
+    if (message == null) {
       return message;
     }
 
@@ -833,8 +833,12 @@
   //
   I18n.parseDate = function(date) {
     var matches, convertedDate, fraction;
+    // A date input of `null` or `undefined` will be returned as-is
+    if (date == null) {
+      return date;
+    }
     // we have a date, so just return it.
-    if (typeof(date) == "object") {
+    if (typeof(date) === "object") {
       return date;
     }
 
@@ -885,29 +889,30 @@
   //
   // The accepted formats are:
   //
-  //     %a  - The abbreviated weekday name (Sun)
-  //     %A  - The full weekday name (Sunday)
-  //     %b  - The abbreviated month name (Jan)
-  //     %B  - The full month name (January)
-  //     %c  - The preferred local date and time representation
-  //     %d  - Day of the month (01..31)
-  //     %-d - Day of the month (1..31)
-  //     %H  - Hour of the day, 24-hour clock (00..23)
-  //     %-H - Hour of the day, 24-hour clock (0..23)
-  //     %I  - Hour of the day, 12-hour clock (01..12)
-  //     %-I - Hour of the day, 12-hour clock (1..12)
-  //     %m  - Month of the year (01..12)
-  //     %-m - Month of the year (1..12)
-  //     %M  - Minute of the hour (00..59)
-  //     %-M - Minute of the hour (0..59)
-  //     %p  - Meridian indicator (AM  or  PM)
-  //     %S  - Second of the minute (00..60)
-  //     %-S - Second of the minute (0..60)
-  //     %w  - Day of the week (Sunday is 0, 0..6)
-  //     %y  - Year without a century (00..99)
-  //     %-y - Year without a century (0..99)
-  //     %Y  - Year with century
-  //     %z  - Timezone offset (+0545)
+  //     %a     - The abbreviated weekday name (Sun)
+  //     %A     - The full weekday name (Sunday)
+  //     %b     - The abbreviated month name (Jan)
+  //     %B     - The full month name (January)
+  //     %c     - The preferred local date and time representation
+  //     %d     - Day of the month (01..31)
+  //     %-d    - Day of the month (1..31)
+  //     %H     - Hour of the day, 24-hour clock (00..23)
+  //     %-H/%k - Hour of the day, 24-hour clock (0..23)
+  //     %I     - Hour of the day, 12-hour clock (01..12)
+  //     %-I/%l - Hour of the day, 12-hour clock (1..12)
+  //     %m     - Month of the year (01..12)
+  //     %-m    - Month of the year (1..12)
+  //     %M     - Minute of the hour (00..59)
+  //     %-M    - Minute of the hour (0..59)
+  //     %p     - Meridian indicator (AM  or  PM)
+  //     %P     - Meridian indicator (am  or  pm)
+  //     %S     - Second of the minute (00..60)
+  //     %-S    - Second of the minute (0..60)
+  //     %w     - Day of the week (Sunday is 0, 0..6)
+  //     %y     - Year without a century (00..99)
+  //     %-y    - Year without a century (0..99)
+  //     %Y     - Year with century
+  //     %z/%Z  - Timezone offset (+0545)
   //
   I18n.strftime = function(date, format) {
     var options = this.lookup("date")
@@ -956,13 +961,16 @@
     format = format.replace("%-d", day);
     format = format.replace("%H", padding(hour));
     format = format.replace("%-H", hour);
+    format = format.replace("%k", hour);
     format = format.replace("%I", padding(hour12));
     format = format.replace("%-I", hour12);
+    format = format.replace("%l", hour12);
     format = format.replace("%m", padding(month));
     format = format.replace("%-m", month);
     format = format.replace("%M", padding(mins));
     format = format.replace("%-M", mins);
     format = format.replace("%p", meridianOptions[meridian]);
+    format = format.replace("%P", meridianOptions[meridian].toLowerCase());
     format = format.replace("%S", padding(secs));
     format = format.replace("%-S", secs);
     format = format.replace("%w", weekDay);
@@ -970,6 +978,7 @@
     format = format.replace("%-y", padding(year).replace(/^0+/, ""));
     format = format.replace("%Y", year);
     format = format.replace("%z", timezoneoffset);
+    format = format.replace("%Z", timezoneoffset);
 
     return format;
   };
@@ -980,12 +989,18 @@
       , format = this.lookup(scope)
     ;
 
-    if (date.toString().match(/invalid/i)) {
-      return date.toString();
+    // A date input of `null` or `undefined` will be returned as-is
+    if (date == null) {
+      return date;
+    }
+
+    var date_string = date.toString()
+    if (date_string.match(/invalid/i)) {
+      return date_string;
     }
 
     if (!format) {
-      return date.toString();
+      return date_string;
     }
 
     return this.strftime(date, format);


### PR DESCRIPTION
## PT Story: Social Media URL: ensure user enters a full valid URL
#### PT URL: https://www.pivotaltracker.com/story/show/170505205

Start off with these initial, simple validation requirements. We can change the requirements (what we require for a "valid" URL) after these.
- is the wording ok?

Perhaps later we won't require the `http://` at the beginning

**This does not convert any bad URLs**.  We can do a rake task for that (and perhaps end emails to folks) separately.


## Changes proposed in this pull request:
1.  **use the jQuery `jquery-validation` library** to handle the validation on the client side with javascript
    - this is well used, and is pretty easy to use
2. change the cucumber (gherkin) parameter {capture_string} so it can handle a ":" in the value of a key/value pair (like the ":" in "http://....")
3. add feature scenarios for this and update the company edit view

## Screenshots (Optional):

### Close up (cropped) of just the social media fields on the Edit Company page
 - there is an _Example line_ below each field

<img width="894" alt="edit-co-social-media-urls-crop--valid" src="https://user-images.githubusercontent.com/673794/87080013-cbd5b380-c1db-11ea-8cfe-e12cbb430ce0.png">

---

### Error messages that show when a social media URL is not valid
- Facebook URL: invalid because it is not a valid URL (no domain/hostname, no path)
- Instagram URL: invalid because there is no path after the domain (no specific Instagram account name)
- YouTube URL: invalid because the protocol is not  `https:`

<img width="891" alt="edit-co-social-media-urls--invalid" src="https://user-images.githubusercontent.com/673794/87080004-c9735980-c1db-11ea-85a2-8f2e8268e6ed.png">

---
## Ready for review:
@AgileVentures/shf-project-team 
