### PR TITLE
Fix 2 failing scenarios for proof of membership access

### DIFF
--- a/features/support/path_helpers.rb
+++ b/features/support/path_helpers.rb
@@ -47,8 +47,11 @@ module PathHelpers
         path = user_path(user)
       when 'edit user account'
         path = admin_only_edit_user_account_path(user)
-      when 'proof of membership image'
+
+      when 'proof of membership html image'
         path = proof_of_membership_path(user)
+      when 'proof of membership jpg download'
+        path = proof_of_membership_path(user, render_to: 'jpg')
 
       # SHF application pages
       when 'new application', 'submit new membership application'

--- a/features/user_account/proof-of-membership-imagepage-access.feature
+++ b/features/user_account/proof-of-membership-imagepage-access.feature
@@ -1,8 +1,10 @@
-Feature: Who can access a member's Proof of Membership download page
-
+Feature: Who can see a member's Proof of Membership image, download it, access it
 
   Background:
     Given the Membership Ethical Guidelines Master Checklist exists
+
+    # must have a SHF logo image that can be put into the proof of membership image
+    Given the App Configuration is not mocked and is seeded
 
     Given the following users exist
       | email                | admin | member | membership_number | first_name | last_name |
@@ -28,28 +30,37 @@ Feature: Who can access a member's Proof of Membership download page
       | member-lars@mutts.se | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |
 
 
-  Scenario: An admin can see a member's proof of membership
+  Scenario: An admin can see a member's proof of membership image
     Given I am logged in as "admin@shf.se"
-    And I am on the "proof of membership image" page for "member-emma@mutts.se"
+    And I am on the "proof of membership html image" page for "member-emma@mutts.se"
     Then I should see t("users.proof_of_membership.proof_title")
     And I should see "1001"
-    When I am on the "proof of membership image" page for "member-lars@mutts.se"
+    And I should see "Emma Member"
+    When I am on the "proof of membership html image" page for "member-lars@mutts.se"
     Then I should see t("users.proof_of_membership.proof_title")
     And I should see "1002"
+    And I should see "Lars Member"
 
-  Scenario: A member can access their own proof of membership download page
+  Scenario: A member can see their own proof of membership html page
     Given I am logged in as "member-emma@mutts.se"
-    And I am on the "proof of membership image" page for "member-emma@mutts.se"
+    When I am on the "proof of membership html image" page for "member-emma@mutts.se"
     Then I should see t("users.proof_of_membership.proof_title")
+    And I should see "Emma Member"
     And I should see "1001"
 
-  Scenario: A member cannot access someone else's proof of membership download page
+  Scenario: A member can see another member's proof of membership  html page
     Given I am logged in as "member-emma@mutts.se"
-    And I am on the "proof of membership image" page for "member-lars@mutts.se"
-    Then I should see a message telling me I am not allowed to see that page
+    When I am on the "proof of membership html image" page for "member-lars@mutts.se"
+    Then I should not see a message telling me I am not allowed to see that page
+    And I should see t("users.proof_of_membership.proof_title")
+    And I should see "Lars Member"
+    And I should see "1002"
 
-  Scenario: A visitor cannot access the proof of membership download image for a member
+
+  Scenario: A visitor can see a member's proof of membership  html page
     Given I am logged out
-    And I am on the "proof of membership image" page for "member-lars@mutts.se"
-    Then I should see a message telling me I am not allowed to see that page
-
+    When I am on the "proof of membership html image" page for "member-lars@mutts.se"
+    Then I should not see a message telling me I am not allowed to see that page
+    And I should see t("users.proof_of_membership.proof_title")
+    And I should see "Lars Member"
+    And I should see "1002"

--- a/features/user_account/proof-of-membership-imagepage-access.feature
+++ b/features/user_account/proof-of-membership-imagepage-access.feature
@@ -1,4 +1,9 @@
-Feature: Who can see a member's Proof of Membership image, download it, access it
+Feature: Who can see a member's Proof of Membership image html page, or download the jpg
+
+  Anyone should be able to see a member's proof of membership html page
+  and
+  anyone should be able to download a member's proof of membership jpg image
+
 
   Background:
     Given the Membership Ethical Guidelines Master Checklist exists
@@ -48,7 +53,7 @@ Feature: Who can see a member's Proof of Membership image, download it, access i
     And I should see "Emma Member"
     And I should see "1001"
 
-  Scenario: A member can see another member's proof of membership  html page
+  Scenario: A member can see another member's proof of membership html page
     Given I am logged in as "member-emma@mutts.se"
     When I am on the "proof of membership html image" page for "member-lars@mutts.se"
     Then I should not see a message telling me I am not allowed to see that page
@@ -56,11 +61,20 @@ Feature: Who can see a member's Proof of Membership image, download it, access i
     And I should see "Lars Member"
     And I should see "1002"
 
+  Scenario: A member can download another member's proof of membership jpg
+    Given I am logged in as "member-emma@mutts.se"
+    When I am on the "proof of membership jpg download" page for "member-lars@mutts.se"
+    Then I should get a downloaded image with the filename "proof_of_membership.jpeg"
 
-  Scenario: A visitor can see a member's proof of membership  html page
+  Scenario: A visitor can see a member's proof of membership html page
     Given I am logged out
     When I am on the "proof of membership html image" page for "member-lars@mutts.se"
     Then I should not see a message telling me I am not allowed to see that page
     And I should see t("users.proof_of_membership.proof_title")
     And I should see "Lars Member"
     And I should see "1002"
+
+  Scenario: A visitor can download a member's proof of membership jpg
+    Given I am logged out
+    When I am on the "proof of membership jpg download" page for "member-lars@mutts.se"
+    Then I should get a downloaded image with the filename "proof_of_membership.jpeg"

--- a/features/user_account/proof_of_membership.feature
+++ b/features/user_account/proof_of_membership.feature
@@ -44,9 +44,9 @@ Feature: Member gets their customized SHF membership card (proof of membership)
     Then I should get a downloaded image with the filename "proof_of_membership.jpeg"
 
   @time_adjust
-  Scenario: Member views proof-of-membership image
+  Scenario: Member views proof-of-membership html image
     Given I am logged in as "emma@mutts.se"
-    And I am on the "proof of membership image" page for "emma@mutts.se"
+    And I am on the "proof of membership html image" page for "emma@mutts.se"
     Then I should see t("users.proof_of_membership.proof_title")
     And I should see t("users.proof_of_membership.member_number")
     And I should see "1001"
@@ -58,7 +58,7 @@ Feature: Member gets their customized SHF membership card (proof of membership)
   @selenium
   Scenario: Expired Membership says 'Expired'
     Given I am logged in as "member-expired@mutts.se"
-    And I am on the "proof of membership image" page for "member-expired@mutts.se"
+    And I am on the "proof of membership html image" page for "member-expired@mutts.se"
     Then I should see t("users.proof_of_membership.proof_title")
     And I should not see t("users.proof_of_membership.member_number")
     And I should not see "999"


### PR DESCRIPTION
## PT Story:  bug: failing proof-of-membership access scenarios
#### PT URL:  https://www.pivotaltracker.com/story/show/174589190


## Changes proposed in this pull request:
1.  step: changed the string for the proof of membership _html image page_ page to make it clearer
2. step: added a path for downloading a proof of membership jpg
3. added scenarios for others (not the member-owner) to download a proof of membership jpg
4. fixed the scenarios to show that anyone can view the proof of membership html page


---
## Ready for review:
@AgileVentures/shf-project-team 
