### PR TITLE
Company show: only admins, those in the co. can see an incomplete co

### DIFF
--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -1,8 +1,15 @@
 class CompanyPolicy < ApplicationPolicy
   include PoliciesHelper
 
+  # Admin can always see (show) any company
+  # A User in the company can see it
+  #
+  # If the company information is complete, then it can be shown to anyone,
+  #  else (if the information is not complete), it cannot be shown.
   def show?
-    true
+    return true if user.admin? || is_in_company?(record)
+
+    record.information_complete? ? true : false
   end
 
   def index?

--- a/features/companies/admin_creates_company.feature
+++ b/features/companies/admin_creates_company.feature
@@ -1,4 +1,6 @@
-Feature: As an admin
+Feature: Admin can create a company
+
+  As an admin
   So that I can view and manage companies
   I need to be able to create them
 
@@ -68,15 +70,22 @@ Feature: As an admin
     Then I should see "No More Snarky Barky"
     And I should see "Bowsers"
 
-  Scenario: User tries to create a company
+  Scenario: User is not allowed to create a company
     Given I am logged in as "applicant_1@happymutts.com"
     And I am on the "create a new company" page
     Then I should see a message telling me I am not allowed to see that page
 
-  Scenario: Visitor tries to create a company
+  Scenario: Visitor is not allowed to create a company
     Given I am Logged out
     And I am on the "create a new company" page
     Then I should see a message telling me I am not allowed to see that page
+
+
+  Scenario: Member is not allowed to create a company
+    Given I am logged in as "member_1@happymutts.com"
+    And I am on the "create a new company" page
+    Then I should see a message telling me I am not allowed to see that page
+
 
   @time_adjust @dinkurs_fetch
   Scenario: Admin creates a company

--- a/features/companies/show-company-complete-info-access.feature
+++ b/features/companies/show-company-complete-info-access.feature
@@ -1,0 +1,123 @@
+Feature: Only show companies with incomplete info to admins and users or members of the company.
+
+  So that visitors and users and members that are not a member of a company
+  do not see a company until all of the necessary information for displaying it is "complete,"
+  only show companies with incomplete information to admins and those that are part of the company.
+  All others should get a 404 message.
+  They should not get a 'you are not authorized' message because we don't want to give
+  any hints that the company does or does not exist.  This is especially important for bots;
+  if they infer that a company (page) does exist, they may try to continue to access it and/or
+  continue to try even more malicious things.
+
+  PivotalTracker: https://www.pivotaltracker.com/story/show/177274707
+
+
+  Background:
+
+    Given the date is set to "2019-06-06"
+    Given the Membership Ethical Guidelines Master Checklist exists
+
+    Given the following regions exist:
+      | name      |
+      | Stockholm |
+
+    Given the following kommuns exist:
+      | name     |
+      | Alingsås |
+
+
+    Given the following companies exist:
+      | name     | company_number | email                               | region    | kommun   | city      | visibility     |
+      |          | 5560360793     | hello@incomplete-info-company-1.com | Stockholm | Alingsås | Harplinge | street_address |
+      | Company2 | 2120000142     | hello@company-2.com                 | Stockholm | Alingsås | Harplinge | street_address |
+
+
+    And the following users exist:
+      | email                            | admin | member |
+      | member-1@addr-all-visible-1.com  |       | true   |
+      | member@company-2.com             |       | true   |
+      | applicant-6@addr-not-visible.com |       | false  |
+      | member-company6@example.com      |       | true   |
+      | member-2@addr-all-visible-1.com  |       | true   |
+      | admin@shf.se                     | true  | false  |
+
+
+    And the following business categories exist
+      | name    |
+      | Groomer |
+
+
+    And the following applications exist:
+      | user_email                      | company_number | categories          | state    |
+      | member-1@addr-all-visible-1.com | 5560360793     | Groomer | accepted |
+      | member@company-2.com            | 2120000142     | Groomer             | accepted |
+      | member-company6@example.com     | 6914762726     | Groomer             | accepted |
+
+    And the following payments exist
+      | user_email                      | start_date | expire_date | payment_type | status | hips_id | company_number |
+      | member-1@addr-all-visible-1.com | 2019-01-01 | 2019-12-31  | member_fee   | betald | none    |                |
+      | member@company-2.com            | 2019-10-1  | 2019-12-31  | member_fee   | betald | none    |                |
+      | member-company6@example.com     | 2019-10-1  | 2019-12-31  | member_fee   | betald | none    |                |
+      | member-2@addr-all-visible-1.com | 2019-01-01 | 2019-12-31  | member_fee   | betald | none    |                |
+      | member-2@addr-all-visible-1.com | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 5560360793     |
+      | member@company-2.com            | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 2120000142     |
+      | member-company6@example.com     | 2017-01-01 | 2017-12-31  | branding_fee | betald | none    | 6914762726     |
+
+    # -----------------------------------
+  Scenario: Visitor cannot see a company with incomplete info; gets a 404 error.
+    Given I am Logged out
+    When I am the page for company number "5560360793"
+    Then I should not see "5560360793"
+    And I should not see "hello@incomplete-info-company-1.com"
+
+    # The actual entity type will be passed in and shown, but it's beyond the current step to fill it in with a nested t("").
+    #  As long as the error message is being displayed, it is working as it should.
+    And I should see t("activerecord.errors.messages.record_not_found.header", entity_type: '')
+
+
+  Scenario: User that is not a part of the company  cannot see a company with incomplete info; gets a 404 error.
+    Given I am logged in as "applicant-6@addr-not-visible.com"
+    When I am the page for company number "5560360793"
+    Then I should not see "5560360793"
+    And I should not see "hello@incomplete-info-company-1.com"
+
+    # The actual entity type will be passed in and shown, but it's beyond the current step to fill it in with a nested t("").
+    #  As long as the error message is being displayed, it is working as it should.
+    And I should see t("activerecord.errors.messages.record_not_found.header", entity_type: '')
+
+
+  Scenario: Member that is not part of the company cannot see a company with incomplete info; gets a 404 error.
+    Given I am logged in as "member-company6@example.com"
+    And I am the page for company number "5560360793"
+    Then I should not see "5560360793"
+    And I should not see "hello@incomplete-info-company-1.com"
+
+    # The actual entity type will be passed in and shown, but it's beyond the current step to fill it in with a nested t("").
+    #  As long as the error message is being displayed, it is working as it should.
+    And I should see t("activerecord.errors.messages.record_not_found.header", entity_type: '')
+
+
+  Scenario: Member that is part of the company can see a company with incomplete info.
+    Given I am logged in as "member-1@addr-all-visible-1.com"
+    When I am the page for company number "5560360793"
+    Then I should see t("companies.show.this_info_missing")
+    And I should see "Groomer"
+    And I should see "hello@incomplete-info-company-1.com"
+    And I should see "123123123"
+    And I should see "Hundforetagarevägen 1"
+    And I should see "310 40"
+    And I should see "Harplinge"
+    And I should see "http://www.example.com"
+
+
+  Scenario: Admin can see all incomplete companies.
+    Given I am logged in as "admin@shf.se"
+    When I am the page for company number "5560360793"
+    Then I should see t("companies.show.this_info_missing")
+    And I should see "Groomer"
+    And I should see "hello@incomplete-info-company-1.com"
+    And I should see "123123123"
+    And I should see "Hundforetagarevägen 1"
+    And I should see "310 40"
+    And I should see "Harplinge"
+    And I should see "http://www.example.com"

--- a/features/companies/show_only_companies_in_good_standing.feature
+++ b/features/companies/show_only_companies_in_good_standing.feature
@@ -8,7 +8,10 @@ Feature: Visitors see only companies in good standing with complete information
   And I only want to see companies with all of the information needed
     so that I can contact them,
 
-  Visitors should only see companies in good standing with complete information.
+  Visitors and users and members should only see companies in good standing with complete information.
+
+  Members and users that are part of a company can view and edit a company that is not in good standing,
+  but will not see the company in the list of all companies.
 
 
   Background:

--- a/spec/policies/company_policy_spec.rb
+++ b/spec/policies/company_policy_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CompanyPolicy do
   let(:admin)  { create(:user, email: 'admin@sfh.com', admin: true) }
   let(:visitor) { build(:visitor) }
   let(:company) { create(:company, company_number: '5712213304')}
+  let(:co_incomplete_info) { create(:company, name: '') }
 
   describe 'For admin' do
     subject { described_class.new(admin, company) }
@@ -38,38 +39,82 @@ RSpec.describe CompanyPolicy do
   end
 
   describe 'For a member that is not part of a company' do
-    subject { described_class.new(member, company) }
+    context 'company information IS complete' do
+      subject { described_class.new(member, company) }
 
-    it { is_expected.to permit_action :index }
-    it { is_expected.to permit_action :show }
-    it { is_expected.to forbid_action :edit }
-    it { is_expected.to forbid_action :update }
-    it { is_expected.to forbid_action :new }
-    it { is_expected.to permit_action :create }
-    it { is_expected.to forbid_action :edit_payment }
+      it { is_expected.to permit_action :index }
+      it { is_expected.to permit_action :show }
+      it { is_expected.to forbid_action :edit }
+      it { is_expected.to forbid_action :update }
+      it { is_expected.to forbid_action :new }
+      it { is_expected.to permit_action :create }
+      it { is_expected.to forbid_action :edit_payment }
+    end
+
+    context 'company information is NOT complete' do
+      subject { described_class.new(member, co_incomplete_info) }
+
+      it { is_expected.to permit_action :index }
+      it { is_expected.to forbid_action :show }
+      it { is_expected.to forbid_action :edit }
+      it { is_expected.to forbid_action :update }
+      it { is_expected.to forbid_action :new }
+      it { is_expected.to permit_action :create }
+      it { is_expected.to forbid_action :edit_payment }
+    end
   end
 
   describe 'For a user (logged in)' do
-    subject { described_class.new(user_1, company) }
 
-    it { is_expected.to permit_action :index }
-    it { is_expected.to permit_action :show }
-    it { is_expected.to forbid_action :edit }
-    it { is_expected.to forbid_action :update }
-    it { is_expected.to forbid_action :new }
-    it { is_expected.to permit_action :create }
-    it { is_expected.to forbid_action :edit_payment }
+    context 'company information IS complete' do
+      subject { described_class.new(user_1, company) }
+
+      it { is_expected.to permit_action :index }
+      it { is_expected.to permit_action :show }
+      it { is_expected.to forbid_action :edit }
+      it { is_expected.to forbid_action :update }
+      it { is_expected.to forbid_action :new }
+      it { is_expected.to permit_action :create }
+      it { is_expected.to forbid_action :edit_payment }
+    end
+
+    context 'company information is NOT complete' do
+      subject { described_class.new(user_1, co_incomplete_info) }
+
+      it { is_expected.to permit_action :index }
+      it { is_expected.to forbid_action :show }
+      it { is_expected.to forbid_action :edit }
+      it { is_expected.to forbid_action :update }
+      it { is_expected.to forbid_action :new }
+      it { is_expected.to permit_action :create }
+      it { is_expected.to forbid_action :edit_payment }
+    end
   end
 
   describe 'For a visitor (not logged in)' do
-    subject { described_class.new(visitor, company) }
 
-    it { is_expected.to permit_action :index }
-    it { is_expected.to permit_action :show }
-    it { is_expected.to forbid_action :edit }
-    it { is_expected.to forbid_action :update }
-    it { is_expected.to forbid_action :new }
-    it { is_expected.to forbid_action :create }
-    it { is_expected.to forbid_action :edit_payment }
+    context 'company information IS complete' do
+      subject { described_class.new(visitor, company) }
+
+      it { is_expected.to permit_action :index }
+      it { is_expected.to permit_action :show }
+      it { is_expected.to forbid_action :edit }
+      it { is_expected.to forbid_action :update }
+      it { is_expected.to forbid_action :new }
+      it { is_expected.to forbid_action :create }
+      it { is_expected.to forbid_action :edit_payment }
+    end
+
+    context 'company information is NOT complete' do
+      subject { described_class.new(visitor, co_incomplete_info) }
+
+      it { is_expected.to permit_action :index }
+      it { is_expected.to forbid_action :show }
+      it { is_expected.to forbid_action :edit }
+      it { is_expected.to forbid_action :update }
+      it { is_expected.to forbid_action :new }
+      it { is_expected.to forbid_action :create }
+      it { is_expected.to forbid_action :edit_payment }
+    end
   end
 end


### PR DESCRIPTION
## PT Story: Admin, Member cannot edit or see a Co. without a name (incomplete)
#### PT URL: https://www.pivotaltracker.com/story/show/177249905


## Changes proposed in this pull request:
1.  update Company policy for `show` action
2.  show 'not found' (404) error so that bots, etc., don't know if an incomplete company does/does not exist.  (reduce possibility of maliciousness)


