### PR TITLE
Removed back button links from all related files

### DIFF
--- a/app/views/admin_only/app_configuration/_edit_action_buttons.html.haml
+++ b/app/views/admin_only/app_configuration/_edit_action_buttons.html.haml
@@ -1,3 +1,3 @@
-%hr
-.text-center
-  = link_to "#{t('back')}", :back, class: 'btn btn-light btn-sm'
+/ %hr
+/ .text-center
+/   = link_to "#{t('back')}", :back, class: 'btn btn-light btn-sm'

--- a/app/views/admin_only/app_configuration/_show_action_buttons.html.haml
+++ b/app/views/admin_only/app_configuration/_show_action_buttons.html.haml
@@ -4,4 +4,4 @@
 %hr
 .text-center
   = link_to "#{t('edit')} #{t('admin_only.app_configuration.show.title')}", admin_only_edit_app_configuration_path, class:'btn btn-light btn-sm'
-  = link_to "#{t('back')}", :back, class: 'btn btn-light btn-sm'
+  

--- a/app/views/business_categories/edit.html.haml
+++ b/app/views/business_categories/edit.html.haml
@@ -2,6 +2,4 @@
   %h1.entry-title= t('.title', category_name: @business_category.name)
 .entry-content
   = render 'form'
-  %hr
-  .text-center
-    = link_to t('back'), business_categories_path, class: 'btn btn-sm btn-light'
+  

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -9,23 +9,9 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
 -- Name: addresses; Type: TABLE; Schema: public; Owner: -
@@ -102,7 +88,7 @@ CREATE TABLE public.app_configurations (
     site_meta_image_height integer DEFAULT 0 NOT NULL,
     og_type character varying DEFAULT 'website'::character varying NOT NULL,
     twitter_card_type character varying DEFAULT 'summary'::character varying NOT NULL,
-    facebook_app_id bigint DEFAULT '12345678909876'::bigint NOT NULL,
+    facebook_app_id bigint DEFAULT 0 NOT NULL,
     site_meta_image_file_name character varying,
     site_meta_image_content_type character varying,
     site_meta_image_file_size integer,


### PR DESCRIPTION
## PT Story: Remove all "back" links/buttons at the bottom of pages
#### PT URL: https://www.pivotaltracker.com/story/show/165002465


## Changes proposed in this pull request:
1. Removed buttons that redirected back to the list of business categories page.
2. I have commented out the code in this partial - `_edit_action_buttons.html.haml` and have not removed it as the back button code was the only one in the file and wasn't sure if I had to delete the file or just remove the lines. So I commented them out. 

## Screenshots (Optional):

---
## Ready for review:
@shf-project-BOT 
