### PR TITLE
BUG: displaying app status: handle nil date (esp. on Heroku)

### DIFF
--- a/app/helpers/shf_applications_helper.rb
+++ b/app/helpers/shf_applications_helper.rb
@@ -8,7 +8,11 @@ module ShfApplicationsHelper
   def app_state_and_date(shf_app)
     return '' unless shf_app
 
-    displayed_date = shf_app.accepted? ? shf_app.when_approved : shf_app.updated_at
+    displayed_date = if shf_app.accepted?
+                       shf_app.when_approved.present? ? shf_app.when_approved : shf_app.updated_at
+                     else
+                       shf_app.updated_at
+                     end
     "#{shf_app_state_translated(shf_app)} - #{displayed_date.strftime('%F')}"
   end
 


### PR DESCRIPTION
## PT Story:  BUG: display accepted app status even if when_approved is nil (Heroku)
#### PT URL: https://www.pivotaltracker.com/story/show/176301623


## Changes proposed in this pull request:
1.  If an application is accepted and `when_approved` is nil, display that `updated_at` instead. 
2. add unit tests for the helper method
3. use `build(...)` where possible in the helper spec


---
## Ready for review:
@
