### PR TITLE
Sprint100 standardize h1 tags #170006455

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,7 +7,7 @@ module ApplicationHelper
   CSS_CLASS_NO = 'no' unless defined?(CSS_CLASS_NO)
   CSS_CLASS_MAYBE = 'maybe' unless defined?(CSS_CLASS_MAYBE)
   CSS_ADMIN_CLASS = 'is-admin' unless defined?(CSS_ADMIN_CLASS)
-  CSS_PAGE_TITLE_CLASS = 'entry-title'
+  CSS_CONTENT_TITLE_CLASS = 'entry-title'
 
 
   include MetaTagsHelper
@@ -148,7 +148,6 @@ module ApplicationHelper
   # current UTC time in seconds, which will be of little use for CSS styling, but
   # there are no pretty alternatives.
   def unique_css_id(active_record_item)
-
     unique_id = if active_record_item.respond_to?(:id) && active_record_item.id
                   active_record_item.id.to_s
                 else
@@ -293,7 +292,7 @@ module ApplicationHelper
   # @param current_classes [Array[String]] - list of CSS classes
   # @return [Array] - a list of the current_classes with the admin class appended if needed
   def with_admin_css_class_if_needed(user, current_classes = [])
-    user.admin? ? (current_classes << admin_css_class) : current_classes
+    user&.admin? ? (current_classes << admin_css_class) : current_classes
   end
 
 
@@ -320,12 +319,14 @@ module ApplicationHelper
   end
 
   # public method for accessing the CSS class for the main title of a page
-  def page_title_css_class
-    CSS_PAGE_TITLE_CLASS
+  def content_title_css_class
+    CSS_CONTENT_TITLE_CLASS
   end
 
   # public method to render the main title of a page
-  def page_title(title, user)
-    tag.h1 title, class: with_admin_css_class_if_needed(user, [page_title_css_class])
+  def content_title(title, user: nil, id: nil, classes: [])
+    tag.h1 title,
+           class: classes + with_admin_css_class_if_needed(user, [content_title_css_class]),
+           id: id
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,6 +7,7 @@ module ApplicationHelper
   CSS_CLASS_NO = 'no' unless defined?(CSS_CLASS_NO)
   CSS_CLASS_MAYBE = 'maybe' unless defined?(CSS_CLASS_MAYBE)
   CSS_ADMIN_CLASS = 'is-admin' unless defined?(CSS_ADMIN_CLASS)
+  CSS_PAGE_TITLE_CLASS = 'entry-title'
 
 
   include MetaTagsHelper
@@ -318,4 +319,13 @@ module ApplicationHelper
     CSS_CLASS_MAYBE
   end
 
+  # public method for accessing the CSS class for the main title of a page
+  def page_title_css_class
+    CSS_PAGE_TITLE_CLASS
+  end
+
+  # public method to render the main title of a page
+  def page_title(title, user)
+    tag.h1 title, class: with_admin_css_class_if_needed(user, [page_title_css_class])
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -330,8 +330,10 @@ module ApplicationHelper
   end
 
   def user_name_for_display(user)
-    user_name = user&.full_name
-    user_name = user&.email if user_name.blank?
+    return '' unless user
+
+    user_name = user.full_name
+    user_name = user.email if user_name.blank?
     h(user_name)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,6 @@
 require 'meta_image_tags_helper'
 
 module ApplicationHelper
-
   # TODO refactor these and methods to access them into a small module that can be used (e.g. also in the PaymentsHelper)
   CSS_CLASS_YES = 'yes' unless defined?(CSS_CLASS_YES)
   CSS_CLASS_NO = 'no' unless defined?(CSS_CLASS_NO)
@@ -9,11 +8,11 @@ module ApplicationHelper
   CSS_ADMIN_CLASS = 'is-admin' unless defined?(CSS_ADMIN_CLASS)
   CSS_CONTENT_TITLE_CLASS = 'entry-title'
 
-
   include MetaTagsHelper
   include MetaImageTagsHelper
   include ShfIconsHelper
 
+  include ERB::Util # Required to test helpers that use h()
 
   # TODO standardize this method name:  should it end in '_css_class' to make it clear it is not related to Ruby classes?
   def flash_class(level)
@@ -328,5 +327,23 @@ module ApplicationHelper
     tag.h1 title,
            class: classes + with_admin_css_class_if_needed(user, [content_title_css_class]),
            id: id
+  end
+
+  def user_name_for_display(user)
+    user_name = user&.full_name
+    user_name = user&.email if user_name.blank?
+    h(user_name)
+  end
+
+  def show_if_user_is_admin(user, text_if_they_are_admin)
+    user.admin? ? tag.span("#{text_if_they_are_admin}", class: 'small') : ''
+  end
+
+  def edit_account_link(user, url: admin_only_edit_user_account_path(user), text: user_account_icon, title: '', show_if: true)
+    show_if ? link_to(text, url, class: ['shf-icon', 'edit-user-account-icon'], title: title) : ''
+  end
+
+  def edit_profile_link(user, url: admin_only_user_profile_edit_path(user), text: user_profile_icon, title: '', show_if: true)
+    show_if ? link_to(text, url, class: ['shf-icon', 'edit-user-profile-icon'], title: title) : ''
   end
 end

--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title', company_name: @company.name)
+  = content_title(t('.title', company_name: @company.name), user: current_user)
 
 .entry-content
   = render partial: 'form',

--- a/app/views/addresses/new.html.haml
+++ b/app/views/addresses/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title', company_name: @company.name)
+  = content_title(t('.title', company_name: @company.name), user: current_user)
 .entry-content
   = render partial: 'form',
            locals: { address: @address, method: :post,

--- a/app/views/admin_only/app_configuration/_show_action_buttons.html.haml
+++ b/app/views/admin_only/app_configuration/_show_action_buttons.html.haml
@@ -4,4 +4,3 @@
 %hr
 .text-center
   = link_to "#{t('edit')} #{t('admin_only.app_configuration.show.title')}", admin_only_edit_app_configuration_path, class:'btn btn-light btn-sm'
-  

--- a/app/views/admin_only/app_configuration/edit.html.haml
+++ b/app/views/admin_only/app_configuration/edit.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('edit') + ' ' + t('.title')
+  = content_title(t('edit') + ' ' + t('.title'), user: current_user)
 
 .entry-content
 

--- a/app/views/admin_only/app_configuration/show.html.haml
+++ b/app/views/admin_only/app_configuration/show.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 
 .entry-content
 

--- a/app/views/admin_only/dashboard/index.html.haml
+++ b/app/views/admin_only/dashboard/index.html.haml
@@ -1,7 +1,7 @@
 -# FIXME - don't load all of the tabs at once!  make each tab a (routed) page and only load it when requested
 - i18n_scope = 'admin_only.dashboard'
 %header.entry-header
-  %h1.entry-title= t('title', scope: i18n_scope)
+  = content_title(t('title', scope: i18n_scope), user: current_user)
 .post-title-divider
   %span
 

--- a/app/views/admin_only/design_guide/show.html.haml
+++ b/app/views/admin_only/design_guide/show.html.haml
@@ -57,7 +57,7 @@
 #design-guide{ class: "#{controller.action_name}" }
 
   %header.entry-header
-    %h1.entry-title Design Guide: Element Examples
+    = content_title('Design Guide: Element Examples', user: current_user)
 
   .entry-content
     .row

--- a/app/views/admin_only/master_checklist_types/edit.html.haml
+++ b/app/views/admin_only/master_checklist_types/edit.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title', name: @admin_only_master_checklist_type.name)
+  = content_title(t('.title', name: @admin_only_master_checklist_type.name), user: current_user)
 
 .entry-content
   = render 'form'

--- a/app/views/admin_only/master_checklist_types/index.html.haml
+++ b/app/views/admin_only/master_checklist_types/index.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 
 .entry-content
 

--- a/app/views/admin_only/master_checklist_types/new.html.haml
+++ b/app/views/admin_only/master_checklist_types/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 
 .entry-content
   = render 'form'

--- a/app/views/admin_only/master_checklist_types/show.html.haml
+++ b/app/views/admin_only/master_checklist_types/show.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= @admin_only_master_checklist_type.name
+  = content_title(@admin_only_master_checklist_type.name, user: current_user)
 
 .entry-content.container-fluid
 

--- a/app/views/admin_only/master_checklists/edit.html.haml
+++ b/app/views/admin_only/master_checklists/edit.html.haml
@@ -2,7 +2,7 @@
 -  no_more_changes_class = @master_checklist.no_more_major_changes? ? 'no-more-major-changes' : ''
 
 %header.entry-header
-  %h1.entry-title{ class: @master_checklist.is_in_use ? '' : 'not-in-use' }= @master_checklist.name
+  = content_title(@master_checklist.name, user: current_user, classes: @master_checklist.is_in_use ? [] : ['not-in-use'])
 
 .entry-content.container{ class: "#{ no_more_changes_class }" }
   .master-checklist-item

--- a/app/views/admin_only/master_checklists/index.html.haml
+++ b/app/views/admin_only/master_checklists/index.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 
 .entry-content
   #master-list-items

--- a/app/views/admin_only/master_checklists/index_as_table.html.haml
+++ b/app/views/admin_only/master_checklists/index_as_table.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 
 .entry-content
   - name_length = 90

--- a/app/views/admin_only/master_checklists/new.html.haml
+++ b/app/views/admin_only/master_checklists/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 
 .entry-content
   = render 'form', locals: { master_checklist: @master_checklist,

--- a/app/views/admin_only/master_checklists/show.html.haml
+++ b/app/views/admin_only/master_checklists/show.html.haml
@@ -3,7 +3,7 @@
 - no_more_changes_class = @master_checklist.no_more_major_changes? ? 'no-more-major-changes' : ''
 
 %header.entry-header
-  = content_title(@master_checklist.name, user: current_user, id: 'h1', classes: [ '#{not_in_use_class}' ]
+  = content_title(@master_checklist.name, user: current_user, id: 'h1', classes: [ '#{not_in_use_class}' ])
   - if @master_checklist.root?
     .entry-content
       .row.mt-2

--- a/app/views/admin_only/master_checklists/show.html.haml
+++ b/app/views/admin_only/master_checklists/show.html.haml
@@ -3,7 +3,7 @@
 - no_more_changes_class = @master_checklist.no_more_major_changes? ? 'no-more-major-changes' : ''
 
 %header.entry-header
-  %h1.entry-title#h1{ class: "#{ not_in_use_class }" }= @master_checklist.name
+  = content_title(@master_checklist.name, user: current_user, id: 'h1', classes: [ '#{not_in_use_class}' ]
   - if @master_checklist.root?
     .entry-content
       .row.mt-2

--- a/app/views/admin_only/member_app_waiting_reasons/edit.html.haml
+++ b/app/views/admin_only/member_app_waiting_reasons/edit.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title', name_sv: @member_app_waiting_reason.name_sv, name_en: @member_app_waiting_reason.name_en  )
+   = content_title(t('.title', name_sv: @member_app_waiting_reason.name_sv, name_en: @member_app_waiting_reason.name_en), user: current_user)
 
 .entry-content
   = render 'form'

--- a/app/views/admin_only/member_app_waiting_reasons/edit.html.haml
+++ b/app/views/admin_only/member_app_waiting_reasons/edit.html.haml
@@ -1,10 +1,10 @@
 %header.entry-header
-   = content_title(t('.title', name_sv: @member_app_waiting_reason.name_sv, name_en: @member_app_waiting_reason.name_en), user: current_user)
+  = content_title(t('.title', name_sv: @member_app_waiting_reason.name_sv, name_en: @member_app_waiting_reason.name_en), user: current_user)
 
 .entry-content
   = render 'form'
   %hr.mt-5
   .text-center
     = link_to t('admin_only.member_app_waiting_reasons.all_member_app_waiting_reasons'), admin_only_member_app_waiting_reasons_path,
-        class: 'btn btn-light btn-sm all-member-app-waiting-reasons',
+      class: 'btn btn-light btn-sm all-member-app-waiting-reasons',
         id: 'all-member-app-waiting-reasons'

--- a/app/views/admin_only/member_app_waiting_reasons/index.html.haml
+++ b/app/views/admin_only/member_app_waiting_reasons/index.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 
 .entry-content
 

--- a/app/views/admin_only/member_app_waiting_reasons/new.html.haml
+++ b/app/views/admin_only/member_app_waiting_reasons/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 
 .entry-content
   = render 'form'

--- a/app/views/admin_only/member_app_waiting_reasons/show.html.haml
+++ b/app/views/admin_only/member_app_waiting_reasons/show.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  = content_title(t('.title', name_sv: @member_app_waiting_reason.name_sv, name_en: @member_app_waiting_reason.name_en), user: current_user) 
+  = content_title(t('.title', name_sv: @member_app_waiting_reason.name_sv, name_en: @member_app_waiting_reason.name_en), user: current_user)
 
 .entry-content
   .row

--- a/app/views/admin_only/member_app_waiting_reasons/show.html.haml
+++ b/app/views/admin_only/member_app_waiting_reasons/show.html.haml
@@ -1,6 +1,5 @@
 %header.entry-header
-  %h1.entry-title
-    = t('.title', name_sv: @member_app_waiting_reason.name_sv, name_en: @member_app_waiting_reason.name_en  )
+  = content_title(t('.title', name_sv: @member_app_waiting_reason.name_sv, name_en: @member_app_waiting_reason.name_en), user: current_user) 
 
 .entry-content
   .row

--- a/app/views/admin_only/user_account/edit.html.haml
+++ b/app/views/admin_only/user_account/edit.html.haml
@@ -2,10 +2,11 @@
   = stylesheet_link_tag 'image-actions-custom-menu', media: 'all'
 
 %header.entry-header
-  - username          = user_name_for_display(@user)
-  - admin_user_text   = show_if_user_is_admin(@user, t('.is_an_admin'))
-  - edit_profile_icon = edit_profile_link(@user, title: t('.edit_user_profile', name: username))
-  - title             = username + ' ' + ' ' + admin_user_text + ' ' + edit_profile_icon
+  :ruby
+    username          = user_name_for_display(@user)
+    admin_user_text   = show_if_user_is_admin(@user, t('.is_an_admin'))
+    edit_profile_icon = edit_profile_link(@user, title: t('.edit_user_profile', name: username))
+    title             = username + ' ' + ' ' + admin_user_text + ' ' + edit_profile_icon
   = content_title(title, user: current_user)
 
 .entry-content.container

--- a/app/views/admin_only/user_account/edit.html.haml
+++ b/app/views/admin_only/user_account/edit.html.haml
@@ -3,17 +3,14 @@
 
 %header.entry-header
   - user_name = @user.full_name
-
-  %h1{ class: with_admin_css_class_if_needed(@current_user, ['entry-title']) }
-    = user_name.empty? ? @user.email : user_name
-    - if @user.admin?
-      %span.small
-        (#{ t('.is_an_admin') })
-    = link_to user_profile_icon, admin_only_user_profile_edit_path(@user), class: ['shf-icon', 'edit-profile-icon'], title: t('.edit_user_profile', name: user_name)
-
+  - title_escaped = h(user_name.empty? ? @user.email : user_name)
+  - title_html_safe = link_to(user_profile_icon, admin_only_user_profile_edit_path(@user), class: ['shf-icon', 'edit-profile-icon'], title: t('.edit_user_profile', name: user_name))
+  - if @user.admin?
+    - title_html_safe =  tag.span(" (#{t('.is_an_admin')})", class: 'small') + ' ' + title_html_safe
+  - title = (title_escaped + title_html_safe).html_safe
+  = content_title(title, user: @current_user)
 
 .entry-content.container
-
   = form_for(@user, as: :user, url: admin_only_user_account_path(@user) ) do |f|
 
     != model_errors_helper(@user)

--- a/app/views/admin_only/user_account/edit.html.haml
+++ b/app/views/admin_only/user_account/edit.html.haml
@@ -2,13 +2,11 @@
   = stylesheet_link_tag 'image-actions-custom-menu', media: 'all'
 
 %header.entry-header
-  - user_name = @user.full_name
-  - title_escaped = h(user_name.empty? ? @user.email : user_name)
-  - title_html_safe = link_to(user_profile_icon, admin_only_user_profile_edit_path(@user), class: ['shf-icon', 'edit-profile-icon'], title: t('.edit_user_profile', name: user_name))
-  - if @user.admin?
-    - title_html_safe =  tag.span(" (#{t('.is_an_admin')})", class: 'small') + ' ' + title_html_safe
-  - title = (title_escaped + title_html_safe).html_safe
-  = content_title(title, user: @current_user)
+  - username          = user_name_for_display(@user)
+  - admin_user_text   = show_if_user_is_admin(@user, t('.is_an_admin'))
+  - edit_profile_icon = edit_profile_link(@user, title: t('.edit_user_profile', name: username))
+  - title             = username + ' ' + ' ' + admin_user_text + ' ' + edit_profile_icon
+  = content_title(title, user: current_user)
 
 .entry-content.container
   = form_for(@user, as: :user, url: admin_only_user_account_path(@user) ) do |f|

--- a/app/views/business_categories/edit.html.haml
+++ b/app/views/business_categories/edit.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title', category_name: @business_category.name)
+  = content_title(t('.title', category_name: @business_category.name), user: current_user)
 .entry-content
   = render 'form'
   

--- a/app/views/business_categories/edit.html.haml
+++ b/app/views/business_categories/edit.html.haml
@@ -2,4 +2,3 @@
   = content_title(t('.title', category_name: @business_category.name), user: current_user)
 .entry-content
   = render 'form'
-  

--- a/app/views/business_categories/index.html.haml
+++ b/app/views/business_categories/index.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 .entry-content
   .table-responsive
     %table.table.table-hover.table-sm#business_categories

--- a/app/views/business_categories/new.html.haml
+++ b/app/views/business_categories/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 .entry-content
   = render 'form'
   %hr

--- a/app/views/business_categories/show.html.haml
+++ b/app/views/business_categories/show.html.haml
@@ -1,7 +1,5 @@
 %header.entry-header
-  %h1.entry-title
-    = t('.title')
-    = @business_category.name
+  = content_title(t('.title') + @business_category.name, user: current_user)
 .entry-content
   - unless @business_category.description.nil?
     %p

--- a/app/views/companies/edit.html.haml
+++ b/app/views/companies/edit.html.haml
@@ -2,7 +2,7 @@
   = javascript_include_tag Ckeditor.cdn_url
 
 %header.entry-header
-  %h1.entry-title= t('.title', company_name: @company.name)
+  = content_title(t('.title', company_name: @company.name), user: current_user)
   .text-center
     - unless association_empty?(@all_business_categories)
       = render 'business_categories/as_list',

--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -1,9 +1,5 @@
 %header.entry-header
-  - unless current_user.admin?
-    %h1.entry-title= t('.title')
-  - if current_user.admin?
-    %h1.entry-title= t('.admin_title')
-
+  = content_title(current_user.admin? ? t('.admin_title') : t('.title'), user: current_user)
 .entry-content
   .row
     .col-lg-4#companies_map

--- a/app/views/companies/new.html.haml
+++ b/app/views/companies/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 .entry-content
   = render 'form', class_name: 'new-company'
   .text-center

--- a/app/views/companies/show.html.haml
+++ b/app/views/companies/show.html.haml
@@ -6,7 +6,7 @@
       class: "#{item_view_class(@company, controller.action_name)}" }
 
   %header.entry-header
-    %h1.entry-title= @company.name
+    = content_title(@company.name, user: current_user)
   .entry-content.container
     .row
       .col

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 .post-title-divider
   %span
 .entry-content.wpcf7

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 .post-title-divider
   %span
 .entry-content.wpcf7

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 .entry-content
   = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
 

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 .entry-content
   = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
     .form-group

--- a/app/views/payments/create.html.haml
+++ b/app/views/payments/create.html.haml
@@ -2,10 +2,8 @@
   = javascript_include_tag HIPS_JS_CDN
 
 %header.entry-header
-  %h1.entry-title
-    - payment_type = t("payment.payment_type.#{@payment.payment_type}")
-    = t('.title', payment_type: payment_type, user_name: @payment.user.full_name)
-
+  - payment_type = t("payment.payment_type.#{@payment.payment_type}")
+  = content_title(t('.title', payment_type: payment_type, user_name: @payment.user.full_name))
   .post-title-divider
     %span
 

--- a/app/views/shf_applications/edit.html.haml
+++ b/app/views/shf_applications/edit.html.haml
@@ -1,7 +1,7 @@
 %div{ :id => "#{unique_css_id(@shf_application)}", class: "#{item_view_class(@shf_application, controller.action_name)}" }
 
   %header.entry-header
-    %h1.entry-title= t('.title')
+    = content_title(t('.title'), user: current_user)
   .entry-content
     .instructions= t('shf_applications.new.instructions_html')
 

--- a/app/views/shf_applications/index.html.haml
+++ b/app/views/shf_applications/index.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 .entry-content
   .row
     .col-6

--- a/app/views/shf_applications/information.html.haml
+++ b/app/views/shf_applications/information.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
   .post-title-divider
     %span
 .entry-content

--- a/app/views/shf_applications/new.html.haml
+++ b/app/views/shf_applications/new.html.haml
@@ -1,7 +1,7 @@
 %div{ :id => "#{@shf_application.class.name.downcase}", class: "new-item #{@shf_application.class.name.downcase}" }
 
   %header.entry-header
-    %h1.entry-title= t('.title')
+    = content_title(t('.title'), user: current_user)
   .entry-content
     .instructions= t('shf_applications.new.instructions_html')
 

--- a/app/views/shf_applications/show.html.haml
+++ b/app/views/shf_applications/show.html.haml
@@ -1,7 +1,7 @@
 %div{ :id => "#{unique_css_id(@shf_application)}", class: "#{item_view_class(@shf_application, controller.action_name)}" }
 
   %header.entry-header
-    %h1.entry-title= t('.title', user_full_name: @shf_application.user.full_name)
+    = content_title(t('.title', user_full_name: @shf_application.user.full_name), user: current_user)
   .entry-content.container-fluid
     .row
       .col

--- a/app/views/shf_documents/contents_edit.html.haml
+++ b/app/views/shf_documents/contents_edit.html.haml
@@ -2,7 +2,7 @@
   = javascript_include_tag Ckeditor.cdn_url
 
 %header.entry-header
-  %h1.entry-title= t('.page_title', document_title: @page)
+  = content_title(t('.page_title', document_title: @page), user: current_user)
 
 .entry-content
   = render 'contents_form'

--- a/app/views/shf_documents/contents_show.html.haml
+++ b/app/views/shf_documents/contents_show.html.haml
@@ -1,8 +1,7 @@
 .shf-document.show#shf-document
 
   %header.entry-header
-    %h1.entry-title
-      = @title
+    = content_title(@title, user: current_user)
   .entry-content
     - if policy(ShfDocument).contents_update?
       = link_to "#{t('.edit_member_page')}",

--- a/app/views/shf_documents/edit.html.haml
+++ b/app/views/shf_documents/edit.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.page_title', document_title: @shf_document.title)
+  = content_title(t('.page_title', document_title: @shf_document.title))
 
 .entry-content
   = render 'form'

--- a/app/views/shf_documents/index.html.haml
+++ b/app/views/shf_documents/index.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.page_title')
+  = content_title(t('.page_title'), user: current_user)
 
 .entry-content
 

--- a/app/views/shf_documents/minutes_and_static_pages.html.haml
+++ b/app/views/shf_documents/minutes_and_static_pages.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.member_pages')
+  = content_title(t('.member_pages'), user: current_user)
 
 .entry-content
   = render partial: 'documents_list', locals: { ul_class: '', li_class: '' }

--- a/app/views/shf_documents/new.html.haml
+++ b/app/views/shf_documents/new.html.haml
@@ -1,7 +1,7 @@
 .shf-document.new#shf-document-new
 
   %header.entry-header
-    %h1.entry-title= t('.page_title')
+    = content_title(t('.page_title'), user: current_user)
 
   .entry-content
 

--- a/app/views/shf_documents/show.html.haml
+++ b/app/views/shf_documents/show.html.haml
@@ -2,7 +2,7 @@
 .shf-document.show#shf-document
 
   %header.entry-header
-    %h1.entry-title= @shf_document.title
+    = content_title(@shf_document.title, user: current_user)
 
   .entry-content
 

--- a/app/views/user_checklists/_checklist_header.html.haml
+++ b/app/views/user_checklists/_checklist_header.html.haml
@@ -3,5 +3,4 @@
   user_checklist [UserChecklist] - the checklist that will be displayed in the header
 
 %header.entry-header
-  %h1{ class: with_admin_css_class_if_needed(current_user, ['entry-title']) }
-    = user_checklist.name
+  = content_title(user_checklist.name, user: current_user)

--- a/app/views/user_checklists/index.html.haml
+++ b/app/views/user_checklists/index.html.haml
@@ -13,7 +13,7 @@
 
 
 %header.entry-header
-  %h1{ class: with_admin_css_class_if_needed(@current_user, ['entry-title']) }=  t('.title', name: @user.full_name)
+  = content_title(t('.title', name: @user.full_name), user: @current_user)
 
 .entry-content
   #user-checklists

--- a/app/views/user_profiles/_edit.html.haml
+++ b/app/views/user_profiles/_edit.html.haml
@@ -5,22 +5,20 @@
 
 - i18n_scope = 'devise.registrations.edit'
 - editor_is_current_user = user == current_user
-- admin_is_editting_their_profile = current_user.admin? && editor_is_current_user
-- admin_is_editting_another_profile = current_user.admin? && !editor_is_current_user
+- admin_is_editing_their_profile = current_user.admin? && editor_is_current_user
+- admin_is_editing_another_profile = current_user.admin? && !editor_is_current_user
 
 %header.entry-header
   - title_t_key = (editor_is_current_user ? 'my_profile_title' : 'edit_profile_for_title')
-  - title = t(title_t_key, scope: i18n_scope, user: user.full_name)
-  %h1.entry-title{ class: with_admin_css_class_if_needed(current_user, ['entry-title']) }
-    = title
-    - if admin_is_editting_another_profile
-      = link_to user_account_icon, @user, class: ['shf-icon', 'edit-user-account-icon'], title: t('.edit_user_account', name: user.full_name)
+  - title_html_safe = h(t(title_t_key, scope: i18n_scope, user: user.full_name))
+  - if admin_is_editing_another_profile
+    - title_html_safe = title_html_safe + ' ' + link_to(user_account_icon, @user, class: ['shf-icon', 'edit-user-account-icon'], title: h(t('.edit_user_account', name: user.full_name)))
+  = content_title(title_html_safe.html_safe, user: current_user)
 
 .entry-content.container
 
   = form_for(user, as: :user, url: form_submit_url, html: { method: :put }) do |f|
     != model_errors_helper(user)
-
     = render partial: 'devise/shared/member_photo', locals: { user: user, f: f }
 
     %h3= t('info_header', scope: i18n_scope )
@@ -44,7 +42,7 @@
           = app_form.label :contact_email
           = app_form.email_field :contact_email, placeholder: "#{t('activerecord.attributes.shf_application.contact_email')}", class: 'form-control'
 
-    - if admin_is_editting_another_profile
+    - if admin_is_editing_another_profile
       .row
         .form-group.col-sm
           = f.label :membership_number

--- a/app/views/user_profiles/_edit.html.haml
+++ b/app/views/user_profiles/_edit.html.haml
@@ -3,16 +3,18 @@
 =#  current_user - the User viewing this (might be an admin, for example)
 -#  form_submit_url - the url used by the form when it is submitted
 
-- i18n_scope = 'devise.registrations.edit'
-- editor_is_current_user = user == current_user
-- admin_is_editing_their_profile = current_user.admin? && editor_is_current_user
-- admin_is_editing_another_profile = current_user.admin? && !editor_is_current_user
+:ruby
+  i18n_scope = 'devise.registrations.edit'
+  editor_is_current_user = user == current_user
+  admin_is_editing_their_profile = current_user.admin? && editor_is_current_user
+  admin_is_editing_another_profile = current_user.admin? && !editor_is_current_user
 
 %header.entry-header
-  - username          = user_name_for_display(user)
-  - base_title        = t(editor_is_current_user ? 'my_profile_title' : 'edit_profile_for_title', scope: i18n_scope, user: username)
-  - edit_account_icon = edit_account_link(user, title: t('.edit_user_account', name: username), show_if: admin_is_editing_another_profile)
-  - title             = h(base_title) + ' ' + edit_account_icon
+  :ruby
+    username          = user_name_for_display(user)
+    base_title        = t(editor_is_current_user ? 'my_profile_title' : 'edit_profile_for_title', scope: i18n_scope, user: username)
+    edit_account_icon = edit_account_link(user, title: t('.edit_user_account', name: username), show_if: admin_is_editing_another_profile)
+    title             = h(base_title) + ' ' + edit_account_icon
   = content_title(title, user: current_user)
 
 .entry-content.container

--- a/app/views/user_profiles/_edit.html.haml
+++ b/app/views/user_profiles/_edit.html.haml
@@ -9,14 +9,13 @@
 - admin_is_editing_another_profile = current_user.admin? && !editor_is_current_user
 
 %header.entry-header
-  - title_t_key = (editor_is_current_user ? 'my_profile_title' : 'edit_profile_for_title')
-  - title_html_safe = h(t(title_t_key, scope: i18n_scope, user: user.full_name))
-  - if admin_is_editing_another_profile
-    - title_html_safe = title_html_safe + ' ' + link_to(user_account_icon, user, class: ['shf-icon', 'edit-user-account-icon'], title: h(t('.edit_user_account', name: user.full_name)))
-  = content_title(title_html_safe.html_safe, user: current_user)
+  - username          = user_name_for_display(user)
+  - base_title        = t(editor_is_current_user ? 'my_profile_title' : 'edit_profile_for_title', scope: i18n_scope, user: username)
+  - edit_account_icon = edit_account_link(user, title: t('.edit_user_account', name: username), show_if: admin_is_editing_another_profile)
+  - title             = h(base_title) + ' ' + edit_account_icon
+  = content_title(title, user: current_user)
 
 .entry-content.container
-
   = form_for(user, as: :user, url: form_submit_url, html: { method: :put }) do |f|
     != model_errors_helper(user)
     = render partial: 'devise/shared/member_photo', locals: { user: user, f: f }

--- a/app/views/user_profiles/_edit.html.haml
+++ b/app/views/user_profiles/_edit.html.haml
@@ -12,7 +12,7 @@
   - title_t_key = (editor_is_current_user ? 'my_profile_title' : 'edit_profile_for_title')
   - title_html_safe = h(t(title_t_key, scope: i18n_scope, user: user.full_name))
   - if admin_is_editing_another_profile
-    - title_html_safe = title_html_safe + ' ' + link_to(user_account_icon, @user, class: ['shf-icon', 'edit-user-account-icon'], title: h(t('.edit_user_account', name: user.full_name)))
+    - title_html_safe = title_html_safe + ' ' + link_to(user_account_icon, user, class: ['shf-icon', 'edit-user-account-icon'], title: h(t('.edit_user_account', name: user.full_name)))
   = content_title(title_html_safe.html_safe, user: current_user)
 
 .entry-content.container

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,5 +1,5 @@
 %header.entry-header
-  %h1.entry-title= t('.title')
+  = content_title(t('.title'), user: current_user)
 .entry-content
   = render partial: 'search_form',
            locals: { search_params: @q,

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,9 +1,10 @@
 %header.entry-header
-  - username          = user_name_for_display(@user)
-  - admin_user_text   = show_if_user_is_admin(@user, t('.is_an_admin'))
-  - edit_account_icon = edit_account_link(@user, text: edit_icon, title: t('.edit_user_account', name: username), show_if: current_user.admin?)
-  - edit_profile_icon = edit_profile_link(@user, title: t('.edit_user_profile', name: username), show_if: current_user.admin?)
-  - title             = username + ' ' + admin_user_text + ' ' + edit_account_icon + ' ' + edit_profile_icon
+  :ruby
+    username          = user_name_for_display(@user)
+    admin_user_text   = show_if_user_is_admin(@user, t('.is_an_admin'))
+    edit_account_icon = edit_account_link(@user, text: edit_icon, title: t('.edit_user_account', name: username), show_if: current_user.admin?)
+    edit_profile_icon = edit_profile_link(@user, title: t('.edit_user_profile', name: username), show_if: current_user.admin?)
+    title             = username + ' ' + admin_user_text + ' ' + edit_account_icon + ' ' + edit_profile_icon
   = content_title(title, user: current_user)
 
 .entry-content.container

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,14 +1,14 @@
 %header.entry-header
   - user_name = @user.full_name
-  %h1{ class: with_admin_css_class_if_needed(@current_user, ['entry-title']) }
-    = user_name.empty? ? @user.email : user_name
-    - if @user.admin?
-      %span.small
-        (#{ t('.is_an_admin') })
-
-    - if @current_user.admin?
-      = link_to edit_icon, admin_only_edit_user_account_path(@user), class: ['shf-icon', 'edit-user-account-icon'], title: t('.edit_user_account', name: user_name)
-      = link_to user_profile_icon, admin_only_user_profile_edit_path(@user), class: ['shf-icon', 'edit-user-profile-icon'], title: t('.edit_user_profile', name: user_name)
+  - title_escaped = h(user_name.empty? ? @user.email : user_name)
+  - title_html_safe = ''
+  - if @user.admin?
+    - title_html_safe << tag.span(" (#{ t('.is_an_admin') })", class: 'small')
+  - if @current_user.admin?
+    - title_html_safe << ' ' + link_to(edit_icon, admin_only_edit_user_account_path(@user), class: ['shf-icon', 'edit-user-account-icon'], title: h(t('.edit_user_account', name: user_name)))
+    - title_html_safe << ' ' + link_to(user_profile_icon, admin_only_user_profile_edit_path(@user), class: ['shf-icon', 'edit-user-profile-icon'], title: h(t('.edit_user_profile', name: user_name)))
+  - title = title_escaped.html_safe + title_html_safe.html_safe
+  = content_title(title, user: @current_user)
 
 
 .entry-content.container

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,15 +1,10 @@
 %header.entry-header
-  - user_name = @user.full_name
-  - title_escaped = h(user_name.empty? ? @user.email : user_name)
-  - title_html_safe = ''
-  - if @user.admin?
-    - title_html_safe << tag.span(" (#{ t('.is_an_admin') })", class: 'small')
-  - if @current_user.admin?
-    - title_html_safe << ' ' + link_to(edit_icon, admin_only_edit_user_account_path(@user), class: ['shf-icon', 'edit-user-account-icon'], title: h(t('.edit_user_account', name: user_name)))
-    - title_html_safe << ' ' + link_to(user_profile_icon, admin_only_user_profile_edit_path(@user), class: ['shf-icon', 'edit-user-profile-icon'], title: h(t('.edit_user_profile', name: user_name)))
-  - title = title_escaped.html_safe + title_html_safe.html_safe
-  = content_title(title, user: @current_user)
-
+  - username          = user_name_for_display(@user)
+  - admin_user_text   = show_if_user_is_admin(@user, t('.is_an_admin'))
+  - edit_account_icon = edit_account_link(@user, text: edit_icon, title: t('.edit_user_account', name: username), show_if: current_user.admin?)
+  - edit_profile_icon = edit_profile_link(@user, title: t('.edit_user_profile', name: username), show_if: current_user.admin?)
+  - title             = username + ' ' + admin_user_text + ' ' + edit_account_icon + ' ' + edit_profile_icon
+  = content_title(title, user: current_user)
 
 .entry-content.container
   - if @user.member?

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -501,4 +501,20 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe '#page_title' do
+    let(:user) { build_stubbed(:user) }
+    let(:title) { 'Title!' }
+
+    it 'renders the page title' do
+      expect(page_title(title, user)).to include(title)
+    end
+
+    it 'uses the appropriate css class for non-admins' do
+      expect(page_title(title, user)).to include(page_title_css_class)
+    end
+
+    it 'also uses the appropriate css class for non-admins' do
+      expect(page_title(title, build_stubbed(:admin))).to include(page_title_css_class, admin_css_class)
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -501,20 +501,28 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#page_title' do
+  describe '#content_title' do
     let(:user) { build_stubbed(:user) }
     let(:title) { 'Title!' }
 
     it 'renders the page title' do
-      expect(page_title(title, user)).to include(title)
+      expect(content_title(title)).to include(title)
     end
 
-    it 'uses the appropriate css class for non-admins' do
-      expect(page_title(title, user)).to include(page_title_css_class)
+    it 'uses the appropriate default css class' do
+      expect(content_title(title, user: user)).to include(content_title_css_class)
     end
 
-    it 'also uses the appropriate css class for non-admins' do
-      expect(page_title(title, build_stubbed(:admin))).to include(page_title_css_class, admin_css_class)
+    it 'also uses the appropriate css class if an admin user is specified' do
+      expect(content_title(title, user: build_stubbed(:admin))).to include(content_title_css_class, admin_css_class)
+    end
+
+    it 'allows to add extra class names' do
+      expect(content_title(title, classes: ['custom-class'])).to include(content_title_css_class, 'custom-class')
+    end
+
+    it 'allows to set the title element id' do
+      expect(content_title(title, id: 'ID')).to include('id="ID"')
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -525,4 +525,47 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(content_title(title, id: 'ID')).to include('id="ID"')
     end
   end
+
+  describe '#user_name_for_display' do
+    include ERB::Util # Required by the helper to work in RSpec context
+    it 'returns an empty string if the user is nil' do
+      expect(user_name_for_display(nil)).to eq ''
+    end
+
+    it 'returns the user name and surname if either or both are present' do
+      expect(user_name_for_display(user)).to include(user.first_name, user.last_name)
+    end
+
+    it 'returns the user email if the user has no first or last name' do
+      user = build_stubbed(:user, first_name: nil, last_name: nil, email: 'a@b.c')
+      expect(user_name_for_display(user)).to eq 'a@b.c'
+    end
+  end
+
+  describe '#show_if_user_is_admin' do
+    it 'renders a text informing that the user is an admin if they are' do
+      admin = build_stubbed(:admin)
+      expect(show_if_user_is_admin(admin, 'admin!')).to include('admin!')
+    end
+
+    it 'it returns an empty string for non-admin users' do
+      expect(show_if_user_is_admin(user, 'admin!')).to be_blank
+    end
+  end
+
+  describe '#edit_profile_link' do
+    it 'renders links to see and edit a user profile' do
+      expect(edit_profile_link(user, text: '---', title: '---')).to include('edit', 'profile')
+    end
+  end
+
+  describe '#edit_account_link' do
+    it 'renders links to see and edit a user profile' do
+      expect(edit_account_link(user, text: '---', title: '---')).to include('edit', 'account')
+    end
+
+    it 'accepts an option to only render on a condition' do
+      expect(edit_account_link(user, text: '---', title: '---', show_if: false)).to eq ''
+    end
+  end
 end


### PR DESCRIPTION
## PT Story: 
#### PT URL:

https://www.pivotaltracker.com/story/show/170006455

## Changes proposed in this pull request

1. Standardize all page `h1` tags by using a helper method

## Screenshots (Optional):
