### PR TITLE
upgrade to bundler 2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -675,4 +675,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
## PT Story:  upgrade to bundler 2.0
#### PT URL:  https://www.pivotaltracker.com/story/show/163674926

https://bundler.io/guides/bundler_2_upgrade.html

## Changes proposed in this pull request:
1.  Gemfile.lock was upgraded to bundler 2


