### PR TITLE
Fix CodeClimate error with rubocop version 

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,6 +23,7 @@ engines:
     enabled: true
   rubocop:
     enabled: true
+    channel: rubocop-0-75
 ratings:
   paths:
   - Gemfile.lock


### PR DESCRIPTION
## PT Story:  fix codeClimate broken with rubocop
#### PT URL: https://www.pivotaltracker.com/story/show/174304440


## Changes proposed in this pull request:
1.  specify the version of rubocop to use (the "channel"

---
## Ready for review:
@
