### PR TITLE
seeding: Start to create "predefined" users

### DIFF
--- a/db/seed_helpers.rb
+++ b/db/seed_helpers.rb
@@ -29,6 +29,10 @@ module SeedHelper
   class SeedAdminENVError < StandardError
   end
 
+  attr_writer :regions, :kommuns, :business_categories, :address_factory
+
+  # ===========================================================================================
+
 
   # Initialize the instance vars
   #
@@ -247,7 +251,7 @@ module SeedHelper
       co.phone_number =   FFaker::PhoneNumberSE.phone_number
       co.website =        FFaker::InternetSE.http_url
 
-      @address_factory.make_n_save_a_new_address(co)
+      address_factory.make_n_save_a_new_address(co)
       co
     end
 
@@ -291,5 +295,8 @@ module SeedHelper
     @business_categories ||= BusinessCategory.all.to_a
   end
 
+  def address_factory
+    @address_factory ||= AddressFactory.new(regions, kommuns)
+  end
 
 end # module SeedHelper

--- a/db/seed_helpers/users_factory.rb
+++ b/db/seed_helpers/users_factory.rb
@@ -1,0 +1,137 @@
+require_relative('../seed_helpers.rb')
+require_relative '../require_all_seeders_and_helpers'
+
+module SeedHelper
+  #--------------------------
+  #
+  # @class PredefinedUsersFactory
+  #
+  # @desc Responsibility: Create Users with specific attributes, etc.
+  #
+  # @author Ashley Engelund (ashley.engelund@gmail.com  weedySeaDragon @ github)
+  # @date   12/10/20
+  #
+  # TODO: Use existing methods to create applications, etc.
+  #--------------------------
+  #
+  class UsersFactory
+
+    # Used to make a certain number of users with random applications, companies, etc.
+    NUM_NEWUSERS = 3
+    NUM_APPLICANTS = 4
+    NUM_MEMBERS = 2
+    NUM_LAPSEDMEMBERS = 3
+    NUM_FORMERMEMBERS = 2
+
+    NEWUSER_LNAME = 'NewUser'
+    APPLICANT_LNAME = 'Applicant'
+    MEMBER_LNAME = 'Member'
+    LAPSEDMEMBER_LNAME = 'LapsedMember'
+    FORMERMEMBER_LNAME = 'FormerMember'
+
+    DUMMY_EMAIL_DOMAIN = 'example.com'
+
+    # --------------------------------------------------------------------------------------------
+
+    def self.seed_predefined_users
+      make_predefined_new_registered_users
+      make_predefined_applicants
+      make_predefined_current_members
+      make_predefined_lapsed_members
+      make_predefined_former_members
+    end
+
+    # New users are those that have signed up, but not submitted any application or done anything else.
+    #   (They have not agreed to any Ethical Guidelines, etc.)
+    def self.make_predefined_new_registered_users
+      make_predefined_with(lastname: NEWUSER_LNAME, number: NUM_NEWUSERS)
+    end
+
+    # Applicants have created a new application (but the application has not been reviewed).  Some
+    #   percentage have done 'other' requirements. (As of 2020-12-10,there is only one 'other'
+    #   requirement:  agree to the Ethical Guidelines.  But there could be additional requirements
+    #   in the future.)
+    # ShfApplications and Companies are created for the applicants
+    def self.make_predefined_applicants
+      make_predefined_with(lastname: APPLICANT_LNAME, number: NUM_APPLICANTS) do |applicant|
+        make_n_save_app(applicant, MA_NEW_STATE)
+      end
+    end
+
+    # Current members are those that have met all of the requirements for membership and have
+    #   paid.  Some percentage have paid in advance (for more than 1 membership term).
+    # ShfApplications and Companies are created for the members.
+    def self.make_predefined_current_members
+      make_member_paid_through(Date.current + 1.day, firstname: 'PaidThrough-tomorrow')
+      make_member_paid_through(Date.current + 1.month, firstname: 'PaidThrough-1-month')
+
+      # earliest_renew_days = User.days_can_renew_early
+      # earliest_str = earliest_renew_days.inspect.gsub(' ', '_')
+      # make_member_paid_through(Date.current + earliest_renew_days, firstname: "PaidThrough-#{earliest_str}")
+      # make_member_paid_through(Date.current + earliest_renew_days + 1, firstname: "PaidThrough-#{earliest_str}_plus_1_day")
+      # make_member_paid_through(Date.current + earliest_renew_days - 1, firstname: "PaidThrough-#{earliest_str}_minus_1_day")
+
+      make_member_paid_through(Date.current + 6.months, firstname: 'PaidThrough-6-months')
+      make_member_paid_through(Date.current + 2.years, firstname: 'PaidThrough-2-years')
+    end
+
+    # Lapsed members are those members that
+    def self.make_predefined_lapsed_members
+
+    end
+
+    # Members with payments overdue are those whose last payment date has past
+    #   AND are in the 'grace period' of when they can pay.
+    # They may or may not have completed all of the requirements for renewing membership for the
+    # membership term. Ex: If the requirement for renewing membership includes "must upload at least
+    # 1 file" they may or may not have done that.  The requirements for renewing membership are
+    # separate from payments.
+    def self.make_predefined_members_payment_overdue
+
+    end
+
+    # Former members are those whose last payment date has past AND they are past the 'grace period'
+    #   as well.
+    def self.make_predefined_former_members
+
+    end
+
+    def self.make_member_paid_through(last_payment_expiry, lastname: MEMBER_LNAME, number: 1, firstname: 'PaidThrough')
+      make_predefined_with(lastname: lastname, number: number, firstname: firstname) do |member|
+        payment_ends_tomorrow = make_n_save_app(member, MA_ACCEPTED_STATE)
+        membership_payment = payment_ends_tomorrow.most_recent_membership_payment
+        membership_payment.update(expire_date: last_payment_expiry, start_date: User.start_date_for_expire_date(last_payment_expiry))
+      end
+    end
+
+    def self.make_predefined_with(lastname: 'Someone', number: 1, firstname: nil)
+      number.times do |i|
+        user = new_user(lastname, number: i, firstname: firstname)
+        yield(user) if block_given?
+      end
+    end
+
+    # @return [User] - created with the given last name, and email and firstname based on the last name
+    #   and number.
+    def self.new_user(lastname = 'SomeUser', number: 1, firstname: nil)
+      fname = firstname.blank? ? firstname_from_lastname_num(lastname, number) : firstname
+      new_email = email_from_firstname(fname)
+
+      raise "Could not create new user #{new_email}. That email is already taken." if User.all.pluck(:email).include?(new_email)
+
+      User.create!(email: new_email,
+                   password: DEFAULT_PASSWORD,
+                   first_name: fname,
+                   last_name: lastname)
+    end
+
+    def self.firstname_from_lastname_num(lastname, num = 1)
+      "#{lastname}#{num}"
+    end
+
+    def self.email_from_firstname(firstname)
+      "#{firstname.downcase}@#{DUMMY_EMAIL_DOMAIN}"
+    end
+  end
+
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -120,9 +120,18 @@ begin
 
   if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_STAGING']
 
+    # -----------------------------------------
+    # Master and User checklists
+
+    Seeders::MasterChecklistTypesSeeder.seed
+    Seeders::MasterChecklistsSeeder.seed
+
+    # -----------------------------------------
     users = {}
 
     ActivityLogger.open(SEEDING_LOG_FILE_NAME, SEEDING_LOG_FACILITY, 'Users') do |log|
+
+      SeedHelper::UsersFactory.seed_predefined_users
 
       number_of_users = (ENV['SHF_SEED_USERS'] || SEED_USERS).to_i
       log.info("Creating #{number_of_users} additional users. (This number can be set with ENV['SHF_SEED_USERS'])...")
@@ -138,12 +147,6 @@ begin
 
       log.info("Users now in the db: #{User.count}")
     end
-
-    # -----------------------------------------
-    # Master and User checklists
-
-    Seeders::MasterChecklistTypesSeeder.seed
-    Seeders::MasterChecklistsSeeder.seed
 
     # -----------------------------------------
 

--- a/spec/db/seed_development_spec.rb
+++ b/spec/db/seed_development_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe 'Dev DB is seeded with users, members, apps, and companies' do
       # must stub this way so the rest of ENV is preserved
       stub_const('ENV', ENV.to_hash.merge({ ENV_ADMIN_EMAIL_KEY    => admin_email,
                                             ENV_ADMIN_PASSWORD_KEY => admin_pwd }))
+
+      allow(SeedHelper::UsersFactory ).to receive(:seed_predefined_users).and_return(true)
       SHFProject::Application.load_tasks
     end
   end
@@ -54,6 +56,11 @@ RSpec.describe 'Dev DB is seeded with users, members, apps, and companies' do
   after(:all) do
     DatabaseCleaner.clean
   end
+
+  before(:each) do
+    allow(SeedHelper::UsersFactory).to receive(:seed_predefined_users).and_return([])
+  end
+
 
   describe 'seeding basic info: users, companies, etc.' do
 
@@ -78,6 +85,7 @@ RSpec.describe 'Dev DB is seeded with users, members, apps, and companies' do
                                               ENV_ADMIN_PASSWORD_KEY   => admin_pwd }))
 
         allow(SeedHelper::AppConfigurationSeeder).to receive(:seed).and_return(true)
+        allow(SeedHelper::UsersFactory ).to receive(:seed_predefined_users).and_return(true)
 
         SHFProject::Application.load_seed
       end

--- a/spec/db/shared_specs_db_seeding.rb
+++ b/spec/db/shared_specs_db_seeding.rb
@@ -30,6 +30,7 @@ RSpec.shared_examples 'admin, business categories, kommuns, and regions are seed
         allow(Seeders::MasterChecklistTypesSeeder).to receive(:seed).and_return([])
         allow(Seeders::MasterChecklistsSeeder).to receive(:seed).and_return([])
         allow(Seeders::UserChecklistsSeeder).to receive(:seed).and_return([])
+        allow(SeedHelper::UsersFactory ).to receive(:seed_predefined_users).and_return(true)
 
         SHFProject::Application.load_tasks
         SHFProject::Application.load_seed


### PR DESCRIPTION
## PT Story: seeding: start to add predefined users
#### PT URL: https://www.pivotaltracker.com/story/show/176152745                  

We don't have to go with these particular predefined users.  We can later figure out exactly which ones will be helpful.

## Changes proposed in this pull request:
1.  added `SeedHelper::UserFactory` to create predefined users
2.  (minor) `SeedHelper` now uses attributes (esp. important for creating addresses with the `address_factory`)

## Screenshots (Optional):
This shows the predefined users after seeding:
- 3 new users (`newuserN@example.com`)
- 4 applicants  (`applicantN@example.com`)
- 4 members  (The members I've defined are all `paidThrough...` so that I can work with renewals.)

**The predefined users all use _@example.com_ as the email domain.**


<img width="811" alt="all-users-with-predefines" src="https://user-images.githubusercontent.com/673794/102125487-a25e2b00-3dfe-11eb-9d31-85bc0b90246e.png">

---
## Ready for review:
@AgileVentures/shf-project-team 
