### PR TITLE
Admin CSV reports: Payments covering a year; refactor into models

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -3,24 +3,26 @@ class AdminController < AdminOnlyController
   # FIXME - this is really an exporter!
 
   def export_ansokan_csv
-    export_csv(AdminOnly::Reports::ShfApplicationsCsvReport.new)
+    export_csv(AdminOnly::Reports::ShfApplicationsCsvReport.new, t('.success'), t('.error'))
   end
 
 
   def export_payments_csv
-    export_csv(AdminOnly::Reports::PaymentsCsvReport.new)
+    export_csv(AdminOnly::Reports::PaymentsCsvReport.new, t('.success'), t('.error'))
   end
 
 
   def export_payments_covering_year_csv
-    export_csv(AdminOnly::Reports::PaymentsCoveringYearCsvReport.new(params[:year]))
+    export_csv(AdminOnly::Reports::PaymentsCoveringYearCsvReport.new(params[:year]),
+               t('.success'), t('.error'))
   end
 
 
   private
 
-  def export_csv(csv_report)
-    export_file(csv_report.to_csv, csv_report.csv_filename, success_msg: t('.success'), error_msg: t('.error'))
+  def export_csv(csv_report, success_message, error_message)
+    export_file(csv_report.to_csv, csv_report.csv_filename,
+                success_msg: success_message, error_msg: error_message)
   end
 
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,64 +1,28 @@
 class AdminController < AdminOnlyController
 
   # FIXME - this is really an exporter!
-  # FIXME - DRY
 
-
-  # export shf_appplications
   def export_ansokan_csv
-
-    begin
-      @shf_applications = ShfApplication.includes(:user).all
-
-      export_name = "Ansokningar-#{Time.zone.now.strftime('%Y-%m-%d--%H-%M-%S')}.csv"
-
-      send_data(export_shf_apps_str(@shf_applications), filename: export_name, type: "text/plain")
-
-      helpers.flash_message(:notice, t('.success'))
-
-    rescue => e
-
-      helpers.flash_message(:alert, "#{t('.error')} [#{e.message}]")
-      redirect_to(request.referer.present? ? :back : root_path)
-
-    end
-
+    export_csv(AdminOnly::Reports::ShfApplicationsCsvReport.new)
   end
 
 
   def export_payments_csv
-    payments = Payment.includes(:user).includes(:company).all
-    export_name = "betalningar-#{Time.zone.now.strftime('%Y-%m-%d--%H-%M-%S')}.csv"
-
-    csv_adapter_class = Adapters::PaymentToCsvAdapter
-    header_str = csv_adapter_class.header_str
-
-    file_contents = items_export_str(payments, csv_adapter_class, header_str)
-
-    export_file(file_contents, export_name, success_msg: t('.success'), error_msg: t('.error'))
+    export_csv(AdminOnly::Reports::PaymentsCsvReport.new)
   end
 
 
   def export_payments_covering_year_csv
-
-    year = params[:year].to_i
-    # FIXME - check params.  error if year is missing
-
-    payments = Payment.includes(:user).includes(:company).covering_year(year.to_i)
-    payments_for_year = payments.map { |payment| PaymentCoveringYear.new(payment: payment, year: year) }
-
-    export_name = "betalningar-for-#{year}--#{Time.zone.now.strftime('%Y-%m-%d--%H-%M-%S')}.csv"
-
-    csv_adapter_class = Adapters::PaymentCoveringYearToCsvAdapter
-    header_str = csv_adapter_class.header_str(year)
-    file_contents = items_export_str(payments_for_year, csv_adapter_class,
-                                     header_str)
-
-    export_file(file_contents, export_name, success_msg: t('.success'), error_msg: t('.error'))
+    export_csv(AdminOnly::Reports::PaymentsCoveringYearCsvReport.new(params[:year]))
   end
 
 
   private
+
+  def export_csv(csv_report)
+    export_file(csv_report.to_csv, csv_report.csv_filename, success_msg: t('.success'), error_msg: t('.error'))
+  end
+
 
   def export_file(file_contents_str, export_filename,
                   success_msg: 'Success!', error_msg: 'Error: something went wrong with the export.')
@@ -73,76 +37,5 @@ class AdminController < AdminOnlyController
       redirect_to(request.referer.present? ? :back : root_path)
     end
 
-  end
-
-
-  def items_export_str(items = [], csv_adapter_class = nil, header_str = '')
-    out_str = header_str
-    items.each do |item|
-      out_str << csv_adapter_class.new(item).as_target.to_s unless csv_adapter_class.nil?
-      out_str << "\n"
-    end
-    out_str.encode('UTF-8')
-  end
-
-
-  # Create a comma separated string for all applications, each application is 1 row
-  # so that the info can be used by SHF for reporting,
-  # to import into other systems, and as
-  # checklists (e.g. to see who has/has not got a membership packet yet, etc.)
-  #
-  # @param shf_apps [Array] - a list of ShfApplications; 1 for each row to be exported
-  # @return [String] - the Comma Separated Values (CSV) list, with a header and 1
-  #    row of information for each application
-  #
-  def export_shf_apps_str(shf_apps)
-
-    out_str = export_shf_apps_header_str
-
-    shf_apps.each do |shf_app|
-      out_str << Adapters::ShfApplicationToCsvAdapter.new(shf_app).as_target.to_s
-      out_str << "\n"
-    end
-
-    out_str.encode('UTF-8')
-  end
-
-
-  # FIXME - these headers should be in the Adapter
-
-  # build the CSV export ShfApplications header string from strings in the locale file(s)
-  def export_shf_apps_header_str
-
-    header_strs = [t('activerecord.attributes.shf_application.contact_email'),
-                   t('activerecord.attributes.user.email'),
-                   t('activerecord.attributes.shf_application.first_name'),
-                   t('activerecord.attributes.shf_application.last_name'),
-                   t('activerecord.attributes.user.membership_number'),
-                   t('activerecord.attributes.user.date_member_packet_sent'),
-                   t('activerecord.attributes.shf_application.state'),
-                   t('admin.export_ansokan_csv.date_state_changed'),
-                   t('activerecord.models.business_category.other'),
-                   t('activerecord.models.company.one'),
-                   t('admin.export_ansokan_csv.member_fee_paid'),
-                   t('admin.export_ansokan_csv.member_fee_expires'),
-                   t('admin.export_ansokan_csv.branding_fee_paid'),
-                   t('admin.export_ansokan_csv.branding_fee_expires'),
-                   t('activerecord.attributes.address.street'),
-                   t('activerecord.attributes.address.post_code'),
-                   t('activerecord.attributes.address.city'),
-                   t('activerecord.attributes.address.kommun'),
-                   t('activerecord.attributes.address.region'),
-                   t('activerecord.attributes.address.country'),
-    ]
-    create_header_str(header_strs)
-  end
-
-
-  def create_header_str(header_entries)
-    out_str = '' # is this stmt needed?
-
-    out_str << header_entries.map { |header_str| "'#{header_str.strip}'" }.join(',')
-
-    out_str << "\n"
   end
 end

--- a/app/models/adapters/payment_covering_year_to_csv_adapter.rb
+++ b/app/models/adapters/payment_covering_year_to_csv_adapter.rb
@@ -55,7 +55,6 @@ module Adapters
     # @return [Array<String] - a list of the header strings
     #
     def self.headers(year)
-
       ["#{I18n.t('activerecord.models.payment.one')} db id",
        I18n.t('name'),
        'E-post',
@@ -79,8 +78,5 @@ module Adapters
        I18n.t('notes', scope: I18N_PAYMENT_ATTRIBS)
       ]
     end
-
-
   end
-
 end

--- a/app/models/adapters/shf_application_to_csv_adapter.rb
+++ b/app/models/adapters/shf_application_to_csv_adapter.rb
@@ -17,7 +17,7 @@ module Adapters
   # @file shf_application_to_csv_adapter.rb
   #
   #--------------------------
-  class ShfApplicationToCsvAdapter < AbstractAdapter
+  class ShfApplicationToCsvAdapter < AbstractCsvAdapter
 
 
     # Required so that the url for the payment page can be used
@@ -26,6 +26,30 @@ module Adapters
 
     def target_class
       CsvRow
+    end
+
+    def self.headers(_args)
+      [I18n.t('activerecord.attributes.shf_application.contact_email'),
+       I18n.t('activerecord.attributes.user.email'),
+       I18n.t('activerecord.attributes.shf_application.first_name'),
+       I18n.t('activerecord.attributes.shf_application.last_name'),
+       I18n.t('activerecord.attributes.user.membership_number'),
+       I18n.t('activerecord.attributes.user.date_member_packet_sent'),
+       I18n.t('activerecord.attributes.shf_application.state'),
+       I18n.t('admin.export_ansokan_csv.date_state_changed'),
+       I18n.t('activerecord.models.business_category.other'),
+       I18n.t('activerecord.models.company.one'),
+       I18n.t('admin.export_ansokan_csv.member_fee_paid'),
+       I18n.t('admin.export_ansokan_csv.member_fee_expires'),
+       I18n.t('admin.export_ansokan_csv.branding_fee_paid'),
+       I18n.t('admin.export_ansokan_csv.branding_fee_expires'),
+       I18n.t('activerecord.attributes.address.street'),
+       I18n.t('activerecord.attributes.address.post_code'),
+       I18n.t('activerecord.attributes.address.city'),
+       I18n.t('activerecord.attributes.address.kommun'),
+       I18n.t('activerecord.attributes.address.region'),
+       I18n.t('activerecord.attributes.address.country')
+      ]
     end
 
 
@@ -97,13 +121,13 @@ module Adapters
     end
 
 
-    # t('Paid') if member fee is paid, otherwise make link to where to pay it
+    # I18n.t('Paid') if member fee is paid, otherwise make link to where to pay it
     def paid_or_payment_link(is_paid, payment_url)
       is_paid ? I18n.t('admin.export_ansokan_csv.paid') : I18n.t('admin.export_ansokan_csv.fee_payment_url', payment_url: payment_url)
     end
 
 
-    # return t('never paid') if arg isNil else the arg.to_s
+    # return I18n.t('never paid') if arg isNil else the arg.to_s
     def never_paid_if_blank(arg)
       arg.blank? ? I18n.t('admin.export_ansokan_csv.never_paid') : arg.to_s
     end

--- a/app/models/admin_only/reports/csv_report.rb
+++ b/app/models/admin_only/reports/csv_report.rb
@@ -1,0 +1,84 @@
+#--------------------------
+#
+# @class CsvReport
+#
+# @desc Responsibility: Common behavior for all reports that can be saved as a CSV file.
+#   - returns the file name
+#   - returns the information as a String with a header and each item as a line with comma separated values (CSVs)
+#
+#
+# @author Ashley Engelund (ashley.engelund@gmail.com  weedySeaDragon @ github)
+# @date   1/25/21
+#
+#--------------------------
+
+class AdminOnly::Reports::CsvReport
+
+  attr_writer :report_items
+
+  # Subclasses MUST define this
+  def self.csv_adapter
+    raise NoMethodError "Subclasses must define #{__method__}"
+  end
+
+
+  # -----------------------------------------------------------------------------------------------
+
+  def initialize(*args)
+    @report_items = get_report_items(args)
+  end
+
+
+  def to_csv
+    items_exported_as_csv(report_items, self.class.csv_adapter, csv_header)
+  end
+
+
+  # Subclasses must override this method to set the report_items
+  def get_report_items(_args)
+    raise NoMethodError, "Subclasses must define #{__method__} and set the report items"
+  end
+
+  def csv_header
+    self.class.csv_adapter.header_str(*csv_header_args)
+  end
+
+
+  # Subclasses can overwrite this to pass in arguments to the adaper class.  ex:
+  # pass in a year value:
+  #    def csv_header_args
+  #      [year]
+  #    end
+  #
+  # @return [Array] - the array of arguments to pass to the adapter .header_str method
+  def csv_header_args
+    []
+  end
+
+
+  def items_exported_as_csv(items = [], csv_adapter = nil, header_str = '')
+    out_str = '' << header_str
+    items.each do |item|
+      out_str << csv_adapter.new(item).as_target.to_s unless csv_adapter.nil?
+      out_str << "\n"
+    end
+    out_str.encode('UTF-8')
+  end
+
+
+  def csv_filename
+    "#{filename_start}--#{Time.zone.now.strftime('%Y-%m-%d--%H-%M-%S')}.csv"
+  end
+
+
+  # Subclasses should provide a more meaningful string
+  def filename_start
+    'rapportera'
+  end
+
+
+  def report_items
+    @report_items ||= []
+  end
+end
+

--- a/app/models/admin_only/reports/payments_covering_year_csv_report.rb
+++ b/app/models/admin_only/reports/payments_covering_year_csv_report.rb
@@ -1,0 +1,47 @@
+#--------------------------
+#
+# @class PaymentsCoveringYearCsvReport
+#
+# @desc Responsibility: all info for a "payments covering any part of a given year" report.
+#   Gathers all of the successful Payments that cover any part of the given year
+#   - can return it in a CSV form
+#
+#
+# @author Ashley Engelund (ashley.engelund@gmail.com  weedySeaDragon @ github)
+# @date   1/25/21
+#
+#--------------------------
+
+class AdminOnly::Reports::PaymentsCoveringYearCsvReport < AdminOnly::Reports::CsvReport
+
+  attr_accessor :year
+  attr_reader :payments
+
+
+  def self.csv_adapter
+    Adapters::PaymentCoveringYearToCsvAdapter
+  end
+
+
+  # -----------------------------------------------------------------------------------------------
+
+  def initialize(year = Date.current.year)
+    @year = year.to_i
+    super
+  end
+
+  def get_report_items(_args)
+    @payments = Payment.includes(:user).includes(:company).completed.covering_year(year.to_i)
+    @report_items = @payments.map { |payment| PaymentCoveringYear.new(payment: payment, year: year) }
+  end
+
+
+  def filename_start
+    "framgangsrika-betalningar-#{year}"
+  end
+
+
+  def csv_header_args
+    [year]
+  end
+end

--- a/app/models/admin_only/reports/payments_csv_report.rb
+++ b/app/models/admin_only/reports/payments_csv_report.rb
@@ -1,0 +1,30 @@
+#--------------------------
+#
+# @class PaymentsCsvReport
+#
+# @desc Responsibility: CSV report for all Payments
+#
+#
+# @author Ashley Engelund (ashley.engelund@gmail.com  weedySeaDragon @ github)
+# @date   1/25/21
+#
+#--------------------------
+
+class AdminOnly::Reports::PaymentsCsvReport < AdminOnly::Reports::CsvReport
+
+  def self.csv_adapter
+    Adapters::PaymentToCsvAdapter
+  end
+
+
+  # -----------------------------------------------------------------------------------------------
+
+  def get_report_items(_args)
+    Payment.includes(:user).includes(:company).all
+  end
+
+
+  def filename_start
+    'betalningar'
+  end
+end

--- a/app/models/admin_only/reports/shf_applications_csv_report.rb
+++ b/app/models/admin_only/reports/shf_applications_csv_report.rb
@@ -1,0 +1,30 @@
+#--------------------------
+#
+# @class ShfApplicationsCsvReport
+#
+# @desc Responsibility: CSV report for all ShfApplications
+#
+#
+# @author Ashley Engelund (ashley.engelund@gmail.com  weedySeaDragon @ github)
+# @date   1/25/21
+#
+#--------------------------
+
+class AdminOnly::Reports::ShfApplicationsCsvReport < AdminOnly::Reports::CsvReport
+
+  def self.csv_adapter
+    Adapters::ShfApplicationToCsvAdapter
+  end
+
+
+  # -----------------------------------------------------------------------------------------------
+
+  def get_report_items(_args)
+    ShfApplication.includes(:user).all
+  end
+
+
+  def filename_start
+    'Ansokningar'
+  end
+end

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -92,22 +92,6 @@ RSpec.describe AdminController, type: :controller do
 
       end
 
-      it 'filename is Ansokningar-<datetime>.csv' do
-
-        post :export_ansokan_csv
-
-        expect(response.header['Content-Disposition']).to match(/filename=\"Ansokningar-\d\d\d\d-\d\d-\d\d--\d\d-\d\d-\d\d\.csv\"/)
-      end
-
-
-      it 'header line is correct' do
-
-        export_response_body
-
-        expect(export_response_body).to eq csv_header
-
-      end
-
 
       describe 'with 0 membership applications' do
 
@@ -426,41 +410,27 @@ RSpec.describe AdminController, type: :controller do
 
 
       describe 'error from send_data is rescued' do
-
-        # status, location, response_body
-
         let(:error_message) { 'Error. Error. Warning Will Robinson' }
 
-        subject { allow(@controller).to receive(:send_data) { raise StandardError.new(error_message) }
-
-        post :export_ansokan_csv
-        }
-
+        subject do
+          allow(@controller).to receive(:send_data) { raise StandardError.new(error_message) }
+          post :export_ansokan_csv
+        end
 
         it 'redirects to back or the root path' do
-
           expect(subject).to redirect_to root_path
-
         end
-
 
         it "flashes an error :alert message" do
-
-          error_flash_message = ["#{I18n.t('admin.export_ansokan_csv.error')} [#{error_message}]"]
-
           expect(subject.request.flash[:alert]).to_not be_nil
-          expect(subject.request.flash[:alert]).to eq error_flash_message
-
+          expect(subject.request.flash[:alert]).to eq ["#{I18n.t('admin.export_ansokan_csv.error')}"]
         end
-
       end
 
 
       describe 'includes membership expiry date' do
 
-
         it "no membership expiry date shows wording and url to pay and 'never paid'" do
-
           user_with_app = FactoryBot.create(:user_with_membership_app)
 
           user_app = user_with_app.shf_application
@@ -474,9 +444,7 @@ RSpec.describe AdminController, type: :controller do
           expected_pattern = /(.*)\n(.*),(.*),(.*),(.*),(.*),(.*),([^"]*),"([^"]*)","([^"]*)","(#{pay_using_url})","(#{never_paid})","([^"]*)","([^"]*)","([^"]*)",'(.*),"([^"]*)",(.*),(.*),(.*)/m
 
           expect(response.body).to match expected_pattern
-
         end
-
       end
 
 

--- a/spec/models/admin_only/reports/csv_report_spec.rb
+++ b/spec/models/admin_only/reports/csv_report_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe AdminOnly::Reports::CsvReport, type: :model do
+
+  let(:stand_in_adapter) { Adapters::PaymentCoveringYearToCsvAdapter }
+  let(:header_line) { "this, is, the,csv,header,line\n" }
+
+  before(:each) { allow_any_instance_of(described_class).to receive(:get_report_items).and_return([]) }
+
+
+  describe '.csv_adapter' do
+    it 'raises a NoMethodError because subclasses must define this' do
+      expect { described_class.csv_adapter }.to raise_error(NoMethodError)
+    end
+  end
+
+  it 'new will call get_report_items to give subclasses a way to set the list of report items' do
+    expect_any_instance_of(described_class).to receive(:get_report_items).and_return(true)
+    described_class.new
+  end
+
+  it 'get_report_items raises NoMethodError because subclasses must override this' do
+    allow_any_instance_of(described_class).to receive(:get_report_items).and_call_original
+    expect{subject.get_report_items(nil)}.to raise_error(NoMethodError)
+  end
+
+
+  describe 'to_csv' do
+    it 'calls items_exported_as_csv with the report items, adapter class to use, and header line' do
+      report_items = ['a', 'b']
+      subject.report_items = report_items
+
+      expect(described_class).to receive(:csv_adapter).and_return('faux_adapter')
+      expect(subject).to receive(:csv_header).and_return(header_line)
+      expect(subject).to receive(:items_exported_as_csv)
+                          .with(report_items, 'faux_adapter', header_line)
+      subject.to_csv
+    end
+  end
+
+  describe 'csv_header' do
+    it 'passes the csv_header args to the header_str method of the adapter' do
+      header_args = [2, 'argument', :values]
+      allow(described_class).to receive(:csv_adapter).and_return(stand_in_adapter)
+      allow(subject).to receive(:csv_header_args).and_return(header_args)
+
+      expect(described_class.csv_adapter).to receive(:header_str).with(*header_args)
+      subject.csv_header
+    end
+  end
+
+  describe 'csv_header_args' do
+    it 'defaults to no args (an empty list of args)' do
+      expect(subject.csv_header_args).to eq []
+    end
+  end
+
+  describe 'items_exported_as_csv' do
+
+    it 'starts with the header string' do
+      allow(subject).to receive(:csv_header).and_return(header_line)
+      expect(subject.items_exported_as_csv([], nil, header_line)).to match(/^#{header_line}/)
+    end
+
+    it 'goes through the given items and uses the adapter class to generate a CSV line for each' do
+      faux_target = double(as_target: 'some,resulting,values,for,the,item')
+      faux_adapter = double(stand_in_adapter)
+
+      faux_target_csv_line = "some,resulting,values,for,the,item\n"
+
+      expect(faux_adapter).to receive(:new).exactly(3).times.and_return(faux_target)
+      expect(subject.items_exported_as_csv([1, 2, 3], faux_adapter, header_line))
+        .to match(/#{header_line}#{faux_target_csv_line}#{faux_target_csv_line}#{faux_target_csv_line}/)
+    end
+
+    it 'encodes the string as UTF-8' do
+      expect(subject.items_exported_as_csv.encoding.to_s).to eq 'UTF-8'
+    end
+  end
+
+
+  describe 'csv_filename' do
+    it 'is the start string, 2 dashes then a timestamp' do
+      start_str = 'FantasticReport'
+      allow(subject).to receive(:filename_start).and_return(start_str)
+
+      travel_to Time.parse("2021-01-25 01:03:04 -0100") do
+        expect(subject.csv_filename).to match(/#{start_str}--2021-01-25--02-03-04/)
+      end
+    end
+
+    it 'extension is csv' do
+      expect(subject.csv_filename.split('.').last).to eq 'csv'
+    end
+  end
+
+
+  describe 'filename_start' do
+    it "is 'rapportera'. Subclasses should provide something more specific and meaningful" do
+      expect(subject.filename_start).to eq 'rapportera'
+    end
+  end
+
+
+  describe 'report_items' do
+    it 'is an empty list. Subclasses should set this to the list of things to convert (adapt) to CSV lines' do
+      expect(subject.report_items).to eq []
+    end
+  end
+
+end

--- a/spec/models/admin_only/reports/payments_covering_year_csv_report_spec.rb
+++ b/spec/models/admin_only/reports/payments_covering_year_csv_report_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe AdminOnly::Reports::PaymentsCoveringYearCsvReport, type: :model do
+
+  let(:report_year) { 2021 }
+  let(:subject) { described_class.new(report_year) }
+  let(:prev_dec_31) { Time.parse("#{report_year - 1}-12-31") }
+  let(:this_dec_31) { Time.parse("#{report_year}-12-31") }
+  let(:next_jan_1) { Time.parse("#{report_year + 1}-01-01") }
+
+  let(:header_line) { "this, is, the,csv,header,line\n" }
+
+  it '.csv_adapter is Adapters::PaymentCoveringYearToCsvAdapter' do
+    expect(described_class.csv_adapter).to eq Adapters::PaymentCoveringYearToCsvAdapter
+  end
+
+  it 'csv_header_args is the year' do
+    expect(subject.csv_header_args).to eq [report_year]
+  end
+
+  it 'filename_start is framgangsrika-betalningar-<the given year>' do
+    expect(subject.filename_start).to eq "framgangsrika-betalningar-#{report_year}"
+  end
+
+
+  describe 'initialize' do
+
+    it 'sets the year to the given year' do
+      report_for_2099 = described_class.new(2099)
+      expect(report_for_2099.year).to eq 2099
+    end
+  end
+
+
+  describe 'report_items' do
+
+    it 'gets all completed payments that cover any part of the given year' do
+      successful_prev_dec31 = create(:payment, :successful, start_date: prev_dec_31)
+      successful_this_dec31 = create(:payment, :successful, start_date: this_dec_31)
+      create(:payment, :successful, start_date: next_jan_1)
+
+      create(:payment, :expired, start_date: prev_dec_31)
+      create(:payment, :pending, start_date: this_dec_31)
+
+      report_2021 = described_class.new(report_year)
+      expect(report_2021.payments).to match_array([successful_prev_dec31, successful_this_dec31])
+    end
+
+    it 'report_items are the payments converted to PaymentCoveringYears' do
+      successful_prev_dec31 = create(:payment, :successful, start_date: prev_dec_31)
+
+      report_2021 = described_class.new(report_year)
+      report_items = report_2021.report_items
+      expect(report_items.size).to eq 1
+      expect(report_items.first).to be_a PaymentCoveringYear
+      expect(report_items.first.year).to eq report_year
+      expect(report_items.first.payment).to eq successful_prev_dec31
+    end
+  end
+end

--- a/spec/models/admin_only/reports/payments_csv_report_spec.rb
+++ b/spec/models/admin_only/reports/payments_csv_report_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe AdminOnly::Reports::PaymentsCsvReport, type: :model do
+
+  it '.csv_adapter is Adapters::PaymentToCsvAdapter' do
+    expect(described_class.csv_adapter).to eq Adapters::PaymentToCsvAdapter
+  end
+
+  it 'filename_start is betalningar' do
+    expect(subject.filename_start).to eq 'betalningar'
+  end
+
+
+  it 'report_items are all Payments' do
+    payment1_member = create(:membership_fee_payment, :successful)
+    payment2_member_pending = create(:membership_fee_payment, :pending)
+    payment3_branding = create(:h_branding_fee_payment)
+    payment4_expired_member = create(:expired_membership_fee_payment)
+
+    expect(subject.report_items).to match_array([payment1_member, payment2_member_pending,
+                                                 payment3_branding, payment4_expired_member])
+  end
+end

--- a/spec/models/admin_only/reports/shf_applications_csv_report_spec.rb
+++ b/spec/models/admin_only/reports/shf_applications_csv_report_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe AdminOnly::Reports::ShfApplicationsCsvReport, type: :model do
+
+  it '.csv_adapter is Adapters::ShfApplicationToCsvAdapter' do
+    expect(described_class.csv_adapter).to eq Adapters::ShfApplicationToCsvAdapter
+  end
+
+  it 'filename_start is Ansokningar' do
+    expect(subject.filename_start).to eq "Ansokningar"
+  end
+
+
+  it 'report_items are all ShfApplications' do
+    app1 = create(:shf_application, contact_email: 'app1@example.com')
+    app2 = create(:shf_application, contact_email: 'app2@example.com')
+
+    expect(subject.report_items).to match_array([app1, app2])
+  end
+end


### PR DESCRIPTION
## PT Story: Report: Number of Membership Days paid in 2020
#### PT URL: https://www.pivotaltracker.com/story/show/176639257

Create an admin report the exports all Payments that "covered" any day in 2020.
- only include successful payments

## Changes proposed in this pull request:
1.  The existing report also included all payments that were not successful; corrected the query
2.  Refactored the CSV reports so that each report is a _model._
    - models are easier to test, can be reused, and represent more of a _single responsibility_
    - The controller then just calls each report model to get the result and presents the result as needed (a download).

---
## Ready for review:
@AgileVentures/shf-project-team 
