### PR TITLE
Not a bug: only Admin, Co. member can view or edit an incomplete company

### DIFF
--- a/features/companies/edit_company-access.feature
+++ b/features/companies/edit_company-access.feature
@@ -2,34 +2,47 @@ Feature: Only admins and company members can edit a company
 
   As an admin or member of a company
   to control who can change information about the company
-  Only I can edit company information
+  Only admins and current members can edit company information
 
 
   Background:
     Given the Membership Ethical Guidelines Master Checklist exists
 
     Given the following users exist:
-      | email                   | admin | member |
-      | paid_member@mutts.com   |       | true   |
-      | unpaid_member@mutts.com |       | true   |
-      | mere_user@mutts.com     |       | false  |
-      | admin@shf.se            | true  | true   |
+      | email                                     | admin | member |
+      | paid_member@mutts.com                     |       | true   |
+      | unpaid_member@mutts.com                   |       | true   |
+      | mere_user@mutts.com                       |       | false  |
+      | paid_member-no-name-co@example.com        |       | true   |
+      | approved_applicant-no-name-co@example.com |       | false  |
+      | new_applicant-no-name-co@example.com      |       | false  |
+      | rejected_applicant-no-name-co@example.com |       | false  |
+      | admin@shf.se                              | true  | true   |
 
     Given the following payments exist
-      | user_email            | start_date | expire_date | payment_type | status | hips_id |
-      | paid_member@mutts.com | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |
+      | user_email                         | start_date | expire_date | payment_type | status | hips_id |
+      | paid_member@mutts.com              | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |
+      | paid_member-no-name-co@example.com | 2017-10-1  | 2017-12-31  | member_fee   | betald | none    |
+
 
     And the following companies exist:
-      | name                  | company_number | email                  |
-      | No More Snarky Barky  | 5560360793     | snarky@snarkybarky.com |
-      | Bowsers               | 2120000142     | bowwow@bowsersy.com    |
-      | Lapsed Member Company | 6613265393     | lapsed@company.com     |
+      | name                  | company_number | email                             |
+      | No More Snarky Barky  | 5560360793     | snarky@snarkybarky.com            |
+      | Bowsers               | 2120000142     | bowwow@bowsersy.com               |
+      | Lapsed Member Company | 6613265393     | lapsed@company.com                |
+      |                       | 5867107939     | no-name-no-members-co@example.com |
+      |                       | 2202000457     | no-name@example.com               |
 
     And the following applications exist:
-      | user_email              | company_number | state    |
-      | paid_member@mutts.com   | 5560360793     | accepted |
-      | unpaid_member@mutts.com | 6613265393     | accepted |
-      | mere_user@mutts.com     | 2120000142     | accepted |
+      | user_email                                | company_number | state    |
+      | paid_member@mutts.com                     | 5560360793     | accepted |
+      | unpaid_member@mutts.com                   | 6613265393     | accepted |
+      | mere_user@mutts.com                       | 2120000142     | accepted |
+      | paid_member-no-name-co@example.com        | 2202000457     | accepted |
+      | approved_applicant-no-name-co@example.com | 2202000457     | accepted |
+      | new_applicant-no-name-co@example.com      | 2202000457     | new      |
+      | rejected_applicant-no-name-co@example.com | 2202000457     | rejected |
+
 
   @time_adjust
   Scenario: Member can edit their company
@@ -38,6 +51,8 @@ Feature: Only admins and company members can edit a company
     And I am on the edit company page for "5560360793"
     Then I should see t("companies.edit.title", company_name: "No More Snarky Barky")
 
+
+  # FIXME If someone is unpaid, they are not a member. This needs to be cleaned up
   Scenario: Unpaid member cannot edit their company
     Given I am logged in as "unpaid_member@mutts.com"
     And I am on the edit company page for "6613265393"
@@ -59,3 +74,49 @@ Feature: Only admins and company members can edit a company
     Given I am logged in as "mere_user@mutts.com"
     And I am on the edit company page for "5560360793"
     Then I should see a message telling me I am not allowed to see that page
+
+
+  Scenario: Applicant (approved app) cannot edit an incomplete (no name) company they belong to (must be a member)
+    Given the date is set to "2017-10-01"
+    And I am logged in as "approved_applicant-no-name-co@example.com"
+    When I am the page for company number "2202000457"
+    Then I should not see t("companies.edit_company")
+    When I am on the edit company page for "2202000457"
+    And  I should see a message telling me I am not allowed to see that page
+
+
+  Scenario: Applicant (new app) cannot edit an incomplete (no name) company they belong to (must be a member)
+    Given the date is set to "2017-10-01"
+    And I am logged in as "new_applicant-no-name-co@example.com"
+    When I am the page for company number "2202000457"
+    Then I should not see t("companies.edit_company")
+    When I am on the edit company page for "2202000457"
+    And  I should see a message telling me I am not allowed to see that page
+
+
+  Scenario: Applicant (rejected app) cannot edit an incomplete (no name) company they belong to (must be a member)
+    Given the date is set to "2017-10-01"
+    And I am logged in as "rejectedapplicant-no-name-co@example.com"
+    When I am the page for company number "2202000457"
+    Then I should not see t("companies.edit_company")
+    When I am on the edit company page for "2202000457"
+    And  I should see a message telling me I am not allowed to see that page
+
+
+  Scenario: Member can edit an incomplete (no name) company they belong to
+    Given the date is set to "2017-10-01"
+    And I am logged in as "paid_member-no-name-co@example.com"
+    And I am the page for company number "2202000457"
+    When I click on t("companies.edit_company")
+    Then I am on the edit company page for "2202000457"
+
+
+  Scenario: Admin can edit a company that is not complete (no name and/or no members)
+    Given I am logged in as "admin@shf.se"
+    And I am the page for company number "5867107939"
+    When I click on t("companies.edit_company")
+    Then I am on the edit company page for "5867107939"
+
+    When I am the page for company number "2202000457"
+    And I click on t("companies.edit_company")
+    Then I am on the edit company page for "2202000457"

--- a/features/step_definitions/company_steps.rb
+++ b/features/step_definitions/company_steps.rb
@@ -28,7 +28,7 @@ And(/^the following company addresses exist:$/) do |table|
   end
 end
 
-And(/^I am (on )*the page for company number "([^"]*)"$/) do |grammar_fix_on, company_number|
+And(/^I am (on )*the page for company number "([^"]*)"$/) do |_grammar_fix_on, company_number|
   company = Company.find_by_company_number(company_number)
   visit path_with_locale(company_path company)
 end

--- a/features/step_definitions/membership_application_steps.rb
+++ b/features/step_definitions/membership_application_steps.rb
@@ -46,7 +46,7 @@ And(/^the following applications exist:$/) do |table|
     legacy_app = hash[IS_LEGACY] == 'true' ? true : false
 
     # 'ma' = Member Application
-    if (ma = user.shf_application)
+    if (member_application = user.shf_application)
       user.shf_application.companies << companies
 
     else
@@ -58,27 +58,27 @@ And(/^the following applications exist:$/) do |table|
                                        num_categories: num_categories)
 
       if legacy_app
-        ma = FactoryBot.build(:shf_application, :legacy_application, ma_attributes)
+        member_application = FactoryBot.build(:shf_application, :legacy_application, ma_attributes)
       else
-        ma = FactoryBot.build(:shf_application, ma_attributes)
+        member_application = FactoryBot.build(:shf_application, ma_attributes)
       end
 
-      ma.companies = companies
+      member_application.companies = companies
     end
 
     if hash[CATEGORIES]
       categories = []
       for category_name in hash[CATEGORIES].split(/\s*,\s*/)
-        categories << BusinessCategory.find_by_name(category_name) unless ma.business_categories.where(name: category_name).exists?
+        categories << BusinessCategory.find_by_name(category_name) unless member_application.business_categories.where(name: category_name).exists?
       end
-      ma.business_categories << categories
+      member_application.business_categories << categories
     end
 
     if hash[UPLOADED_FILES]
       uploaded_files = []
 
       for uploaded_file_name in hash[UPLOADED_FILES].split(/\s*,\s*/)
-        unless ma.uploaded_files.where(user: user.id, actual_file_file_name: uploaded_file_name).exists?
+        unless member_application.uploaded_files.where(user: user.id, actual_file_file_name: uploaded_file_name).exists?
           file_already_uploaded = UploadedFile.find_by(user: user, actual_file_file_name: uploaded_file_name)
           if file_already_uploaded
             uploaded_file = file_already_uploaded
@@ -87,7 +87,7 @@ And(/^the following applications exist:$/) do |table|
             if file_fixture_exists?(uploaded_file_name, 'the following applications exist')
               File.open(Rails.root.join(UPLOADED_FILES_DIR, uploaded_file_name), 'r') do |f|
                 uploaded_file = UploadedFile.create!(user: user,
-                                                     shf_application: ma,
+                                                     shf_application: member_application,
                                                      actual_file: f,
                                                      actual_file_file_name: uploaded_file_name)
               end
@@ -96,17 +96,17 @@ And(/^the following applications exist:$/) do |table|
           uploaded_files << uploaded_file
         end
       end
-      ma.uploaded_files << uploaded_files
+      member_application.uploaded_files << uploaded_files
     end
 
     if legacy_app
       # We save without validation - so, confirm that the **only** validation errors
       # would be associated with the missing file-delivery method.
-      ma.valid?
-      expect(ma.errors.keys).to match_array [:file_delivery_method]
+      member_application.valid?
+      expect(member_application.errors.keys).to match_array [:file_delivery_method]
     end
 
-    ma.save!(validate: (legacy_app ? false : true))
+    member_application.save!(validate: (legacy_app ? false : true))
   end
 end
 


### PR DESCRIPTION
## PT Story:  Admin, Member cannot edit or see a Co. without a name (incomplete)
#### PT URL: https://www.pivotaltracker.com/story/show/177249905

This is working as it should:  An admin or company member _can_ view and edit an incomplete company.  An applicant or user _cannot_.

## Changes proposed in this pull request:
1.  added scenarios to explicitly show the business rules and test access

---
## Ready for review:
@
