### PR TITLE
Restore fade in modals; undo PR 812

### DIFF
--- a/app/views/companies/_company_create_modal.html.haml
+++ b/app/views/companies/_company_create_modal.html.haml
@@ -1,4 +1,4 @@
-.modal#company-create-modal{ tabindex: '-1', role: 'dialog' }
+.modal.fade#company-create-modal{ tabindex: '-1', role: 'dialog' }
   .modal-dialog{ role: 'document' }
     .modal-content
       = form_for company, url: companies_path,

--- a/app/views/companies/_edit_branding_modal.html.haml
+++ b/app/views/companies/_edit_branding_modal.html.haml
@@ -1,4 +1,4 @@
-.modal#edit-branding-modal{ tabindex: '-1', role: 'dialog' }
+.modal.fade#edit-branding-modal{ tabindex: '-1', role: 'dialog' }
   .modal-dialog{ role: 'document' }
     .modal-content
 

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -176,7 +176,7 @@ Feature: Create a new membership application
     When I am on the "show my application" page for "applicant_1@random.com"
     And I should see "5560360793, 2120000142"
 
-  @selenium
+  @selenium @skip_ci_test
   Scenario: User creates App with two companies, creates one company, corrects error in company number
     Given I am on the "user instructions" page
     And I click on first t("menus.nav.users.apply_for_membership") link
@@ -226,7 +226,7 @@ Feature: Create a new membership application
     And I should see t("shf_applications.create.success_with_app_files_missing")
 
 
-  @selenium
+  @selenium @skip_ci_test
   Scenario: A user cannot submit a new Membership Application with no category [SAD PATH]
     Given I am on the "user instructions" page
     And I click on first t("menus.nav.users.apply_for_membership") link
@@ -272,7 +272,7 @@ Feature: Create a new membership application
     And the field t("shf_applications.new.phone_number") should not have a required field indicator
     And I should see t("is_required_field")
 
-  @selenium
+  @selenium @skip_ci_test
   Scenario: Two users can submit a new Membership Application (with empty membershipnumbers)
     Given I am on the "user instructions" page
     And I click on first t("menus.nav.users.apply_for_membership") link
@@ -367,44 +367,33 @@ Feature: Create a new membership application
       # | kickiimmi.nu  | 0706898525 |
 
 
-  @selenium
-  Scenario: Apply for membership- New Company- no company number [SAD PATH]
-    Given I am on the "new application" page
 
+
+  @selenium @skip_ci_test
+  Scenario Outline: Apply for membership - when things go wrong with company create [SAD PATH]
+    Given I am on the "new application" page
     And I fill in the translated form with data:
       | shf_applications.new.contact_email | shf_applications.new.phone_number |
       | <c_email>                          | <phone>                           |
 
     And I select files delivery radio button "files_uploaded"
 
-    # Create new company in modal but do not fill in the company number
+    # Create new company in modal
     And I click on t("companies.new.title")
-    And I fill in "company_email" with "kicki@immi.nu"
-    And I click on t("companies.create.create_submit")
-    Then I should see error t("activerecord.attributes.company.company_number") t("errors.messages.blank")
-    And I should receive no emails
-    And "admin@shf.se" should receive no emails
-
-
-  @selenium
-  Scenario: Apply for membership- New Company- no email [SAD PATH]
-    Given I am on the "new application" page
-
     And I fill in the translated form with data:
-      | shf_applications.new.contact_email | shf_applications.new.phone_number |
-      | <c_email>                          | <phone>                           |
+      | companies.show.company_number | companies.show.email |
+      | <c_number>                    | <c_email>            |
 
-    And I select files delivery radio button "files_uploaded"
-
-    # Create new company in modal but do not fill in the company number
-    And I click on t("companies.new.title")
-    And I fill in "company-number-in-modal" with "5562252998"
     And I click on t("companies.create.create_submit")
-    Then I should see error t("activerecord.attributes.company.email") t("errors.messages.invalid")
+
+    Then I should see error <model_attribute> <error>
     And I should receive no emails
     And "admin@shf.se" should receive no emails
 
-
+    Scenarios:
+      | c_number   | c_email       | phone      | model_attribute                                     | error                        |
+      |            | kicki@immi.nu | 0706898525 | t("activerecord.attributes.company.company_number") | t("errors.messages.blank")   |
+      | 5562252998 |               | 0706898525 | t("activerecord.attributes.company.email")          | t("errors.messages.invalid") |
 
 
   Scenario: Apply for membership: company number wrong length (no uploads) [SAD PATH]


### PR DESCRIPTION
## PT Story:  Remove .fade from modals to get features passing (NO: won't do)
#### PT URL:  https://www.pivotaltracker.com/story/show/173668362


## Changes proposed in this pull request:
1.  put CSS `fade` class back into 2 modals where it had been removed
2. revert `create_membership_application.feature`:
   1. revert Scenario "Apply for membership - when things go wrong with company create [SAD PATH]" to a Scenario Outline
   1. put `@skip_ci_test` tags back in to the following scenarios:
      - User creates App with two companies, creates one company, corrects error in company number
      - A user cannot submit a new Membership Application with no category [SAD PATH]
      - Two users can submit a new Membership Application (with empty membershipnumbers)
      - Apply for membership - when things go wrong with company create [SAD PATH]

   Those will intermittently fail again

---
## Ready for review:
@patmbolger 
