### PR TITLE
remove duplicate problem scenarios (keep in problem-scenarios-... .feature) files

### DIFF
--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -182,37 +182,6 @@ Feature: Create a new membership application
     And I should see "5560360793, 2120000142"
 
   @selenium
-  Scenario: User creates App with two companies, creates one company, corrects error in company number
-    Given I am on the "user instructions" page
-    And I click on first t("menus.nav.users.apply_for_membership") link
-    And I fill in the translated form with data:
-      | shf_applications.show.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 556036-07                            | 031-1234567                       | info@craft.se                      |
-    And I select "Groomer" Category
-
-    # Create new company in modal
-    And I click on t("companies.new.title")
-
-    And I fill in "company-number-in-modal" with "2286411992"
-    And I fill in t("companies.show.email") with "info@craft.se"
-
-    Then I want to create a new company
-    And I click on t("companies.create.create_submit")
-
-    And I select files delivery radio button "upload_later"
-
-    And I click on t("shf_applications.new.submit_button_label")
-    And I should see t("activerecord.errors.models.shf_application.attributes.companies.not_found", value: '55603607')
-    Then I fill in t("shf_applications.show.company_number") with "556036-0793, 2286411992"
-    And I click on t("shf_applications.new.submit_button_label")
-    Then I should be on the "user account" page for "applicant_1@random.com"
-
-    And I should see t("shf_applications.create.success_with_app_files_missing")
-
-    When I am on the "show my application" page for "applicant_1@random.com"
-    And I should see "5560360793, 2286411992"
-
-  @selenium
   Scenario: A user can submit a new Membership Application with multiple categories
     Given I am on the "user instructions" page
     And I click on first t("menus.nav.users.apply_for_membership") link
@@ -230,37 +199,6 @@ Feature: Create a new membership application
     And I should see t("shf_applications.create.success_with_app_files_missing")
 
 
-  @selenium
-  Scenario: A user cannot submit a new Membership Application with no category [SAD PATH]
-    Given I am on the "user instructions" page
-    And I click on first t("menus.nav.users.apply_for_membership") link
-    And I fill in the translated form with data:
-      | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 031-1234567                       | info@craft.se                      |
-
-    # Create new company in modal
-    And I click on t("companies.new.title")
-
-    And I fill in "company-number-in-modal" with "2286411992"
-    And I fill in t("companies.show.email") with "info@craft.se"
-
-    Then I want to create a new company
-    And I click on t("companies.create.create_submit")
-
-    And I should see t("shf_applications.new.file_delivery_selection")
-
-    And I select files delivery radio button "files_uploaded"
-
-    And I click on t("shf_applications.new.submit_button_label")
-
-    Then I should see error t("activerecord.attributes.shf_application.business_categories") t("errors.messages.blank")
-
-    Then I select "Groomer" Category
-    And I click on t("shf_applications.new.submit_button_label")
-
-    And I should see t("shf_applications.create.success_with_app_files_missing")
-
-
   Scenario: Applicant cannot see membership number when submitting
     Given I am on the "landing" page
     And I click on t("menus.nav.users.apply_for_membership")
@@ -274,53 +212,6 @@ Feature: Create a new membership application
     And the field t("shf_applications.new.contact_email") should have a required field indicator
     And the field t("shf_applications.new.phone_number") should not have a required field indicator
     And I should see t("is_required_field")
-
-  @selenium
-  Scenario: Two users can submit a new Membership Application (with empty membershipnumbers)
-    Given I am on the "user instructions" page
-    And I click on first t("menus.nav.users.apply_for_membership") link
-    And I fill in the translated form with data:
-      | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 031-1234567                       | applicant_1@random.com             |
-    And I select "Groomer" Category
-
-    # Create new company in modal
-    And I click on t("companies.new.title")
-
-    And I fill in "company-number-in-modal" with "5562252998"
-    And I fill in t("companies.show.email") with "info@craft.se"
-
-    Then I want to create a new company
-    And I click on t("companies.create.create_submit")
-
-    And I should see t("shf_applications.new.file_delivery_selection")
-
-    And I select files delivery radio button "upload_later"
-
-    And I click on t("shf_applications.new.submit_button_label")
-
-    And I should see t("shf_applications.create.success_with_app_files_missing")
-
-    Given I am logged in as "applicant_2@random.com"
-    Given I am on the "user instructions" page
-    And I click on first t("menus.nav.users.apply_for_membership") link
-    And I fill in the translated form with data:
-      | shf_applications.show.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
-      | 2120000142                           | 031-1234567                       | applicant_2@random.com             |
-    And I select "Groomer" Category
-
-    # Create new company in modal
-    And I click on t("companies.new.title")
-
-    And I fill in "company-number-in-modal" with "6112107039"
-    And I fill in t("companies.show.email") with "info@craft.se"
-
-    Then I want to create a new company
-    And I click on t("companies.create.create_submit")
-
-    And I select files delivery radio button "upload_later"
-
-    And I click on t("shf_applications.new.submit_button_label")
 
 
   @selenium

--- a/features/problem-scenarios-create_membership_application.feature
+++ b/features/problem-scenarios-create_membership_application.feature
@@ -56,7 +56,6 @@ Feature: Create a new membership application [CI PROBLEM SCENARIOS]
 
     And I am logged in as "applicant_1@random.com"
 
-
   # ------------------------------------------------------------
 
 


### PR DESCRIPTION
## PT Story:  Move problem scenarios to problem- file
#### PT URL: https://www.pivotaltracker.com/story/show/175541028


## Changes proposed in this pull request:
1.  removed problem scenarios in the `create_membership_application.feature` file that were already in the `problem....` scenarios file.  (They were duplicated)


---
## Ready for review:
@
