### PR TITLE
Renew membership:  models  (no UI except AppConfig)

### DIFF
--- a/app/controllers/admin_only/app_configuration_controller.rb
+++ b/app/controllers/admin_only/app_configuration_controller.rb
@@ -59,7 +59,8 @@ module AdminOnly
                   :facebook_app_id,
                   :site_meta_image,
                   :payment_too_soon_days,
-                  :membership_guideline_list_id)
+                  :membership_guideline_list_id,
+                  :membership_expired_grace_period)
     end
   end
 

--- a/app/models/admin_only/app_configuration.rb
+++ b/app/models/admin_only/app_configuration.rb
@@ -75,7 +75,6 @@ module AdminOnly
     # Conceptually, 'belongs to' isn't quite right, but it is technically true that
     # the Application Configuration tracks the association to just one MasterChecklist.
     #
-    # FIXME
      belongs_to :membership_guideline_list, class_name: 'AdminOnly::MasterChecklist', optional: true
 
     validates_presence_of :site_name, :site_meta_title

--- a/app/models/reqs_updaters/requirements_for_membership.rb
+++ b/app/models/reqs_updaters/requirements_for_membership.rb
@@ -28,11 +28,15 @@ class RequirementsForMembership < AbstractRequirements
   def self.requirements_met?(args)
     user = args[:user]
 
-    user.has_approved_shf_application? &&
-        membership_guidelines_checklist_done?(user) &&
-        user.membership_current?  # note that membership_current? is only about Payment
+    requirements_excluding_payments_met?(user) &&
+      payment_requirements_met?(user)
   end
 
+  # FIXME - be consistent everywhere about whether the requirements include payments or not
+  def self.requirements_excluding_payments_met?(user)
+    user.has_approved_shf_application? &&
+      membership_guidelines_checklist_done?(user)
+  end
 
   # @return [Boolean] - if a user must have a completed Membership Guidelines checklist,
   #   return true if has been completed  (false if not completed)
@@ -42,4 +46,7 @@ class RequirementsForMembership < AbstractRequirements
     UserChecklistManager.completed_membership_guidelines_checklist?(user)
   end
 
+  def self.payment_requirements_met?(user)
+    user.payments_current?
+  end
 end # RequirementsForMembership

--- a/app/models/reqs_updaters/requirements_for_renewal.rb
+++ b/app/models/reqs_updaters/requirements_for_renewal.rb
@@ -1,0 +1,61 @@
+#--------------------------
+#
+# @class RequirementsForRenewal
+#
+# @desc Responsibility: Knows what the requirements are for a Member to renew membership.
+#       - Given a member, it can respond true or false if the membership renewal requirements are met.
+#   Note that it is _not_ the responsibility of this class to know if the given member has been
+#   unpaid so long that they cannot simply 'renew' but must re-apply.
+#
+#       This is a very simple class because the requirements are currently very simple.
+#       The importance is that
+#       IT IS THE ONLY PLACE THAT CODE NEEDS TO BE TOUCHED IF MEMBERSHIP REQUIREMENTS ARE CHANGED.
+#
+#  Only 1 is needed for the system.
+#
+# @author Ashley Engelund (ashley@ashleycaroline.com  weedySeaDragon @ github)
+# @date   12/08/20
+#
+#--------------------------
+
+class RequirementsForRenewal < AbstractRequirements
+
+  def self.has_expected_arguments?(args)
+    args_have_keys?(args, [:user])
+  end
+
+  def self.requirements_met?(args)
+    requirements_excluding_payments_met?(args[:user]) &&
+      payment_requirements_met?(args[:user])
+  end
+
+  def self.requirements_excluding_payments_met?(user)
+    user.can_renew_today? &&
+      user.has_approved_shf_application? &&
+      membership_guidelines_checklist_done?(user) &&
+      doc_uploaded_during_this_membership_term?(user)
+  end
+
+  # @return [Boolean] - if a user must have a completed Membership Guidelines checklist,
+  #   return true if has been completed  (false if not completed)
+  # else if the user does not have to have a completed Membership Guidelines checklist,
+  #   return true (we assume it's fine)
+  def self.membership_guidelines_checklist_done?(user)
+    UserChecklistManager.completed_membership_guidelines_checklist?(user)
+  end
+
+  # @return [Boolean] - Has the user uploaded at least 1 document since the start of this membership term?
+  # FIXME - in the last year of the membership term or during the payment term?
+  #   - what if the member paid for 2 terms in advance?
+  def self.doc_uploaded_during_this_membership_term?(user)
+    user.file_uploaded_during_this_membership_term?
+  end
+
+  def self.max_days_can_still_renew
+    AdminOnly::AppConfiguration.config_to_use.membership_expired_grace_period
+  end
+
+  def self.payment_requirements_met?(user)
+    user.payments_current? || user.membership_expired_in_grace_period?
+  end
+end

--- a/app/models/reqs_updaters/requirements_for_renewal.rb
+++ b/app/models/reqs_updaters/requirements_for_renewal.rb
@@ -56,6 +56,6 @@ class RequirementsForRenewal < AbstractRequirements
   end
 
   def self.payment_requirements_met?(user)
-    user.payments_current? || user.membership_expired_in_grace_period?
+    user.payments_current?
   end
 end

--- a/app/models/shf_application.rb
+++ b/app/models/shf_application.rb
@@ -9,6 +9,9 @@ class ShfApplication < ApplicationRecord
   include AASM
   include UpdatedAtRange
 
+
+  before_destroy :before_destroy_checks
+
   after_initialize :add_observers
   after_update :clear_image_caches
   before_destroy :before_destroy_checks
@@ -113,7 +116,7 @@ class ShfApplication < ApplicationRecord
     where(state: app_state).count
   end
 
-  # Have to guard agains the condition where there are no uploaded files in the system
+  # Have to guard against the condition where there are no uploaded files in the system
   def self.no_uploaded_files
     return not_decided if UploadedFile.count == 0
 
@@ -195,6 +198,18 @@ class ShfApplication < ApplicationRecord
   end
 
 
+  # @return [boolean] - is the application in a state where the applicant can edit it?
+  def applicant_can_edit?
+    CAN_EDIT_STATES.include? state.to_sym
+  end
+
+
+  # @return [Boolean] - can the applicant upload files for this application?
+  def applicant_can_upload_files?
+    applicant_can_edit? || (accepted? && user.membership_app_and_payments_current?)
+  end
+
+
   def upload_files_will_be_delivered_later?
     file_delivery_method&.email? || file_delivery_method&.mail?
   end
@@ -244,11 +259,8 @@ class ShfApplication < ApplicationRecord
   end
 
   def before_destroy_checks
-
     destroy_uploaded_files
-
     destroy_associated_companies
-
   end
 
 
@@ -261,7 +273,6 @@ class ShfApplication < ApplicationRecord
   private
 
   def destroy_uploaded_files
-
     uploaded_files.each do |uploaded_file|
       uploaded_file.actual_file = nil
       uploaded_file.destroy

--- a/app/models/shf_application.rb
+++ b/app/models/shf_application.rb
@@ -198,18 +198,6 @@ class ShfApplication < ApplicationRecord
   end
 
 
-  # @return [boolean] - is the application in a state where the applicant can edit it?
-  def applicant_can_edit?
-    CAN_EDIT_STATES.include? state.to_sym
-  end
-
-
-  # @return [Boolean] - can the applicant upload files for this application?
-  def applicant_can_upload_files?
-    applicant_can_edit? || (accepted? && user.membership_app_and_payments_current?)
-  end
-
-
   def upload_files_will_be_delivered_later?
     file_delivery_method&.email? || file_delivery_method&.mail?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -104,7 +104,7 @@ class User < ApplicationRecord
 
   # @return [ActiveSupport::Duration]
   def self.membership_expired_grace_period
-    ActiveSupport::Duration.days(AdminOnly::AppConfiguration.config_to_use.membership_expired_grace_period.to_i)
+    AdminOnly::AppConfiguration.config_to_use.membership_expired_grace_period.to_i.days
   end
 
   def self.most_recent_upload_method
@@ -113,7 +113,7 @@ class User < ApplicationRecord
 
   # @return [ActiveSupport::Duration]
   def self.days_can_renew_early
-    ActiveSupport::Duration.days(AdminOnly::AppConfiguration.config_to_use.payment_too_soon_days.to_i)
+    AdminOnly::AppConfiguration.config_to_use.payment_too_soon_days.to_i.days
   end
 
   # ----------------------------------
@@ -186,7 +186,7 @@ class User < ApplicationRecord
   end
 
   # The membership term has expired, but are they  still within a 'grace period'?
-  def membership_expired_in_grace_period?(this_date = Time.zone.now)
+  def membership_expired_in_grace_period?(this_date = Date.current)
     return false if this_date.nil?
 
     term_expired? && date_within_grace_period?(this_date,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -172,6 +172,8 @@ class User < ApplicationRecord
     !!membership_expire_date&.future? # using '!!' will turn a nil into false
   end
 
+  alias_method :payments_current?, :membership_current?
+
 
   # TODO this should not be the responsibility of the User class. Need a MembershipManager class for this.
   # FIXME - this is ONLY about the payments, not the membership status as a whole.

--- a/app/views/admin_only/app_configuration/edit.html.haml
+++ b/app/views/admin_only/app_configuration/edit.html.haml
@@ -63,6 +63,11 @@
           .form-inline
             = f.label :payment_too_soon_days, "#{t('.payment_too_soon_days')}:", class: 'control-label field-label'
             = f.number_field :payment_too_soon_days, class: 'form-control payment-too-soon-days', min: 0
+    .form-row
+      .col-sm-12.membership-expired-grace-period
+        .form-inline
+          = f.label :membership_expired_grace_period, "#{t('.membership_expired_grace_period')}:", class: 'control-label field-label'
+          = f.number_field :membership_expired_grace_period, class: 'form-control membership-expired-grace-period', min: 0
 
     %hr
     .row

--- a/app/views/admin_only/app_configuration/show.html.haml
+++ b/app/views/admin_only/app_configuration/show.html.haml
@@ -67,6 +67,11 @@
         = field_or_none(t('.payment_too_soon_days'),
             @app_configuration.payment_too_soon_days,
             tag_options: {class: 'payment-too-soon-days'})
+    .row
+      .col-sm-10
+        = field_or_none(t('.membership_expired_grace_period'),
+            @app_configuration.membership_expired_grace_period,
+            tag_options: {class: 'membership-expired-grace-period'})
 
   %hr
   .row

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,6 +302,7 @@ en:
         twitter_card_type: &site_twitter_card_type Twitter card type
         facebook_app_id: &site_facebook_app_id Facebook Application ID
         payment_too_soon_days: &payment_too_soon_days Number of days that a user will be warned that a payment is 'too soon'
+        membership_expired_grace_period: &membership_expired_grace_period 'Number of days a member can pay without penalty after their membership expires'
 
       task_attempt:
         task_name: Task name
@@ -1394,6 +1395,7 @@ en:
         payment_too_soon_days: *payment_too_soon_days
         membership_guideline_list: &membership_guideline_list Membership Guideline List
         membership_guideline_list_tooltip: &membership_guideline_list_tooltip Choose a top level list that will be used as the Membership Guidelines list. (Only top level lists that are in use are shown.)
+        membership_expired_grace_period: *membership_expired_grace_period
         required_field: &required_field required field
 
       show:
@@ -1413,6 +1415,7 @@ en:
         facebook_app_id: *site_facebook_app_id
         missing: *missing
         payment_too_soon_days: *payment_too_soon_days
+        membership_expired_grace_period: *membership_expired_grace_period
         membership_guideline_list: *membership_guideline_list
         required_field: *required_field
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -309,6 +309,7 @@ sv:
         twitter_card_type: &site_twitter_card_type Twitter card type
         facebook_app_id: &site_facebook_app_id Facebook Application ID
         payment_too_soon_days: &payment_too_soon_days Number of days that a user will be warned that a payment is 'too soon'
+        membership_expired_grace_period: &membership_expired_grace_period 'Number of days a member can pay without penalty after their membership expires'
 
       user_checklist:
         name: *name
@@ -1399,6 +1400,7 @@ sv:
         facebook_app_id: *site_facebook_app_id
         missing: *missing
         payment_too_soon_days: *payment_too_soon_days
+        membership_expired_grace_period: *membership_expired_grace_period
         membership_guideline_list: &membership_guideline_list Membership Guideline List
         membership_guideline_list_tooltip: &membership_guideline_list_tooltip Choose a top level list that will be used as the Membership Guidelines list. (Only top level lists that are in use are shown.)
         required_field: &required_field obligatoriskt fält
@@ -1420,6 +1422,7 @@ sv:
         facebook_app_id: *site_facebook_app_id
         missing: *missing
         payment_too_soon_days: *payment_too_soon_days
+        membership_expired_grace_period: *membership_expired_grace_period
         membership_guideline_list: *membership_guideline_list
         required_field: *required_field
 

--- a/db/migrate/20201214212325_add_membership_expired_grace_period_to_app_configuration.rb
+++ b/db/migrate/20201214212325_add_membership_expired_grace_period_to_app_configuration.rb
@@ -1,0 +1,6 @@
+class AddMembershipExpiredGracePeriodToAppConfiguration < ActiveRecord::Migration[5.2]
+  def change
+
+    add_column :app_configurations, :membership_expired_grace_period, :integer, default: 90, null: false, comment: "Number of days after membership expiration that a member can pay without penalty"
+  end
+end

--- a/db/seed_helpers/app_configuration_seeder.rb
+++ b/db/seed_helpers/app_configuration_seeder.rb
@@ -26,7 +26,9 @@ module SeedHelper
                                                    site_meta_keywords:    'hund, hundägare, hundinstruktör, hundentreprenör, Sveriges Hundföretagare, svenskt hundföretag, etisk, H-märkt, hundkurs',
                                                    og_type:               'website',
                                                    twitter_card_type:     'summary',
-                                                   facebook_app_id:       ENV.fetch('SHF_FB_APPID', nil).to_i
+                                                   facebook_app_id:       ENV.fetch('SHF_FB_APPID', nil).to_i,
+                                                   payment_too_soon_days: 45,
+                                                   membership_expired_grace_period: 90
       )
 
       meta_image_file            = File.open(File.join(__dir__, SITE_DEFAULT_IMAGE))

--- a/features/payments_and_member_status/member_pays_membership_fee.feature
+++ b/features/payments_and_member_status/member_pays_membership_fee.feature
@@ -11,13 +11,10 @@ Feature: Member pays membership fee
     Given the date is set to "2018-01-01"
 
     Given the following users exist:
-      | email          | admin | member | membership_number |
-      | emma@mutts.com |       | true   | 1001              |
-      | admin@shf.se   | true  | false  |                   |
+      | email          | admin | member | membership_number |agreed_to_membership_guidelines |
+      | emma@mutts.com |       | true   | 1001              | true                           |
+      | admin@shf.se   | true  | false  |                   |                                |
 
-    And the following users have agreed to the Membership Ethical Guidelines:
-      | email          |
-      | emma@mutts.com |
 
     Given the following companies exist:
       | name       | company_number | email               | region    |
@@ -31,11 +28,15 @@ Feature: Member pays membership fee
       | user_email     | start_date | expire_date | payment_type | status | hips_id |
       | emma@mutts.com | 2018-01-1  | 2018-12-31  | member_fee   | betald | none    |
 
+    Given these files have been uploaded:
+      | user_email     | file name | description                               |
+      | emma@mutts.com | image.png | Image of a class completion certification |
+
+
   @time_adjust
   Scenario: Member pays membership fee after term expires (after prior payment expiration date)
     Given the date is set to "2019-02-12"
     And I am logged in as "emma@mutts.com"
-    And I have agreed to all of the Membership Guidelines
     And I am on the "user account" page for "emma@mutts.com"
 #    And I should see t("payors.past_due")
     Then I click on t("users.show_for_applicant.pay_membership")
@@ -59,17 +60,15 @@ Feature: Member pays membership fee
 
 
   @time_adjust
-  Scenario: Member pays fee 'too soon' (way early) and extends membership
-    Given the date is set to "2018-01-02"
+  Scenario: Member pays fee early and extends membership
+    Given the date is set to "2018-11-20"
     And I am logged in as "emma@mutts.com"
     And I am on the "user account" page for "emma@mutts.com"
     And I should see "1001"
-    And I should see t("payors.too_early")
     Then I click on t("menus.nav.members.pay_membership")
     And I complete the membership payment
     And I should see t("payments.success.success")
     Then the user is paid through "2019-12-31"
-    #And I should see t("payors.paying_now_extends_until", fee_name: 'membership fee', term_name: 'membership', extended_end_date: '2019-12-31')
 
 
   @time_adjust

--- a/spec/models/conditions_response/membership_status_check_spec.rb
+++ b/spec/models/conditions_response/membership_status_check_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe MembershipStatusCheck, type: :model do
     allow(mock_log).to receive(:info)
     allow(mock_log).to receive(:record)
     allow(mock_log).to receive(:close)
+
+    allow(UserChecklistManager).to receive(:completed_membership_guidelines_checklist?)
+                                     .and_return(true)
   end
 
 

--- a/spec/models/reqs_updaters/requirements_for_membership_spec.rb
+++ b/spec/models/reqs_updaters/requirements_for_membership_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe RequirementsForMembership, type: :model do
     allow(AdminOnly::UserChecklistFactory).to receive(:create_member_guidelines_checklist_for).and_return(true)
   end
 
-
   let(:subject) { RequirementsForMembership }
   let(:user) { build(:user) }
 
@@ -27,7 +26,6 @@ RSpec.describe RequirementsForMembership, type: :model do
     end
   end
 
-
   describe '.membership_guidelines_checklist_done?' do
     it 'calls UserChecklistManager to see if the user has completed the Ethical guidelines checklist' do
       expect(UserChecklistManager).to receive(:completed_membership_guidelines_checklist?)
@@ -35,7 +33,6 @@ RSpec.describe RequirementsForMembership, type: :model do
       subject.membership_guidelines_checklist_done?(user)
     end
   end
-
 
   describe '.requirements_excluding_payments_met?' do
     it 'all non-payment requirements  are && together' do
@@ -48,19 +45,17 @@ RSpec.describe RequirementsForMembership, type: :model do
     end
   end
 
-
   describe '.requirements_met?' do
 
     it 'all non-payment requirements && all payment requirements' do
       expect(subject).to receive(:requirements_excluding_payments_met?).with(user)
-                           .and_return(true)
+                                                                       .and_return(true)
       expect(subject).to receive(:payment_requirements_met?).with(user)
                                                             .and_return(true)
 
       expect(subject.requirements_met?(user: user)).to be_truthy
     end
   end
-
 
   describe '.payment_requirements_met?' do
 
@@ -73,7 +68,6 @@ RSpec.describe RequirementsForMembership, type: :model do
       expect(subject.payment_requirements_met?(u)).to be_falsey
     end
   end
-
 
   describe 'Integration tests' do
     let(:member) { create(:member_with_membership_app) }
@@ -95,7 +89,6 @@ RSpec.describe RequirementsForMembership, type: :model do
              expire_date: expire_date)
     end
 
-
     describe '.requirements_met?' do
 
       context 'has approved application' do
@@ -105,87 +98,87 @@ RSpec.describe RequirementsForMembership, type: :model do
           approved_app.user
         end
 
-      context 'membership guidelines ARE agreed to' do
-        before(:each) { allow(UserChecklistManager).to receive(:completed_membership_guidelines_checklist?).and_return(true) }
+        context 'membership guidelines ARE agreed to' do
+          before(:each) { allow(UserChecklistManager).to receive(:completed_membership_guidelines_checklist?).and_return(true) }
 
-        it 'true if membership payment made (and it has not expired)' do
-          another_approved_app = create(:shf_application, :accepted)
-          approved_and_paid = another_approved_app.user
+          it 'true if membership payment made (and it has not expired)' do
+            another_approved_app = create(:shf_application, :accepted)
+            approved_and_paid = another_approved_app.user
 
-          start_date, expire_date = User.next_membership_payment_dates(approved_and_paid.id)
-          create(:membership_fee_payment,
-                 :successful,
-                 user: approved_and_paid,
-                 start_date: start_date,
-                 expire_date: expire_date)
+            start_date, expire_date = User.next_membership_payment_dates(approved_and_paid.id)
+            create(:membership_fee_payment,
+                   :successful,
+                   user: approved_and_paid,
+                   start_date: start_date,
+                   expire_date: expire_date)
 
-          expect(subject.requirements_met?({ user: approved_and_paid })).to be_truthy
-        end
+            expect(subject.requirements_met?({ user: approved_and_paid })).to be_truthy
+          end
 
-        it 'false if membership payment made and it HAS expired' do
-          another_approved_app = create(:shf_application, :accepted)
-          approved_and_paid = another_approved_app.user
+          it 'false if membership payment made and it HAS expired' do
+            another_approved_app = create(:shf_application, :accepted)
+            approved_and_paid = another_approved_app.user
 
-          start_date, expire_date = User.next_membership_payment_dates(approved_and_paid.id)
-          create(:membership_fee_payment,
-                 :successful,
-                 user: approved_and_paid,
-                 start_date: start_date,
-                 expire_date: expire_date)
+            start_date, expire_date = User.next_membership_payment_dates(approved_and_paid.id)
+            create(:membership_fee_payment,
+                   :successful,
+                   user: approved_and_paid,
+                   start_date: start_date,
+                   expire_date: expire_date)
 
             travel_to(expire_date + 1.day) do
-            expect(subject.requirements_met?({ user: approved_and_paid })).to be_falsey
+              expect(subject.requirements_met?({ user: approved_and_paid })).to be_falsey
+            end
+          end
+
+          it 'false if membership payment not made' do
+            expect(subject.requirements_met?({ user: approved_applicant })).to be_falsey
           end
         end
 
-        it 'false if membership payment not made' do
-          expect(subject.requirements_met?({ user: approved_applicant })).to be_falsey
-        end
-      end
+        context 'membership guidelines NOT agreed to' do
+          before(:each) { allow(UserChecklistManager).to receive(:completed_membership_guidelines_checklist?).and_return(false) }
 
-      context 'membership guidelines NOT agreed to' do
-        before(:each) { allow(UserChecklistManager).to receive(:completed_membership_guidelines_checklist?).and_return(false) }
+          it 'false if membership payment made AND it does not expire until AFTER the start of the membership guidelines requirements' do
+            another_approved_app = create(:shf_application, :accepted)
+            approved_and_paid = another_approved_app.user
 
-        it 'false if membership payment made AND it does not expire until AFTER the start of the membership guidelines requirements' do
-          another_approved_app = create(:shf_application, :accepted)
-          approved_and_paid = another_approved_app.user
+            start_date, expire_date = User.next_membership_payment_dates(approved_and_paid.id)
+            create(:membership_fee_payment,
+                   :successful,
+                   user: approved_and_paid,
+                   start_date: start_date,
+                   expire_date: expire_date)
 
-          start_date, expire_date = User.next_membership_payment_dates(approved_and_paid.id)
-          create(:membership_fee_payment,
-                 :successful,
-                 user: approved_and_paid,
-                 start_date: start_date,
-                 expire_date: expire_date)
-
-          expect(subject.requirements_met?({ user: approved_and_paid })).to be_falsey
-        end
-
-        it 'false if membership payment made and it HAS expired' do
-          another_approved_app = create(:shf_application, :accepted)
-          approved_and_paid = another_approved_app.user
-
-          start_date, expire_date = User.next_membership_payment_dates(approved_and_paid.id)
-          create(:membership_fee_payment,
-                 :successful,
-                 user: approved_and_paid,
-                 start_date: start_date,
-                 expire_date: expire_date)
-
-            travel_to(expire_date + 1.day) do
             expect(subject.requirements_met?({ user: approved_and_paid })).to be_falsey
           end
-        end
 
-        it 'false if membership payment not made' do
-          expect(subject.requirements_met?({ user: approved_applicant })).to be_falsey
+          it 'false if membership payment made and it HAS expired' do
+            another_approved_app = create(:shf_application, :accepted)
+            approved_and_paid = another_approved_app.user
+
+            start_date, expire_date = User.next_membership_payment_dates(approved_and_paid.id)
+            create(:membership_fee_payment,
+                   :successful,
+                   user: approved_and_paid,
+                   start_date: start_date,
+                   expire_date: expire_date)
+
+            travel_to(expire_date + 1.day) do
+              expect(subject.requirements_met?({ user: approved_and_paid })).to be_falsey
+            end
+          end
+
+          it 'false if membership payment not made' do
+            expect(subject.requirements_met?({ user: approved_applicant })).to be_falsey
+          end
         end
       end
-    end
 
-    context 'does not have an approved application: always false' do
+      context 'does not have an approved application: always false' do
 
-      context 'membership guidelines ARE agreed to' do
-        before(:each) { allow(UserChecklistManager).to receive(:completed_membership_guidelines_checklist?).and_return(true) }
+        context 'membership guidelines ARE agreed to' do
+          before(:each) { allow(UserChecklistManager).to receive(:completed_membership_guidelines_checklist?).and_return(true) }
 
           ShfApplication.all_states.reject { |s| s == ShfApplication::STATE_ACCEPTED }.each do |app_state|
 

--- a/spec/models/reqs_updaters/requirements_for_renewal_spec.rb
+++ b/spec/models/reqs_updaters/requirements_for_renewal_spec.rb
@@ -1,0 +1,295 @@
+require 'rails_helper'
+
+RSpec.describe RequirementsForRenewal, type: :model do
+
+  before(:each) do
+    # stub this so we don't have to create the MasterChecklist for the Member Guidelines checklist
+    # if a ShfApplication is accepted.
+    allow(AdminOnly::UserChecklistFactory).to receive(:create_member_guidelines_checklist_for).and_return(true)
+  end
+
+  let(:subject) { RequirementsForRenewal }
+  let(:user) { build(:user) }
+
+
+  describe '.has_expected_arguments?' do
+    it 'args has expected :user key' do
+      expect(subject.has_expected_arguments?({ user: 'some user' })).to be_truthy
+    end
+
+    it 'args does not have expected :user key' do
+      expect(subject.has_expected_arguments?({ not_user: 'not some user' })).to be_falsey
+    end
+
+    it 'args is nil' do
+      expect(subject.has_expected_arguments?(nil)).to be_falsey
+    end
+  end
+
+
+  describe '.requirements_met?' do
+    it 'checks if all non-payment requirements are met' do
+      u = build(:user)
+      expect(subject).to receive(:requirements_excluding_payments_met?).with(u)
+      subject.requirements_met?(user: u)
+    end
+
+    it 'checks if all payment requirements are met' do
+      u = build(:user)
+      allow(subject).to receive(:requirements_excluding_payments_met?)
+                          .with(u)
+                          .and_return(true)
+      expect(subject).to receive(:payment_requirements_met?).with(u)
+      subject.requirements_met?(user: u)
+    end
+  end
+
+
+  describe '.requirements_excluding_payments_met?' do
+    it 'all requirements checked and && together' do
+      allow(subject).to receive(:max_days_can_still_renew).and_return(10)
+
+      expect(user).to receive(:has_approved_shf_application?)
+                        .and_return(true)
+      expect(subject).to receive(:membership_guidelines_checklist_done?)
+                           .and_return(true)
+      expect(subject).to receive(:doc_uploaded_during_this_membership_term?)
+                           .with(user)
+                           .and_return(true)
+      expect(user).to receive(:can_renew_today?)
+                        .and_return(true)
+
+      expect(subject.requirements_excluding_payments_met?(user)).to be_truthy
+    end
+  end
+
+
+  describe '.doc_uploaded_during_this_membership_term?' do
+
+    it 'queries the user to see if a doc has been uploaded on or after the term start' do
+      expect(user).to receive(:file_uploaded_during_this_membership_term?)
+                          .and_return(true)
+      expect(subject.doc_uploaded_during_this_membership_term?(user)).to be_truthy
+    end
+
+    it 'no docs uploaded' do
+      expect(subject.doc_uploaded_during_this_membership_term?(user)).to be_falsey
+    end
+  end
+
+
+  describe '.max_days_can_still_renew' do
+    it 'gets the membership_expired_grace_period from the Application Configuration' do
+      expect(AdminOnly::AppConfiguration.config_to_use).to receive(:membership_expired_grace_period).and_return(5)
+      described_class.max_days_can_still_renew
+    end
+  end
+
+
+  describe '.payment_requirements_met?' do
+
+    it 'true if a payment has been made and the expiration date is in the future' do
+      u = build(:user)
+      expect(u).to receive(:payments_current?).and_return(true)
+      expect(subject.payment_requirements_met?(u)).to be_truthy
+    end
+
+    context 'a payment has been made but the expiration date is today or in the past' do
+
+      it 'result = is the payment expiration still in the grace period?' do
+        u = build(:user)
+        allow(u).to receive(:payments_current?).and_return(false)
+
+        expect(u).to receive(:membership_expired_in_grace_period?).and_return(true)
+        expect(subject.payment_requirements_met?(u)).to be_truthy
+      end
+    end
+
+    it 'false if no payments have been made' do
+      u = build(:user)
+      expect(subject.payment_requirements_met?(u)).to be_falsey
+    end
+  end
+
+
+
+  describe 'Integration tests' do
+    let(:member) { build(:member_with_membership_app) }
+
+    describe '.requirements_met?' do
+      before(:each) { allow(User).to receive(:days_can_renew_early).and_return(5) }
+
+      it 'always false if has never made a payment' do
+        approved_app = create(:shf_application, :accepted)
+        expect(subject.requirements_met?({ user: approved_app.user })).to be_falsey
+      end
+
+
+      context 'has approved application' do
+
+        let(:approved_applicant) do
+          approved_app = create(:shf_application, :accepted)
+          approved_app.user
+        end
+
+        context 'membership guidelines ARE agreed to' do
+          before(:each) { allow(UserChecklistManager).to receive(:completed_membership_guidelines_checklist?).and_return(true) }
+
+          context 'file has been uploaded during this membership term' do
+            before(:each) { allow(described_class).to receive(:doc_uploaded_during_this_membership_term?).and_return(true) }
+
+            context 'membership has not expired' do
+
+              it 'true if not too early to renew' do
+                another_approved_app = create(:shf_application, :accepted)
+                approved_and_paid = another_approved_app.user
+
+                start_date, expire_date = User.next_membership_payment_dates(approved_and_paid.id)
+                create(:membership_fee_payment,
+                       :successful,
+                       user: approved_and_paid,
+                       start_date: start_date,
+                       expire_date: expire_date)
+
+                travel_to(expire_date - 3) do
+                  expect(approved_and_paid.can_renew_today?).to be_truthy
+                  expect(approved_and_paid.membership_guidelines_checklist_done?).to be_truthy
+                  expect(subject.doc_uploaded_during_this_membership_term?(approved_and_paid)).to be_truthy
+
+                  expect(subject.requirements_met?({ user: approved_and_paid })).to be_truthy
+                end
+              end
+
+              it 'false if too early to renew' do
+                another_approved_app = create(:shf_application, :accepted)
+                approved_and_paid = another_approved_app.user
+
+                start_date, expire_date = User.next_membership_payment_dates(approved_and_paid.id)
+                create(:membership_fee_payment,
+                       :successful,
+                       user: approved_and_paid,
+                       start_date: start_date,
+                       expire_date: expire_date)
+
+                travel_to(expire_date - 7) do
+                  expect(approved_and_paid.can_renew_today?).to be_falsey
+                  expect(approved_and_paid.membership_guidelines_checklist_done?).to be_truthy
+                  expect(subject.doc_uploaded_during_this_membership_term?(approved_and_paid)).to be_truthy
+
+                  expect(subject.requirements_met?({ user: approved_and_paid })).to be_falsey
+                end
+              end
+            end
+
+            context 'membership has expired' do
+
+              it 'true if membership payment made and still in grace period' do
+                another_approved_app = create(:shf_application, :accepted)
+                approved_and_paid = another_approved_app.user
+
+                start_date, expire_date = User.next_membership_payment_dates(approved_and_paid.id)
+                create(:membership_fee_payment,
+                       :successful,
+                       user: approved_and_paid,
+                       start_date: start_date,
+                       expire_date: expire_date)
+
+                travel_to(expire_date + 1.day) do
+                  expect(subject.requirements_met?({ user: approved_and_paid })).to be_truthy
+                end
+              end
+            end
+
+            it 'false if membership payment not made' do
+              expect(subject.requirements_met?({ user: approved_applicant })).to be_falsey
+            end
+          end
+
+          context 'no file uploaded during this membership term' do
+            it 'always false' do
+              allow(described_class).to receive(:doc_uploaded_during_this_membership_term?)
+                                          .and_return(false)
+
+              another_approved_app = create(:shf_application, :accepted)
+              approved_and_paid = another_approved_app.user
+
+              start_date, expire_date = User.next_membership_payment_dates(approved_and_paid.id)
+              create(:membership_fee_payment,
+                     :successful,
+                     user: approved_and_paid,
+                     start_date: start_date,
+                     expire_date: expire_date)
+
+              travel_to(expire_date - 3) do
+                expect(approved_and_paid.can_renew_today?).to be_truthy
+                expect(approved_and_paid.membership_guidelines_checklist_done?).to be_truthy
+                expect(subject.doc_uploaded_during_this_membership_term?(approved_and_paid)).to be_falsey
+
+                expect(subject.requirements_met?({ user: approved_and_paid })).to be_falsey
+              end
+            end
+          end
+
+        end
+
+        context 'membership guidelines NOT agreed to' do
+          before(:each) { allow(UserChecklistManager).to receive(:completed_membership_guidelines_checklist?).and_return(false) }
+
+          it 'always false' do
+            another_approved_app = create(:shf_application, :accepted)
+            approved_and_paid = another_approved_app.user
+            expect(subject.requirements_met?(user: approved_and_paid)).to be_falsey
+          end
+        end
+      end
+
+      context 'does not have an approved application: always false' do
+
+        context 'membership guidelines ARE agreed to' do
+          before(:each) { allow(UserChecklistManager).to receive(:completed_membership_guidelines_checklist?).and_return(true) }
+
+          ShfApplication.all_states.reject { |s| s == ShfApplication::STATE_ACCEPTED }.each do |app_state|
+
+            context "app is #{app_state}" do
+
+              it "false if membership payment made (and it has not expired)" do
+                unapproved_app = create(:shf_application, state: app_state)
+                unapproved_user = unapproved_app.user
+                start_date, expire_date = User.next_membership_payment_dates(unapproved_user.id)
+                create(:membership_fee_payment,
+                       :successful,
+                       user: unapproved_user,
+                       start_date: start_date,
+                       expire_date: expire_date)
+
+                expect(subject.requirements_met?({ user: unapproved_user })).to be_falsey
+              end
+
+              it "false if membership payment made and it HAS expired" do
+                unapproved_app = create(:shf_application, state: app_state)
+                unapproved_and_paid = unapproved_app.user
+
+                start_date, expire_date = User.next_membership_payment_dates(unapproved_and_paid.id)
+                create(:membership_fee_payment,
+                       :successful,
+                       user: unapproved_and_paid,
+                       start_date: start_date,
+                       expire_date: expire_date)
+
+                travel_to(expire_date + 1.day) do
+                  expect(subject.requirements_met?({ user: unapproved_and_paid })).to be_falsey
+                end
+              end
+
+              it "false if membership payment not made" do
+                unapproved_app = create(:shf_application, state: app_state)
+                unapproved_applicant = unapproved_app.user
+                expect(subject.requirements_met?({ user: unapproved_applicant })).to be_falsey
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/reqs_updaters/requirements_for_renewal_spec.rb
+++ b/spec/models/reqs_updaters/requirements_for_renewal_spec.rb
@@ -94,23 +94,14 @@ RSpec.describe RequirementsForRenewal, type: :model do
       expect(subject.payment_requirements_met?(u)).to be_truthy
     end
 
-    context 'a payment has been made but the expiration date is today or in the past' do
-
-      it 'result = is the payment expiration still in the grace period?' do
-        u = build(:user)
-        allow(u).to receive(:payments_current?).and_return(false)
-
-        expect(u).to receive(:membership_expired_in_grace_period?).and_return(true)
-        expect(subject.payment_requirements_met?(u)).to be_truthy
-      end
-    end
-
     it 'false if no payments have been made' do
       u = build(:user)
       expect(subject.payment_requirements_met?(u)).to be_falsey
     end
   end
 
+
+  # ------------------------------------------------------------------------------------------
 
 
   describe 'Integration tests' do
@@ -183,7 +174,7 @@ RSpec.describe RequirementsForRenewal, type: :model do
 
             context 'membership has expired' do
 
-              it 'true if membership payment made and still in grace period' do
+              it 'false if membership payment made and still in grace period' do
                 another_approved_app = create(:shf_application, :accepted)
                 approved_and_paid = another_approved_app.user
 
@@ -195,7 +186,7 @@ RSpec.describe RequirementsForRenewal, type: :model do
                        expire_date: expire_date)
 
                 travel_to(expire_date + 1.day) do
-                  expect(subject.requirements_met?({ user: approved_and_paid })).to be_truthy
+                  expect(subject.requirements_met?({ user: approved_and_paid })).to be_falsey
                 end
               end
             end

--- a/spec/models/shf_application_spec.rb
+++ b/spec/models/shf_application_spec.rb
@@ -610,6 +610,33 @@ RSpec.describe ShfApplication, type: :model do
   end
 
 
+  describe 'applicant_can_upload_files?' do
+    it 'true if can edit the application' do
+      app = create(:shf_application)
+      allow(app).to receive(:applicant_can_edit?).and_return(true)
+
+      expect(app.applicant_can_upload_files?).to be_truthy
+    end
+
+    it 'true if accepted and member is current' do
+      app = create(:shf_application, :accepted)
+      allow(app.user).to receive(:membership_app_and_payments_current?).and_return(true)
+
+      expect(app.applicant_can_upload_files?).to be_truthy
+    end
+
+    it 'false otherwise' do
+      rejected_app = create(:shf_application, :rejected)
+      allow(rejected_app.user).to receive(:membership_app_and_payments_current?).and_return(true)
+      expect(rejected_app.applicant_can_upload_files?).to be_falsey
+
+      accepted_app = create(:shf_application, :accepted)
+      allow(accepted_app.user).to receive(:membership_app_and_payments_current?).and_return(false)
+      expect(accepted_app.applicant_can_upload_files?).to be_falsey
+    end
+  end
+
+
   describe 'possibly_waiting_for_upload?' do
     # Only these states can be waiting for file uploads
     STATES_CAN_BE_WAITING = %w(new under_review waiting_for_applicant)
@@ -678,7 +705,7 @@ RSpec.describe ShfApplication, type: :model do
   end
 
 
-  context 'Business Subcategories' do
+  describe 'Business Subcategories' do
 
     let(:parent) { create(:business_category, name: 'parent') }
     let(:unassociated_category) { create(:business_category) }

--- a/spec/models/shf_application_spec.rb
+++ b/spec/models/shf_application_spec.rb
@@ -610,33 +610,6 @@ RSpec.describe ShfApplication, type: :model do
   end
 
 
-  describe 'applicant_can_upload_files?' do
-    it 'true if can edit the application' do
-      app = create(:shf_application)
-      allow(app).to receive(:applicant_can_edit?).and_return(true)
-
-      expect(app.applicant_can_upload_files?).to be_truthy
-    end
-
-    it 'true if accepted and member is current' do
-      app = create(:shf_application, :accepted)
-      allow(app.user).to receive(:membership_app_and_payments_current?).and_return(true)
-
-      expect(app.applicant_can_upload_files?).to be_truthy
-    end
-
-    it 'false otherwise' do
-      rejected_app = create(:shf_application, :rejected)
-      allow(rejected_app.user).to receive(:membership_app_and_payments_current?).and_return(true)
-      expect(rejected_app.applicant_can_upload_files?).to be_falsey
-
-      accepted_app = create(:shf_application, :accepted)
-      allow(accepted_app.user).to receive(:membership_app_and_payments_current?).and_return(false)
-      expect(accepted_app.applicant_can_upload_files?).to be_falsey
-    end
-  end
-
-
   describe 'possibly_waiting_for_upload?' do
     # Only these states can be waiting for file uploads
     STATES_CAN_BE_WAITING = %w(new under_review waiting_for_applicant)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1822,7 +1822,113 @@ RSpec.describe User, type: :model do
       user_sent_package.toggle_membership_packet_status
       expect(user_sent_package.date_membership_packet_sent).not_to be_nil
     end
+  end
+
+  describe 'file_uploaded_on_or_after?' do
+    let(:yesterday) { Date.current - 1.day }
+    let(:tomorrow) { Date.current + 1.day }
+    let(:faux_file_today) { double('UploadedFile', created_at: Date.current) }
+    let(:faux_file_tomorrow) { double('UploadedFile', created_at: tomorrow) }
+    let(:faux_file_yesterday) { double('UploadedFile', created_at: yesterday) }
+    let(:faux_file_one_week_ago) { double('UploadedFile', created_at: Date.current - 7.days) }
+
+    it 'no uploads' do
+      expect(build(:user).file_uploaded_on_or_after?(tomorrow)).to be_falsey
+    end
+
+    it 'gets the last uploaded file, ordered by the method to get the most recent upload' do
+      u = build(:user)
+      allow(u).to receive(:uploaded_files).and_return([faux_file_today])
+      expect(u).to receive(:most_recent_upload_method).and_call_original
+      expect(u).to receive(:most_recent_uploaded_file).and_return(faux_file_today)
+      u.file_uploaded_on_or_after?
+    end
+
+    it 'default given date is today' do
+      u = build(:user)
+      allow(u).to receive(:uploaded_files).and_return([faux_file_today])
+      allow(u).to receive(:most_recent_uploaded_file).and_return(faux_file_today)
+
+      expect(u.file_uploaded_on_or_after?).to be_truthy
+    end
+
+    it 'true if last upload was after the given date' do
+      u = build(:user)
+      allow(u).to receive(:uploaded_files).and_return([faux_file_today, faux_file_tomorrow])
+      allow(u).to receive(:most_recent_uploaded_file).and_return(faux_file_tomorrow)
+
+      expect(u.file_uploaded_on_or_after?(yesterday)).to be_truthy
+    end
+
+    it 'true if last upload was on the given date' do
+      u = build(:user)
+      allow(u).to receive(:uploaded_files).and_return([faux_file_one_week_ago, faux_file_yesterday])
+      allow(u).to receive(:most_recent_uploaded_file).and_return(faux_file_yesterday)
+
+      expect(u.file_uploaded_on_or_after?(yesterday)).to be_truthy
+    end
+
+    it 'false if last upload was before the given date' do
+      u = build(:user)
+      allow(u).to receive(:uploaded_files).and_return([faux_file_one_week_ago, faux_file_yesterday])
+      allow(u).to receive(:most_recent_uploaded_file).and_return(faux_file_yesterday)
+
+      expect(u.file_uploaded_on_or_after?(Date.current)).to be_falsey
+    end
 
   end
 
+  describe 'file_uploaded_during_this_membership_term?' do
+    it 'gets the files uploaded on or after the membership start date' do
+      u = build(:user)
+      start_date = Date.current - 2
+      allow(u).to receive(:membership_start_date)
+                    .and_return(start_date)
+      expect(u).to receive(:file_uploaded_on_or_after?)
+                     .with(start_date)
+      u.file_uploaded_during_this_membership_term?
+    end
+  end
+
+  describe 'most_recent_uploaded_file' do
+    let(:yesterday) { Date.current - 1.day }
+    let(:tomorrow) { Date.current + 1.day }
+    let(:faux_file_today) { double('UploadedFile', created_at: Date.current) }
+    let(:faux_file_tomorrow) { double('UploadedFile', created_at: tomorrow) }
+    let(:faux_file_yesterday) { double('UploadedFile', created_at: yesterday) }
+    let(:faux_file_one_week_ago) { double('UploadedFile', created_at: Date.current - 7.days) }
+
+    it 'nil if there are no uploaded files' do
+      expect(build(:user).most_recent_uploaded_file).to be_nil
+    end
+
+    it 'returns the most recently created uploaded_file for the user' do
+      u = build(:user, uploaded_files: [])
+      file1 = create(:uploaded_file, :pdf, user: u)
+      file1.update(created_at: Time.zone.now)
+      file2 = create(:uploaded_file, :jpg, user: u)
+      file2.update(created_at: (Time.zone.now - 1.day))
+      u.uploaded_files << file1 << file2
+
+      expect(u).to receive(:uploaded_files).and_call_original
+      expect(u.most_recent_uploaded_file).to eq(file1)
+    end
+  end
+
+  describe '.most_recent_upload_method' do
+    it 'is the created_at date' do
+      expect(described_class.most_recent_upload_method).to eq(:created_at)
+    end
+  end
+
+  describe 'most_recent_upload_method' do
+    it 'calls the class method' do
+      expect(described_class).to receive(:most_recent_upload_method) #.and_call_original
+      subject.most_recent_upload_method
+    end
+  end
+
+  describe 'issue_membership_number' do
+    pending
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,8 +4,6 @@ require 'shared_context/unstub_paperclip_all_run_commands'
 require 'shared_context/users'
 require 'shared_context/named_dates'
 
-# TODO use the users already defined/created in the shared_context/users?
-
 # ================================================================================
 
 RSpec.describe User, type: :model do
@@ -18,8 +16,8 @@ RSpec.describe User, type: :model do
 
   before(:each) do
     allow_any_instance_of(Paperclip::Attachment).to receive(:post_process_file)
-                                                        .with(any_args)
-                                                        .and_call_original
+                                                      .with(any_args)
+                                                      .and_call_original
   end
 
   let(:user) { create(:user) }
@@ -99,7 +97,6 @@ RSpec.describe User, type: :model do
   end
   # --------
 
-
   describe 'Factory' do
     it 'has valid factories' do
       expect(build(:user)).to be_valid
@@ -132,8 +129,8 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_uniqueness_of :membership_number }
     it do
       is_expected.to validate_attachment_content_type(:member_photo)
-                         .allowing('image/png', 'image/jpeg')
-                         .rejecting('image/gif', 'image/bmp')
+                       .allowing('image/png', 'image/jpeg')
+                       .rejecting('image/gif', 'image/bmp')
     end
 
     describe 'validates file contents and file type' do
@@ -170,9 +167,8 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_attached_file(:member_photo) }
     it { is_expected.to have_many(:companies).through(:shf_application) }
     it { is_expected.to accept_nested_attributes_for(:shf_application)
-                            .allow_destroy(false).update_only(true) }
+                          .allow_destroy(false).update_only(true) }
   end
-
 
   describe 'Admin' do
     subject { create(:user, admin: true) }
@@ -181,14 +177,12 @@ RSpec.describe User, type: :model do
     it { is_expected.not_to be_member }
   end
 
-
   describe 'User' do
     subject { build(:user, admin: false) }
 
     it { is_expected.not_to be_admin }
     it { is_expected.not_to be_member }
   end
-
 
   describe 'destroy or nullify associated records when user is destroyed' do
 
@@ -236,7 +230,6 @@ RSpec.describe User, type: :model do
         end
       end
 
-
       context 'h-branding (h-markt licensing) payments' do
 
         it 'user (id) is set to nil' do
@@ -256,7 +249,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-
   describe 'Scopes' do
 
     describe 'admins' do
@@ -274,7 +266,6 @@ RSpec.describe User, type: :model do
         expect(all_admins).not_to include user1
       end
     end
-
 
     describe 'members' do
 
@@ -298,7 +289,6 @@ RSpec.describe User, type: :model do
       end
 
     end
-
 
     context 'with known user info' do
 
@@ -340,13 +330,11 @@ RSpec.describe User, type: :model do
         member_current_exp_jan3
       end
 
-
       it 'application_accepted' do
         in_scope = described_class.application_accepted
         app_states = in_scope.map { |member| member.shf_application.state }.uniq
         expect(app_states).to match_array([ShfApplication::STATE_ACCEPTED.to_s])
       end
-
 
       it 'membership_payment_current' do
         travel_to(jan_1) do
@@ -384,7 +372,6 @@ RSpec.describe User, type: :model do
 
     end
 
-
     describe 'expiration dates' do
 
       # set today to January 1, 2019 for every example run
@@ -400,7 +387,6 @@ RSpec.describe User, type: :model do
 
       JUN_01 = JAN_01 + 151
 
-
       describe 'membership_expires_in_x_days' do
 
         it 'x = 1 day, 0 days, -1 days' do
@@ -410,7 +396,6 @@ RSpec.describe User, type: :model do
           create(:h_branding_fee_payment, :successful,
                  user: member_only_branding_fees_exp_jan02,
                  expire_date: JAN_02)
-
 
           # both branding fee and membership fee paid on Jan 2:
           both_exp_jan02_1 = create(:member_with_membership_app, first_name: 'Both fees Exp jan02 1')
@@ -427,7 +412,6 @@ RSpec.describe User, type: :model do
           create(:member_with_expiration_date, expiration_date: JAN_01)
           create(:member_with_expiration_date, expiration_date: JAN_02)
           create(:member_with_expiration_date, expiration_date: JAN_02)
-
 
           membership_expires_in_1_day = User.membership_expires_in_x_days(1)
           expect(membership_expires_in_1_day.count).to eq 3
@@ -465,14 +449,12 @@ RSpec.describe User, type: :model do
                    expire_date: JUN_01)
           end
 
-
           expires_today = User.membership_expires_in_x_days(151)
           expect(expires_today.count).to eq 1
           expect(expires_today.pluck(:expire_date).uniq.first).to eq(JUN_01)
           expect(expires_today.pluck(:payment_type).uniq.first).to eq Payment::PAYMENT_TYPE_MEMBER
         end
       end
-
 
       describe 'company_hbrand_expires_in_x_days' do
 
@@ -483,7 +465,6 @@ RSpec.describe User, type: :model do
           create(:h_branding_fee_payment, :successful,
                  user: member_only_branding_fees_exp_jan02,
                  expire_date: JAN_02)
-
 
           # both branding fee and membership fee paid on Jan 2:
           both_exp_jan02_1 = create(:member_with_membership_app, first_name: 'Both fees Exp jan02 1')
@@ -500,7 +481,6 @@ RSpec.describe User, type: :model do
           create(:member_with_expiration_date, expiration_date: JAN_01)
           create(:member_with_expiration_date, expiration_date: JAN_02)
           create(:member_with_expiration_date, expiration_date: JAN_02)
-
 
           membership_expires_in_1_day = User.membership_expires_in_x_days(1)
           expect(membership_expires_in_1_day.count).to eq 3
@@ -538,7 +518,6 @@ RSpec.describe User, type: :model do
                    expire_date: JUN_01)
           end
 
-
           brandingfees_expires_in_151d = User.company_hbrand_expires_in_x_days(151)
           expect(brandingfees_expires_in_151d.count).to eq 1
           expect(brandingfees_expires_in_151d.pluck(:expire_date).uniq.first).to eq(JUN_01)
@@ -547,9 +526,7 @@ RSpec.describe User, type: :model do
       end
     end
 
-
   end # Scopes
-
 
   context 'proof-of-membership JPG cache management' do
     let(:user2) { create(:user) }
@@ -620,11 +597,10 @@ RSpec.describe User, type: :model do
       it 'is not called if other attribute changes' do
         expect(user).not_to receive(:clear_proof_of_membership_jpg_cache)
         user.update_attributes(email: 'new@mail.com',
-                                  date_membership_packet_sent: Date.current)
+                               date_membership_packet_sent: Date.current)
       end
     end
   end
-
 
   describe '#has_shf_application?' do
 
@@ -684,7 +660,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-
   describe '#member_fee_payment_due?' do
 
     describe 'is a member' do
@@ -711,7 +686,6 @@ RSpec.describe User, type: :model do
       end
     end
   end
-
 
   describe '#member_or_admin?' do
 
@@ -774,7 +748,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-
   describe '#allowed_to_pay_hbrand_fee?' do
 
     it 'true if the admin' do
@@ -805,7 +778,6 @@ RSpec.describe User, type: :model do
 
     end
 
-
     describe 'not a member' do
 
       it 'false if no applications' do
@@ -830,7 +802,6 @@ RSpec.describe User, type: :model do
       end
     end
   end
-
 
   describe '#has_approved_app_for_company?' do
 
@@ -881,7 +852,6 @@ RSpec.describe User, type: :model do
       end
     end
 
-
     describe 'is a member' do
 
       it 'false if company number not in the approved app with 2 other companies' do
@@ -908,7 +878,6 @@ RSpec.describe User, type: :model do
 
   end
 
-
   describe '#has_app_for_company?' do
 
     describe 'not a member' do
@@ -932,7 +901,6 @@ RSpec.describe User, type: :model do
           end
         end
       end
-
 
       describe 'true if company not in application (with 2 other companies)' do
         let(:user_with_app) { create(:user, email: 'user-app-has-given-company@example.com') }
@@ -977,7 +945,6 @@ RSpec.describe User, type: :model do
 
   end
 
-
   describe '#has_app_for_company_number?' do
 
     describe 'not a member' do
@@ -1001,7 +968,6 @@ RSpec.describe User, type: :model do
           end
         end
       end
-
 
       describe 'true if company number not in application (with 2 other companies)' do
         let(:user_with_app) { create(:user, email: 'user-app-has-given-company@example.com') }
@@ -1046,11 +1012,9 @@ RSpec.describe User, type: :model do
 
   end
 
-
-  describe '#apps_for_company' do
-
+  describe 'apps_for_company' do
+    pending
   end
-
 
   describe '#apps_for_company_number' do
 
@@ -1078,7 +1042,6 @@ RSpec.describe User, type: :model do
       expect(user_with_app.apps_for_company_number(given_co_num).to_a).to match_array([app1])
     end
   end
-
 
   describe '#sort_apps_by_when_approved' do
 
@@ -1118,7 +1081,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-
   describe '#has_full_name?' do
 
     it 'true if both first and last name are present' do
@@ -1136,8 +1098,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-
-  context 'payment and membership period' do
+  describe 'payment and membership period' do
 
     describe '#membership_start_date' do
       it 'returns the start_date for latest completed payment' do
@@ -1147,7 +1108,6 @@ RSpec.describe User, type: :model do
         expect(user.membership_start_date).to eq member_payment2.start_date
       end
     end
-
 
     describe '#membership_expire_date' do
       it 'returns the expire_date for latest completed payment' do
@@ -1176,7 +1136,6 @@ RSpec.describe User, type: :model do
       end
     end
 
-
     describe '.next_membership_payment_date' do
 
       around(:each) do |example|
@@ -1192,9 +1151,8 @@ RSpec.describe User, type: :model do
       it 'returns date-after-expiration for second payment start date' do
         member_payment1
         expect(User.next_membership_payment_date(user.id))
-            .to eq Time.zone.today + 1.year
+          .to eq Time.zone.today + 1.year
       end
-
 
       context 'if next payment occurs after prior payment expire date' do
 
@@ -1212,7 +1170,6 @@ RSpec.describe User, type: :model do
       end
     end
 
-
     describe '.next_membership_payment_dates' do
 
       around(:each) do |example|
@@ -1228,20 +1185,20 @@ RSpec.describe User, type: :model do
       # FIXME it returns one year MINUS 1 DAY
       it 'returns one year later for first payment expire date' do
         expect(User.next_membership_payment_dates(user.id)[1])
-            .to eq Time.zone.today + 1.year - 1.day
+          .to eq Time.zone.today + 1.year - 1.day
       end
 
       it 'returns date-after-expiration for second payment start date' do
         member_payment1
         expect(User.next_membership_payment_dates(user.id)[0])
-            .to eq Time.zone.today + 1.year
+          .to eq Time.zone.today + 1.year
       end
 
       # FIXME returns one year MINUS 1 DAY
       it 'returns one year later for second payment expire date' do
         member_payment1
         expect(User.next_membership_payment_dates(user.id)[1])
-            .to eq Time.zone.today + 1.year + 1.year - 1.day
+          .to eq Time.zone.today + 1.year + 1.year - 1.day
       end
 
       context 'if next payment occurs after prior payment expire date' do
@@ -1277,7 +1234,7 @@ RSpec.describe User, type: :model do
   describe '#allowed_to_pay_member_fee?' do
 
     it 'false if the user is an admin' do
-      expect(create(:admin).allowed_to_pay_member_fee?).to be_falsey
+      expect(build(:admin).allowed_to_pay_member_fee?).to be_falsey
     end
 
     context 'not an admin' do
@@ -1338,7 +1295,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-
   describe 'membership_current? just checks membership payment status' do
 
     context 'membership payments have not expired yet' do
@@ -1361,7 +1317,6 @@ RSpec.describe User, type: :model do
       end
 
     end
-
 
     context 'testing dates right before, on, and after expire_date' do
 
@@ -1407,13 +1362,11 @@ RSpec.describe User, type: :model do
 
   end
 
-
   describe 'membership_current_as_of? checks membership payment status as of a given date' do
 
     it 'is false if nil is the given date' do
       expect((create :user).membership_current_as_of?(nil)).to be_falsey
     end
-
 
     context 'membership payments have not expired yet' do
 
@@ -1433,7 +1386,6 @@ RSpec.describe User, type: :model do
       end
 
     end
-
 
     context 'testing dates right before, on, and after expire_date' do
 
@@ -1507,7 +1459,6 @@ RSpec.describe User, type: :model do
 
       end
 
-
       context 'testing dates right before, on, and after expire_date' do
 
         let(:paid_expires_today_member) {
@@ -1580,7 +1531,6 @@ RSpec.describe User, type: :model do
 
     end #  context 'has an approved application'
 
-
     context 'does NOT have an approved application - is always FALSE' do
 
       context 'membership payments have not expired yet' do
@@ -1603,7 +1553,6 @@ RSpec.describe User, type: :model do
         end
 
       end
-
 
       context 'testing dates right before, on, and after expire_date' do
 
@@ -1651,13 +1600,11 @@ RSpec.describe User, type: :model do
 
   end
 
-
   describe 'membership_app_and_payments_current_as_of?  checks both application and membership payment status as of a given date' do
 
     it 'is false if nil is the given date' do
       expect((create :user).membership_app_and_payments_current_as_of?(nil)).to be_falsey
     end
-
 
     context 'has an approved application' do
 
@@ -1683,7 +1630,6 @@ RSpec.describe User, type: :model do
         end
 
       end # context 'membership payments have not expired yet'
-
 
       context 'testing dates right before, on, and after expire_date' do
 
@@ -1737,11 +1683,9 @@ RSpec.describe User, type: :model do
           end
         end
 
-
       end # context 'testing dates right before, on, and after expire_date'
 
     end # context 'has an approved application'
-
 
     context 'does NOT have an approved application: is always FALSE' do
 
@@ -1763,7 +1707,6 @@ RSpec.describe User, type: :model do
         end
 
       end # context 'membership payments have not expired yet'
-
 
       context 'testing dates right before, on, and after expire_date' do
 
@@ -1803,7 +1746,6 @@ RSpec.describe User, type: :model do
 
   end
 
-
   describe '#get_short_proof_of_membership_url' do
     context 'there is already a shortened url in the table' do
       it 'returns shortened url' do
@@ -1827,16 +1769,14 @@ RSpec.describe User, type: :model do
     end
   end
 
-
   describe 'membership_guidelines_checklist_done?' do
 
     it 'asks the Requirement for Membership [the one place to implement that]' do
       expect(RequirementsForMembership).to receive(:membership_guidelines_checklist_done?)
-                                               .with(subject)
+                                             .with(subject)
       subject.membership_guidelines_checklist_done?
     end
   end
-
 
   describe '#membership_packet_sent?' do
 
@@ -1850,7 +1790,6 @@ RSpec.describe User, type: :model do
       expect(user_sent_package.membership_packet_sent?).to be_falsey
     end
   end
-
 
   describe '#toggle_membership_packet_status' do
 
@@ -1866,20 +1805,17 @@ RSpec.describe User, type: :model do
       expect(user_sent_package.date_membership_packet_sent).to eq frozen_time
     end
 
-
     it 'can set the date_sent' do
       set_date = Time.new(2020, 02, 02, 2, 2, 2)
       user_sent_package.toggle_membership_packet_status(set_date)
       expect(user_sent_package.date_membership_packet_sent).to eq set_date
     end
 
-
     it 'if it has been sent, now it is set to unsent' do
       user_sent_package.update(date_membership_packet_sent: Time.now)
       user_sent_package.toggle_membership_packet_status
       expect(user_sent_package.date_membership_packet_sent).to be_nil
     end
-
 
     it 'if it has not been sent, it is set to sent' do
       user_sent_package.update(date_membership_packet_sent: nil)

--- a/spec/shared_context/mock_app_configuration.rb
+++ b/spec/shared_context/mock_app_configuration.rb
@@ -123,6 +123,10 @@ class MockAppConfig
     60
   end
 
+  def self.membership_expired_grace_period
+    90
+  end
+
   # ----------------------------------------------------
   #  Default results to use to stub methods
 


### PR DESCRIPTION
## PT Story:  Renew Membership
- Renewals must also agree to Ethical Guidelines https://www.pivotaltracker.com/story/show/172131253
- Membership Renewal: New doc required every year
https://www.pivotaltracker.com/story/show/154046321

This PR has the changes and additions to **models** for implementing membership renewal.
The only UX is for the new attribute added to the Application Configuration -- so the admin can set/change the value of it.

Once these are ok, then it will be straightforward to add the UX based on this PR.

## Changes proposed in this pull request:
1.  add `membership_expired_grace_period` to AppConfiguration : the number of days after a membership has expired that a user can renew without having to apply as a new member again
2.  track all of the requirements for renewing in the new `RequirementsForRenewal` class.  Also refactor the `RequirementsForMembership` class:  both track all of the non-payment requirements and the payment-related requirements.
3. `ShfApplication:`
    - is an applicant allowed to upload more files to the application?  (Not if it has been accepted or rejected, etc.)
4.  `User` (this is where most additions were made)
    1. file uploads:  get the most recent upload; were any files uploaded during the membership term?
    2. grace period:  is a date within the grace period?  is it after the grace period?
    3. can a user pay the membership fee?
        - is this a renewal?  if so, have the renewal requirements been met?
        - is this a new member? if so, have the membership requirements been met?

---
## Ready for review:
@patmbolger @thesuss @AgileVentures/shf-project-team 
