### PR TITLE
Sprint110 ordered ancestry minor fix

### DIFF
--- a/app/models/concerns/ordered_ancestry_entry.rb
+++ b/app/models/concerns/ordered_ancestry_entry.rb
@@ -74,11 +74,10 @@ module OrderedAncestryEntry
     # @param new_position [Integer] - the 0-based position for the new entry.
     #  Default = the size of the list of children,  which will place the new_entry at the end
     #
-    # @return [Array] - children with the new entry inserted
+    # @return [OrderedAncestryEntry] - children with the new entry inserted
     def insert(new_entry, new_position = children.size)
       increment_child_positions(new_position)
       new_entry.update(list_position: new_position, parent: self)
-      new_entry
     end
 
     alias_method :insert_in_children, :insert
@@ -87,7 +86,7 @@ module OrderedAncestryEntry
 
 
     def sorted_siblings
-      siblings.order(:list_position)
+      siblings.order(list_position: :asc)
     end
 
 

--- a/app/models/user_checklist.rb
+++ b/app/models/user_checklist.rb
@@ -95,6 +95,7 @@ class UserChecklist < ApplicationRecord
   # Add .includes to the query used to get all descendants to help reduce N+1 queries
   def children
     # super.includes(:master_checklist).includes(:user)
+    save! unless persisted? # Ancestry gem requires that the object be saved before performing any ancestry queries
     super #.includes(:user)
   end
 

--- a/config/locales/ancestry.sv.yml
+++ b/config/locales/ancestry.sv.yml
@@ -1,0 +1,16 @@
+sv:
+  ancestry:
+    unknown_depth_option: "Unknown depth option: %{scope_name}."
+    invalid_orphan_strategy: "Invalid orphan strategy, valid ones are :rootify, :adopt, :restrict and :destroy."
+    invalid_ancestry_column: "Invalid format for ancestry column of node %{node_id}: %{ancestry_column}."
+    reference_nonexistent_node: "Reference to nonexistent node in node %{node_id}: %{ancestor_id}."
+    conflicting_parent_id: "Conflicting parent id found in node %{node_id}: %{parent_id} for node %{node_id} while expecting %{expected}"
+    cannot_rebuild_depth_cache: "Cannot rebuild depth cache for model without depth caching."
+
+    option_must_be_hash: "Options for has_ancestry must be in a hash."
+    unknown_option: "Unknown option for has_ancestry: %{key} => %{value}."
+    named_scope_depth_cache: "Named scope '%{scope_name}' is only available when depth caching is enabled."
+
+    exclude_self: "%{class_name} cannot be a descendant of itself."
+    cannot_delete_descendants: "Cannot delete record because it has descendants."
+    no_child_for_new_record: "No child ancestry for new record. Save record before performing tree operations."

--- a/spec/models/user_checklist_spec.rb
+++ b/spec/models/user_checklist_spec.rb
@@ -137,8 +137,8 @@ RSpec.describe UserChecklist, type: :model do
 
       it 'is ordered so the most recently created one is last' do
         second_list = create(:user_checklist, :completed, user: user1,
-               master_checklist: guideline_master,
-               num_completed_children: 2)
+                             master_checklist: guideline_master,
+                             num_completed_children: 2)
         second_list.update(created_at: Time.zone.now + 1.day)
 
         expect(described_class.membership_guidelines_for_user(user1).count).to eq 2
@@ -203,11 +203,13 @@ RSpec.describe UserChecklist, type: :model do
       result_list_positions = result.map(&:list_position)
       expect(result_list_positions).to match_array([0, 5])
     end
+
+    it 'size = completed items + uncompleted items' do
+      # The root of the list is also uncomplete, so it is counted, too
+      expect(three_complete_two_uncomplete_list.all_that_are_completed.size + three_complete_two_uncomplete_list.all_that_are_uncompleted.size).to eq(6)
+    end
   end
 
-  it 'size = completed items + uncompleted items (uncompleted includes root)' do
-    expect(three_complete_two_uncomplete_list.all_that_are_completed.size + three_complete_two_uncomplete_list.all_that_are_uncompleted.size).to eq(6)
-  end
 
   describe 'percent_complete' do
     context 'no children' do
@@ -248,7 +250,6 @@ RSpec.describe UserChecklist, type: :model do
           create(:user_checklist, parent: top3)
           create(:user_checklist, :completed, parent: top3)
           expect(top3.percent_complete).to eq 33
-
 
           top4 = create(:user_checklist)
           c4_1 = create(:user_checklist, :completed, parent: top4)
@@ -364,6 +365,7 @@ RSpec.describe UserChecklist, type: :model do
       end
     end
   end
+
 
   describe 'all_changed_by_completion_toggle' do
     describe 'is set to completed if it is not complete' do
@@ -739,6 +741,7 @@ RSpec.describe UserChecklist, type: :model do
     end
   end
 
+
   describe 'set_complete_including_children' do
     # Would be good to stub things so these tests don't hit the db so much
     it 'sets self to complete' do
@@ -805,6 +808,7 @@ RSpec.describe UserChecklist, type: :model do
     end
   end
 
+
   describe 'set_uncomplete_including_children' do
     # Would be good to stub things so these tests don't hit the db so much
     it 'sets self to uncomplete' do
@@ -843,6 +847,7 @@ RSpec.describe UserChecklist, type: :model do
     end
   end
 
+
   describe 'set_complete_update_parent' do
     let(:given_date_completed) { Time.parse("2020-10-31") }
 
@@ -875,6 +880,7 @@ RSpec.describe UserChecklist, type: :model do
       end
     end
   end
+
 
   describe 'set_uncomplete_update_parent' do
     it 'returns empty list if the checklist is already uncomplete' do


### PR DESCRIPTION
## PT Story: 
#### PT URL:

Minor fixes to OrderedAncestry
(I wanted to keep these out of the PR for Renewals)

## Changes proposed in this pull request:
1. add sv locale file for  Ancestry errors (= the english one)
2. default sort order is :asc
3.  must save an entry before fetching the children for it
4.  insert: return the new inserted entry

---
## Ready for review:
@
