### PR TITLE
show company db id for admins

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -150,8 +150,8 @@ table {
 
 .col {
   .db-id {
-    line-height: 1em;
     font-size: smaller;
+    line-height: 1em;
   }
 }
 

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,5 +1,6 @@
 @import "shf-custom-colors";
 
+// FIXME: clarify what goes here and what goes in style.scss
 
 .yes,
 .Yes,
@@ -140,4 +141,17 @@
   padding: 0;
 }
 
+
+table {
+  .db-id {
+    font-size: smaller;
+  }
+}
+
+.col {
+  .db-id {
+    line-height: 1em;
+    font-size: smaller;
+  }
+}
 

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -1,7 +1,7 @@
 @import 'shf-custom-colors';
 
 // TODO Some of these should these be put into their respective model stylesheets or if it's general, into custom ?
-
+// FIXME: clarify what goes here and what goes in style.scss
 
 #about-info-modal {
 

--- a/app/views/companies/_companies_list.html.haml
+++ b/app/views/companies/_companies_list.html.haml
@@ -3,6 +3,8 @@
     %table.table.table-hover.table-md
       %thead
         %tr
+          -# The .companies_pagination style is what triggers the Javascript to replace the #companies_list page content
+              @see app/assets/javascripts/companies.js
           %th
             = t('activerecord.models.business_category.one')
           %th
@@ -26,6 +28,10 @@
                         t('activerecord.attributes.company.company_number'), {},
                         { class: 'companies_pagination', remote: true })
             %th
+              = sort_link(search_params, :id,
+                        'db id', {},
+                        { class: 'db-id companies_pagination', remote: true })
+            %th
             %th
 
       %tbody
@@ -43,6 +49,7 @@
 
             - if current_user.admin?
               %td.company-number= company.company_number
+              %td.db-id= company.id
               %td.edit= link_to icon('fas', 'edit'), edit_company_path(company)
               %td.delete= link_to icon('fas', 'trash', class: 'delete'), company, method: :delete,
                               data: { :confirm => "#{t('confirm_are_you_sure')}" }

--- a/app/views/companies/show.html.haml
+++ b/app/views/companies/show.html.haml
@@ -8,9 +8,14 @@
   %header.entry-header
     = content_title(@company.name, user: current_user)
   .entry-content.container
+    - if current_user.admin?
+      .row.db-id
+        .col.db-id
+          = field_or_none 'db id', @company.id, tag_options: {class: 'db-id'}
+
     .row
       .col
-        - if @company.categories
+        - if @company.categories.any?
           .categories
             = render 'business_categories/as_list',
               categories: @company.business_categories.roots.distinct

--- a/features/companies/only-admin-sees-dbid-company.feature
+++ b/features/companies/only-admin-sees-dbid-company.feature
@@ -1,0 +1,99 @@
+Feature: Only the Admin sees the db id for a company, list of companies
+
+  As the admin,
+  So that I can help debug problems,
+  show me the database id for companies
+  on the individual company pages
+  and on the list of companies.
+
+  Only the admin can see the db-id.
+
+  PivotalTracker: https://www.pivotaltracker.com/story/show/177249720
+
+
+  Background:
+
+    Given the date is set to "2019-06-06"
+    Given the Membership Ethical Guidelines Master Checklist exists
+
+    Given the following regions exist:
+      | name         |
+      | Stockholm    |
+
+    Given the following kommuns exist:
+      | name     |
+      | Alingsås |
+
+    Given the following companies exist:
+      | name                       | company_number | email                      | region       | kommun   | city      | visibility     |
+      | Company 1                  | 5560360793     | hello@company-1.com        | Stockholm    | Alingsås | Harplinge | street_address |
+
+
+    And the following users exist:
+      | email                            | admin | member |
+      | member@company-1.com             |       | true   |
+      | applicant@company-1.com          |       | false  |
+      | admin@shf.se                     | true  | false  |
+
+
+    And the following business categories exist
+      | name    |
+      | Groomer |
+
+    And the following applications exist:
+      | user_email                       | company_number | categories | state    |
+      | member@company-1.com             | 5560360793     | Groomer    | accepted |
+      | applicant@company-1.com          | 5560360793     | Groomer    | new      |
+
+
+    And the following payments exist
+      | user_email                       | start_date | expire_date | payment_type | status | hips_id | company_number |
+      | member@company-1.com             | 2019-01-01 | 2019-12-31  | member_fee   | betald | none    |                |
+
+
+  # -----------------------------------------------------------------------------------------------
+
+  Scenario: Admin sees the database id in list of Companies
+    Given I am logged in as "admin@shf.se"
+    When I am on the "all companies" page
+    Then I should see "db id"
+
+  Scenario: Admin sees db id on Company page
+    Given I am logged in as "admin@shf.se"
+    When I am on the page for company number "5560360793"
+    Then I should see "db id"
+
+
+  Scenario: Member does not see database id in list of Companies
+    Given I am logged in as "member@company-1.com"
+    When I am on the "all companies" page
+    Then I should not see "db id"
+
+
+  Scenario: Member does not see db id on Company page
+    Given I am logged in as "member@company-1.com"
+    When I am on the page for company number "5560360793"
+    Then I should not see "db id"
+
+
+  Scenario: Applicant does not see database id in list of Companies
+    Given I am logged in as "applicant@company-1.com"
+    When I am on the "all companies" page
+    Then I should not see "db id"
+
+
+  Scenario: Applicant does not see db id on Company page
+    Given I am logged in as "applicant@company-1.com"
+    When I am on the page for company number "5560360793"
+    Then I should not see "db id"
+
+  Scenario: Visitor does not see database id in list of Companies
+    Given I am logged out
+    When I am on the "all companies" page
+    Then I should not see "db id"
+
+
+  Scenario: Visitor does not see db id on Company page
+    Given I am logged out
+    When I am on the page for company number "5560360793"
+    Then I should not see "db id"

--- a/features/companies/show-company.feature
+++ b/features/companies/show-company.feature
@@ -29,32 +29,26 @@ Feature: Show company page - display different info depending on role
       | Bromölla |
 
     Given the following companies exist:
-      | name     | company_number | email          | region       | kommun   | city      | visibility     |
-      | Company1 | 5560360793     | cmpy1@mail.com | Stockholm    | Alingsås | Harplinge | street_address |
-      | Company2 | 2120000142     | cmpy2@mail.com | Västerbotten | Bromölla | Harplinge | street_address |
-      | Company3 | 6613265393     | cmpy3@mail.com | Stockholm    | Alingsås | Harplinge | post_code      |
-      | Company4 | 6222279082     | cmpy4@mail.com | Stockholm    | Alingsås | Harplinge | city           |
-      | Company5 | 8025085252     | cmpy5@mail.com | Stockholm    | Alingsås | Harplinge | kommun         |
-      | Company6 | 6914762726     | cmpy6@mail.com | Stockholm    | Alingsås | Harplinge | none           |
-      | Company7 | 7661057765     | cmpy7@mail.com | Stockholm    | Alingsås | Harplinge | street_address |
-      | Company8 | 7736362901     | cmpy8@mail.com | Stockholm    | Alingsås | Harplinge | street_address |
+      | name                                  | company_number | email                      | region       | kommun   | city      | visibility     |
+      | Co.1 - Addr Visible to Street Address | 5560360793     | hello@company-1.com        | Stockholm    | Alingsås | Harplinge | street_address |
+      | Company2                              | 2120000142     | hello@company-2.com        | Västerbotten | Bromölla | Harplinge | street_address |
+      | Company3                              | 6613265393     | hello@company-3.com        | Stockholm    | Alingsås | Harplinge | post_code      |
+      | Company4                              | 6222279082     | hello@company-4.com        | Stockholm    | Alingsås | Harplinge | city           |
+      | Company5                              | 8025085252     | hello@company-5.com        | Stockholm    | Alingsås | Harplinge | kommun         |
+      | Co.6 - Address Not Visible            | 6914762726     | hello@addr-not-visible.com | Stockholm    | Alingsås | Harplinge | none           |
+      | Company7                              | 7661057765     | hello@company-7.com        | Stockholm    | Alingsås | Harplinge | street_address |
+      | Company8                              | 7736362901     | hello@company-8.com        | Stockholm    | Alingsås | Harplinge | street_address |
 
     And the following users exist:
-      | email           | admin | member |
-      | user1@mutts.com |       | true   |
-      | user2@mutts.com |       | true   |
-      | user3@mutts.com |       | true   |
-      | user4@mutts.com |       | true   |
-      | user5@mutts.com |       | true   |
-      | user6@mutts.com |       | true   |
-      | admin@shf.se    | true  | false  |
-
-    Given the following payments exist
-      | user_email      | start_date | expire_date | payment_type | status | hips_id |
-      | user1@mutts.com | 2019-01-01 | 2019-12-31  | member_fee   | betald | none    |
-      | user2@mutts.com | 2019-10-1  | 2019-12-31  | member_fee   | betald | none    |
-      | user3@mutts.com | 2019-10-1  | 2019-12-31  | member_fee   | betald | none    |
-      | user6@mutts.com | 2019-01-01 | 2019-12-31  | member_fee   | betald | none    |
+      | email                            | admin | member |
+      | member-1@addr-all-visible-1.com  |       | true   |
+      | member@company-2.com             |       | true   |
+      | applicant-6@addr-not-visible.com |       | false  |
+      | member-6@addr-not-visible.com    |       | true   |
+      | member-no-payments@company-3.com |       | true   |
+      | member-no-payments@company-2.com |       | true   |
+      | member-2@addr-all-visible-1.com  |       | true   |
+      | admin@shf.se                     | true  | false  |
 
 
     And the following business categories exist
@@ -67,35 +61,42 @@ Feature: Show company page - display different info depending on role
       | JustForFun   |
 
     And the following applications exist:
-      | user_email      | company_number | categories                        | state    |
-      | user1@mutts.com | 5560360793     | Groomer, JustForFun               | accepted |
-      | user2@mutts.com | 2120000142     | Groomer, Trainer, Rehab           | accepted |
-      | user3@mutts.com | 6914762726     | Psychologist, Groomer             | accepted |
-      | user4@mutts.com | 6613265393     | Groomer                           | accepted |
-      | user5@mutts.com | 2120000142     | Psychologist                      | accepted |
-      | user6@mutts.com | 5560360793     | Groomer, JustForFun, Psychologist | accepted |
+      | user_email                       | company_number | categories                        | state    |
+      | member-1@addr-all-visible-1.com  | 5560360793     | Groomer, JustForFun               | accepted |
+      | member@company-2.com             | 2120000142     | Groomer, Trainer, Rehab           | accepted |
+      | applicant-6@addr-not-visible.com | 6914762726     | Groomer                           | new      |
+      | member-6@addr-not-visible.com    | 6914762726     | Psychologist, Groomer             | accepted |
+      | member-no-payments@company-3.com | 6613265393     | Groomer                           | accepted |
+      | member-no-payments@company-2.com | 2120000142     | Psychologist                      | accepted |
+      | member-2@addr-all-visible-1.com  | 5560360793     | Groomer, JustForFun, Psychologist | accepted |
+
 
     And the following payments exist
-      | user_email   | start_date | expire_date | payment_type | status | hips_id | company_number |
-      | admin@shf.se | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 5560360793     |
-      | admin@shf.se | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 2120000142     |
-      | admin@shf.se | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 6613265393     |
-      | admin@shf.se | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 6222279082     |
-      | admin@shf.se | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 8025085252     |
-      | admin@shf.se | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 6914762726     |
-      | admin@shf.se | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 7661057765     |
-      | admin@shf.se | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 7736362901     |
+      | user_email                       | start_date | expire_date | payment_type | status | hips_id | company_number |
+      | member-1@addr-all-visible-1.com  | 2019-01-01 | 2019-12-31  | member_fee   | betald | none    |                |
+      | member@company-2.com             | 2019-10-1  | 2019-12-31  | member_fee   | betald | none    |                |
+      | member-6@addr-not-visible.com    | 2019-10-1  | 2019-12-31  | member_fee   | betald | none    |                |
+      | member-2@addr-all-visible-1.com  | 2019-01-01 | 2019-12-31  | member_fee   | betald | none    |                |
+      | member-2@addr-all-visible-1.com  | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 5560360793     |
+      | member@company-2.com             | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 2120000142     |
+      | member-no-payments@company-3.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 6613265393     |
+      | admin@shf.se                     | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 6222279082     |
+      | admin@shf.se                     | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 8025085252     |
+      | member-6@addr-not-visible.com    | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 6914762726     |
+      | admin@shf.se                     | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 7661057765     |
+      | admin@shf.se                     | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 7736362901     |
 
 
+    # -----------------------------------
   Scenario: Show company details to a visitor, but don't show the org nr.
     Given I am Logged out
     And I am the page for company number "5560360793"
     Then I should not see "5560360793"
-    And I should see "Company1"
+    And I should see "Co.1 - Addr Visible to Street Address"
     And I should see "Groomer"
     And I should see t("companies.show.members")
     And I should see "Firstname Lastname"
-    And I should see "cmpy1@mail.com"
+    And I should see "hello@company-1.com"
     And I should see "123123123"
     And I should see "Hundforetagarevägen 1"
     And I should see "310 40"
@@ -108,7 +109,7 @@ Feature: Show company page - display different info depending on role
     And I should see "Trainer"
     And I should see "Rehab"
     And I should see "Psychologist"
-    And I should see "cmpy2@mail.com"
+    And I should see "hello@company-2.com"
     And I should see "123123123"
     And I should see "Hundforetagarevägen 1"
     And I should see "310 40"
@@ -116,13 +117,13 @@ Feature: Show company page - display different info depending on role
     And I should see "http://www.example.com"
 
   Scenario: Show company details to member of the company.
-    Given I am logged in as "user1@mutts.com"
+    Given I am logged in as "member-1@addr-all-visible-1.com"
     And I am the page for company number "5560360793"
     Then I should not see "5560360793"
-    And I should see "Company1"
+    And I should see "Co.1 - Addr Visible to Street Address"
     And I should see "Groomer"
     And I should see "JustForFun"
-    And I should see "cmpy1@mail.com"
+    And I should see "hello@company-1.com"
     And I should see "123123123"
     And I should see "Hundforetagarevägen 1"
     And I should see "310 40"
@@ -133,10 +134,10 @@ Feature: Show company page - display different info depending on role
     Given I am logged in as "admin@shf.se"
     And I am the page for company number "5560360793"
     Then I should see "5560360793"
-    And I should see "Company1"
+    And I should see "Co.1 - Addr Visible to Street Address"
     And I should see "Groomer"
     And I should see "JustForFun"
-    And I should see "cmpy1@mail.com"
+    And I should see "hello@company-1.com"
     And I should see "123123123"
     And I should see "Hundforetagarevägen 1"
     And I should see "310 40"
@@ -149,7 +150,7 @@ Feature: Show company page - display different info depending on role
     And I should see "Trainer"
     And I should see "Rehab"
     And I should see "Psychologist"
-    And I should see "cmpy2@mail.com"
+    And I should see "hello@company-2.com"
     And I should see "123123123"
     And I should see "Hundforetagarevägen 1"
     And I should see "310 40"
@@ -168,7 +169,7 @@ Feature: Show company page - display different info depending on role
   @time_adjust
   Scenario: Show company address to member regardless of visibility setting
     Given the date is set to "2017-10-01"
-    Given I am logged in as "user3@mutts.com"
+    Given I am logged in as "member-6@addr-not-visible.com"
     And I am the page for company number "6914762726"
     And I should see "Hundforetagarevägen 1"
     And I should see "310 40"
@@ -205,7 +206,7 @@ Feature: Show company page - display different info depending on role
   Scenario: Visitor: Don't show company address
     Given I am Logged out
     And I am the page for company number "6914762726"
-    And I should see "Company6"
+    And I should see "Co.6 - Address Not Visible"
     And I should not see "Hundforetagarevägen 1"
     And I should not see "310 40"
     And I should not see "Harplinge"


### PR DESCRIPTION
## PT Story:  Admin needs to see db id for companies
#### PT URL:  https://www.pivotaltracker.com/story/show/177249720


## Changes proposed in this pull request:
1.  show the database id (db id) on the Companies index page - to admins only
2. show the db id on the Company show page - to admins only
3. add feature
4. (minor) clean up show-companies.feature

## Screenshots (Optional):

---
## Ready for review:
@
