### PR TITLE
BUG: companies with members query wrong

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,3 +33,4 @@
 @import 'master-checklists';
 @import 'user-checklists';
 @import 'shf-application-2';
+@import 'payments';

--- a/app/assets/stylesheets/payments.scss
+++ b/app/assets/stylesheets/payments.scss
@@ -1,0 +1,5 @@
+// Payment styles
+
+.payments-list {
+  font-size: smaller;
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,7 +78,7 @@ class User < ApplicationRecord
 
   scope :agreed_to_membership_guidelines, -> { where(id: UserChecklist.top_level_for_current_membership_guidelines.completed.pluck(:user_id)) }
 
-  scope :current_members, -> { membership_payment_current.paid_on_or_after_guidelines_reqd.agreed_to_membership_guidelines.application_accepted }
+  scope :current_members, -> { application_accepted.membership_payment_current }
 
 
   # -----------------------------------

--- a/app/views/payments/_payments_list.html.haml
+++ b/app/views/payments/_payments_list.html.haml
@@ -1,0 +1,25 @@
+
+-# set reasonable default
+- payments_list = local_assigns.fetch(:payments, [])
+
+.payments-list
+  %table.table.table-hover.table-sm
+    %thead
+      %tr
+        %th.payment-date= t('.payment_date')
+        %th.type= t('.type')
+        %th.status= t('.status')
+        %th.term-start-date= t('.start_date')
+        %th.term-end-date= t('.end_date')
+        %th.notes= t('.notes')
+        %th.hips-id HIPS id
+    %tbody
+    - payments_list.each do | payment |
+      %tr.payment
+        %td.payment-date= payment.created_at
+        %td.type= payment.payment_type
+        %td.status= payment.status
+        %td.term-start-date= payment.start_date
+        %td.term-end-date= payment.expire_date
+        %td.notes= payment.notes
+        %td.hips-id= payment.hips_id

--- a/app/views/payor/_term_status.html.haml
+++ b/app/views/payor/_term_status.html.haml
@@ -61,7 +61,17 @@
           .payment-status-hint= payment_due_hint(entity)
 
     - if current_user.admin?
-      = render partial: 'payor/admin_note_and_edit_status_row',
-       locals: { entity: entity,
-       target_id: admin_edit_target_id,
-       button_text: admin_edit_status_text }
+      .admin-only
+        .row
+          = render partial: 'payor/admin_note_and_edit_status_row',
+           locals: { entity: entity,
+           target_id: admin_edit_target_id,
+           button_text: admin_edit_status_text }
+
+
+        .row
+          .col.mt-2
+            %h4.section-title= t('.admin_user_payments_title')
+        .row
+          .col
+            = render 'payments/payments_list', {payments: entity.payments}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,9 +202,9 @@ en:
         date_member_packet_sent: &date_member_packet_sent Date Member Packet sent
 
       payment:
-        payment_type: Payment Type
-        status: Status
-        start_date: Start Date
+        payment_type: &payment_type Payment Type
+        status: &payment_status Status
+        start_date: &start_date Start Date
         expire_date: &expire_date Expire Date
         notes: &notes Notes
         created: *created
@@ -443,6 +443,11 @@ en:
     yes_pay_answer: 'Yes, make a payment'
     no_pay_answer: 'No. Nevermind. Do not make a payment'
     admin_cant_edit: Membership status can't be updated. (Perhaps no payments have been made.)
+
+
+  payor:
+    term_status:
+      admin_user_payments_title: *payments
 
 
   payment:
@@ -1085,6 +1090,16 @@ en:
 
     error:
       error: There was an error in processing your payment
+
+    payments_list:
+      payment_date: Payment date
+      type: *payment_type
+      status: *payment_status
+      start_date: *start_date
+      end_date: *expire_date
+      notes: *notes
+      hips_id: HIPS id
+
 
   company_locator:
     error:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -200,9 +200,9 @@ sv:
         date_member_packet_sent: &date_member_packet_sent Paket skickat
 
       payment:
-        payment_type: Betalningstyp
-        status: Status
-        start_date: Startdatum
+        payment_type: &payment_type Betalningstyp
+        status: &payment_status Status
+        start_date: &start_date Startdatum
         expire_date: &expire_date Utgångsdatum
         notes: &notes Anteckningar
         created: *created
@@ -442,10 +442,16 @@ sv:
     no_pay_answer: 'Nej.'
     admin_cant_edit: "Medlemsstatus kan inte uppdateras. (Kanske har inga betalningar gjorts.)"
 
+
+  payor:
+    term_status:
+      admin_user_payments_title: *payments
+
+
   payment:
     payment_type:
-      member_fee: Medlemsavgift
-      branding_fee: H-märkesavgift
+      member_fee: &member_fee Medlemsavgift
+      branding_fee: &branding_fee H-märkesavgift
     status:
       paid: &paid Betald
       never_paid: &never_paid Aldrig betald
@@ -1094,6 +1100,16 @@ sv:
 
     error:
       error: Det uppstod ett fel vid hantering av din betalning
+
+    payments_list:
+      payment_date: Payment date
+      status: *payment_status
+      type: *payment_type
+      start_date: *start_date
+      end_date: *expire_date
+      notes: *notes
+      hips_id: HIPS id
+
 
   user_checklists:
     all_list_items: &user_checklists_all_items Tillbaka till medlemsåtagandet

--- a/features/emails/email-memberChair-welcome-first-time-member.feature
+++ b/features/emails/email-memberChair-welcome-first-time-member.feature
@@ -23,6 +23,11 @@ Feature: Membership chair gets an email when a first-time-ever membership has be
       | new-member@no-h-brand.se    |       |
       | admin@shf.com               | true  |
 
+    And the following users have agreed to the Membership Ethical Guidelines:
+      | email                       |
+      | lars-member@lars.se         |
+      | new-member@good-standing.se |
+      | new-member@no-h-brand.se    |
 
     And the following business categories exist
       | name    |
@@ -46,15 +51,14 @@ Feature: Membership chair gets an email when a first-time-ever membership has be
       | new-member@good-standing.se | 5562252998     | Groomer    | accepted |
       | new-member@no-h-brand.se    | 6613265393     | Groomer    | accepted |
 
-
-    Given the following payments exist
-      | user_email          | start_date | expire_date | payment_type | status | hips_id |
-      | lars-member@lars.se | 2020-01-01 | 2020-12-31  | member_fee   | betald | none    |
-
-
+    And the date is set to "2020-01-01"
     Given the following payments exist
       | user_email          | start_date | expire_date | payment_type | status | hips_id | company_number |
+      | lars-member@lars.se | 2020-01-01 | 2020-12-31  | member_fee   | betald | none    |                |
       | lars-member@lars.se | 2020-01-01 | 2020-12-31  | branding_fee | betald | none    | 5562252998     |
+
+
+  # ===========================================================================================
 
 
   Scenario: New Member granted membership and associated with company already in good standing. Email is sent when membership is granted.
@@ -109,19 +113,19 @@ Feature: Membership chair gets an email when a first-time-ever membership has be
     Then I should see t("payments.success.success")
     And company number "2120000142" is paid through "2021-11-30"
 
-    And I am the page for company number "5562252998"
+    When I am the page for company number "5562252998"
+    And the date is set to "2020-12-01"
     Then I should see "AlreadyInGoodStanding"
     And I should see t("payors.due")
     When I click on t("menus.nav.company.pay_branding_fee")
     And I complete the branding payment for "AlreadyInGoodStanding"
     Then I should see t("payments.success.success")
     And company number "5562252998" is paid through "2021-12-31"
-
     And I am logged out
 
     Given the date is set to "2021-01-05"
     And a clear email queue
-    And I am logged in as "lars-member@lars.se"
+    When I am logged in as "lars-member@lars.se"
     And I am on the "user account" page for "lars-member@lars.se"
     When I click on t("menus.nav.members.pay_membership")
     And I complete the membership payment

--- a/features/user_account/admin-info-on-account-page.feature
+++ b/features/user_account/admin-info-on-account-page.feature
@@ -1,0 +1,80 @@
+Feature: Admin sees additional info on User Account pages
+
+  As an admin
+  So that I can see why an account has the current status it does
+  and so I can see important historical information about the account
+  and so I can see what actions I have or need to take for the account
+  Show me more information about the account
+
+
+  Background:
+
+    Given the date is set to "2018-06-06"
+    Given the App Configuration is not mocked and is seeded
+    And the Membership Ethical Guidelines Master Checklist exists
+
+
+    Given the following users exist:
+      | email                   | admin | membership_number | member | first_name | last_name |
+      | emma-member@example.com |       | 1001              | true   | Emma       | IsAMember |
+      | lars-member@example.com |       | 101               | true   |            |           |
+      | admin@shf.se            | true  |                   |        |            |           |
+
+    And the following users have agreed to the Membership Ethical Guidelines:
+      | email                   |
+      | emma-member@example.com |
+      | lars-member@example.com |
+
+    And the following regions exist:
+      | name      |
+      | Stockholm |
+
+    And the following companies exist:
+      | name        | company_number | email               | region    |
+      | Happy Mutts | 5560360793     | woof@happymutts.com | Stockholm |
+      | Bowsers     | 2120000142     | bark@bowsers.com    | Stockholm |
+
+
+    And the following business categories exist
+      | name         | description   | subcategories          |
+      | dog grooming | grooming dogs | light trim, custom cut |
+
+
+    And the following applications exist:
+      | user_email              | contact_email              | company_number | state    | categories   |
+      | lars-member@example.com | lars-member@happymutts.com | 5560360793     | accepted | dog grooming |
+      | emma-member@example.com | emma-member@bowsers.com    | 2120000142     | accepted | dog grooming |
+
+
+    And the following payments exist
+      | user_email              | start_date | expire_date | payment_type | status | hips_id |
+      | emma-member@example.com | 2018-01-1  | 2018-12-31  | member_fee   | betald | none    |
+      | emma-member@example.com | 2018-01-1  | 2018-12-31  | branding_fee   | betald | none    |
+      | lars-member@example.com | 2018-05-05 | 2019-05-04  | member_fee   | betald | none    |
+
+
+    And the following membership packets have been sent:
+      | user_email              | date_sent  |
+      | lars-member@example.com | 2018-05-06 |
+
+    And I am logged in as "admin@shf.se"
+
+    # ---------------------------------------------------------------------------------------
+
+  Scenario: Admin sees payments
+    When I am on the "user account" page for "emma-member@example.com"
+    Then I should see t("payor.term_status.admin_user_payments_title")
+    And I should see t("payments.payments_list.payment_date")
+    And I should see t("payments.payments_list.type")
+    And I should see t("payments.payments_list.status")
+    And I should see t("payments.payments_list.start_date")
+    And I should see t("payments.payments_list.end_date")
+    And I should see t("payments.payments_list.notes")
+    And I should see t("payments.payments_list.hips_id")
+
+    And I should see "betald" in the row for "member_fee"
+    And I should see "2018-01-01" in the row for "member_fee"
+    And I should see "2018-12-31" in the row for "member_fee"
+    And I should see "betald" in the row for "branding_fee"
+    And I should see "2018-01-01" in the row for "branding_fee"
+    And I should see "2018-12-31" in the row for "branding_fee"

--- a/spec/models/user_checklist_manager_spec.rb
+++ b/spec/models/user_checklist_manager_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe UserChecklistManager do
           after(:each) { travel_back }
 
 
-          it 'true if members expiration < today (would not be a current member!)' do
+          it 'true if members expiration < two_days_before_req_duration_end (would not be a current member!)' do
             user = build(:member_with_membership_app)
             user.payments << create(:expired_membership_fee_payment) # expired yesterday
             user.save!
@@ -189,7 +189,7 @@ RSpec.describe UserChecklistManager do
             expect(described_class.must_complete_membership_guidelines_checklist?(user)).to be_truthy
           end
 
-          it 'true if member expiration date = today (would not be a current member!)' do
+          it 'true if member expiration date = two_days_before_req_duration_end (would not be a current member!)' do
             user = build(:member_with_membership_app)
             user.payments << create(:expired_membership_fee_payment, expire_date: Time.zone.now) # expired yesterday
             user.save!
@@ -198,7 +198,7 @@ RSpec.describe UserChecklistManager do
             expect(described_class.must_complete_membership_guidelines_checklist?(user)).to be_truthy
           end
 
-          it 'false if member expiration date > today' do
+          it 'false if member expiration date > two_days_before_req_duration_end' do
             user = build(:member_with_membership_app)
             user.payments << create(:expired_membership_fee_payment, expire_date: (Time.zone.now + 1.day))
             user.save!

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,7 +4,7 @@ require 'shared_context/unstub_paperclip_all_run_commands'
 require 'shared_context/users'
 require 'shared_context/named_dates'
 
-# TODO use the users already defined/created in the shared_context/users
+# TODO use the users already defined/created in the shared_context/users?
 
 # ================================================================================
 
@@ -386,15 +386,6 @@ RSpec.describe User, type: :model do
         described_class.current_members
       end
 
-      it 'membership payment was made after the membership guidelines were a requirement' do
-        expect(described_class).to receive(:paid_on_or_after_guidelines_reqd).and_call_original
-        described_class.current_members
-      end
-
-      it 'must have agreed to all of the current membership guidelines (if required)' do
-        expect(described_class).to receive(:agreed_to_membership_guidelines).and_call_original
-        described_class.current_members
-      end
     end
 
 


### PR DESCRIPTION
## PT Story: BUG: query for showing Companies is wrong
#### PT URL: https://www.pivotaltracker.com/story/show/176026535


## Changes proposed in this pull request:
1.  'current_members' should be those with current payments and approved application.  
3. Show payments to admin on the User and Company pages

## Screenshots (Optional):
<img width="716" alt="Screen Shot 2020-12-06 at 3 11 31 PM" src="https://user-images.githubusercontent.com/673794/101295970-a32b0780-37d5-11eb-82cf-ee31aa910b6a.png">

---


<img width="731" alt="Screen Shot 2020-12-06 at 3 11 18 PM" src="https://user-images.githubusercontent.com/673794/101295974-a4f4cb00-37d5-11eb-9ae4-ecc7c0d147b6.png">



---
## Ready for review:
@thesuss 
