### PR TITLE
Admin sees all applicants for a Company

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,7 +311,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)

--- a/app/assets/stylesheets/companies.scss
+++ b/app/assets/stylesheets/companies.scss
@@ -177,6 +177,11 @@ th .complete-status {
 
   }
 
+  .admin-only {
+    .company-applicants-list {
+      font-size: smaller;
+    }
+  }
 }
 
 

--- a/app/views/companies/_company_applicants.html.haml
+++ b/app/views/companies/_company_applicants.html.haml
@@ -21,6 +21,7 @@
                             %th.business-categories= t('.business_categories')
                             %th.is-member= t('.is_member')
                             %th.app-status= t('.app status')
+                            %th.app-updated= t('lastupdated')
 
                         - applications.each do |application|
                           %tbody
@@ -29,3 +30,4 @@
                               %td.is-member= business_categories_str(application)
                               %td.app-status= yes_no_span(application.user.member)
                               %td.app-state= link_to(t("activerecord.attributes.shf_application.state/#{application.state}"), application)
+                              %td.app-updated= application.updated_at

--- a/app/views/companies/_company_applicants.html.haml
+++ b/app/views/companies/_company_applicants.html.haml
@@ -4,21 +4,28 @@
   - applications = company.shf_applications - company.approved_applications_from_members # FIXME
 
   - if applications.any?
-    .row.admin-only
-      .col-12.company-applicants
-        .table-responsive-lg
-          %table.table.table-sm.table-hover.company-applicants
-            %thead
-              %tr
-                %th.text-nowrap= t('.title')
-                %th= t('.business_categories')
-                %th= t('.is_member')
-                %th= t('.app status')
+    .company-applicants
+      .admin-only
+        .row
+          .col-12
+            %h3.section-title= t('activerecord.models.shf_application.other')
+            .section
+              .row
+                .col-12
+                  .company-applicants-list
+                    .table-responsive
+                      %table.table.table-sm.table-hover
+                        %thead
+                          %tr
+                            %th.text-nowrap= t('.title')
+                            %th.business-categories= t('.business_categories')
+                            %th.is-member= t('.is_member')
+                            %th.app-status= t('.app status')
 
-            - applications.each do |application|
-              %tbody
-                %tr.applicant
-                  %td= link_to(application.user.full_name, application.user)
-                  %td= business_categories_str(application)
-                  %td= yes_no_span(application.user.member)
-                  %td= link_to(t("activerecord.attributes.shf_application.state/#{application.state}"), application)
+                        - applications.each do |application|
+                          %tbody
+                            %tr.applicant
+                              %td.business-categories= link_to(application.user.full_name, application.user)
+                              %td.is-member= business_categories_str(application)
+                              %td.app-status= yes_no_span(application.user.member)
+                              %td.app-state= link_to(t("activerecord.attributes.shf_application.state/#{application.state}"), application)

--- a/app/views/companies/_company_applicants.html.haml
+++ b/app/views/companies/_company_applicants.html.haml
@@ -1,0 +1,24 @@
+-# only the admin should see this
+
+- if current_user.admin?
+  - applications = company.shf_applications - company.approved_applications_from_members # FIXME
+
+  - if applications.any?
+    .row.admin-only
+      .col-12.company-applicants
+        .table-responsive-lg
+          %table.table.table-sm.table-hover.company-applicants
+            %thead
+              %tr
+                %th.text-nowrap= t('.title')
+                %th= t('.business_categories')
+                %th= t('.is_member')
+                %th= t('.app status')
+
+            - applications.each do |application|
+              %tbody
+                %tr.applicant
+                  %td= link_to(application.user.full_name, application.user)
+                  %td= business_categories_str(application)
+                  %td= application.user.member
+                  %td= link_to(t("shf_applications.#{application.state}"), application)

--- a/app/views/companies/_company_applicants.html.haml
+++ b/app/views/companies/_company_applicants.html.haml
@@ -20,5 +20,5 @@
                 %tr.applicant
                   %td= link_to(application.user.full_name, application.user)
                   %td= business_categories_str(application)
-                  %td= application.user.member
-                  %td= link_to(t("shf_applications.#{application.state}"), application)
+                  %td= yes_no_span(application.user.member)
+                  %td= link_to(t("activerecord.attributes.shf_application.state/#{application.state}"), application)

--- a/app/views/companies/_company_members.html.haml
+++ b/app/views/companies/_company_members.html.haml
@@ -1,4 +1,7 @@
-- applications = company.approved_applications_from_members # FIXME
+- if current_user.admin?
+  - applications = company.shf_applications
+- else
+  - applications = company.approved_applications_from_members # FIXME
 
 - if applications.any?
   .row
@@ -7,11 +10,16 @@
         %table.table.table-sm.table-hover.company-members
           %thead
             %tr
-              %th.text-nowrap= t('companies.show.members')
-              %th= t('activerecord.models.business_category.other')
-
+              %th.text-nowrap= t('.co_members')
+              %th= t('.business_categories')
+              - if current_user.admin?
+                %th= t('.is_member')
+                %th= t('.app status')
           - applications.each do |application|
             %tbody
               %tr.member
                 %td= application.user.full_name
                 %td= business_categories_str(application)
+                - if current_user.admin?
+                  %td= application.user.member
+                  %td= application.state

--- a/app/views/companies/_company_members.html.haml
+++ b/app/views/companies/_company_members.html.haml
@@ -1,7 +1,4 @@
-- if current_user.admin?
-  - applications = company.shf_applications
-- else
-  - applications = company.approved_applications_from_members # FIXME
+- applications = company.approved_applications_from_members # FIXME
 
 - if applications.any?
   .row
@@ -10,16 +7,21 @@
         %table.table.table-sm.table-hover.company-members
           %thead
             %tr
-              %th.text-nowrap= t('.co_members')
+              %th.text-nowrap= t('.title')
               %th= t('.business_categories')
               - if current_user.admin?
                 %th= t('.is_member')
                 %th= t('.app status')
           - applications.each do |application|
+            - app_admin_only_css = application.accepted? ? '' : 'admin-only'
+
             %tbody
-              %tr.member
-                %td= link_to(application.user.full_name, application.user)
+              %tr.member{ class: "#{app_admin_only_css}"}
+                - if current_user.admin?
+                  %td= link_to(application.user.full_name, application.user)
+                - else
+                  %td= application.user.full_name
                 %td= business_categories_str(application)
                 - if current_user.admin?
-                  %td= application.user.member
-                  %td= link_to(application.state, application)
+                  %td.admin-only= application.user.member
+                  %td.admin-only= link_to(t("shf_applications.#{application.state}"), application)

--- a/app/views/companies/_company_members.html.haml
+++ b/app/views/companies/_company_members.html.haml
@@ -18,8 +18,8 @@
           - applications.each do |application|
             %tbody
               %tr.member
-                %td= application.user.full_name
+                %td= link_to(application.user.full_name, application.user)
                 %td= business_categories_str(application)
                 - if current_user.admin?
                   %td= application.user.member
-                  %td= application.state
+                  %td= link_to(application.state, application)

--- a/app/views/companies/_company_members.html.haml
+++ b/app/views/companies/_company_members.html.haml
@@ -16,7 +16,7 @@
             - app_admin_only_css = application.accepted? ? '' : 'admin-only'
 
             %tbody
-              %tr.member{ class: "#{app_admin_only_css}"}
+              %tr.member{ class: "#{app_admin_only_css}" }
                 - if current_user.admin?
                   %td= link_to(application.user.full_name, application.user)
                 - else

--- a/app/views/companies/_company_members.html.haml
+++ b/app/views/companies/_company_members.html.haml
@@ -23,5 +23,5 @@
                   %td= application.user.full_name
                 %td= business_categories_str(application)
                 - if current_user.admin?
-                  %td.admin-only= application.user.member
-                  %td.admin-only= link_to(t("shf_applications.#{application.state}"), application)
+                  %td.admin-only= yes_no_span(application.user.member)
+                  %td.admin-only= link_to(t("activerecord.attributes.shf_application.state/#{application.state}"), application)

--- a/app/views/companies/show.html.haml
+++ b/app/views/companies/show.html.haml
@@ -84,6 +84,7 @@
     - user_can_edit = policy(@company).update?
 
     = render 'company_members', company: @company, applications: @applications
+    = render 'company_applicants', company: @company, applications: @applications if current_user.admin?
 
     = render 'company_addresses', company: @company, user_can_edit: user_can_edit
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -847,6 +847,12 @@ en:
       this_info_missing: "This information is missing:"
       complete: *complete
 
+    company_members:
+      co_members: Company Members
+      business_categories: *business_categories
+      is_member: *member
+      app_status: *state
+
     index:
       title: Find H-labeled companies
       admin_title: Edit member companies

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -741,6 +741,7 @@ en:
       being_destroyed: *status_being_destroyed
 
     new_status: *status_new
+    new: *status_new
     accept_btn: Accept
     accepted: *status_accepted
     reject_btn: Reject
@@ -848,7 +849,13 @@ en:
       complete: *complete
 
     company_members:
-      co_members: Company Members
+      title: &co_members Company Members
+      business_categories: *business_categories
+      is_member: *member
+      app_status: *state
+
+    company_applicants:
+      title: &co_applicants Company Applicants
       business_categories: *business_categories
       is_member: *member
       app_status: *state

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -741,7 +741,6 @@ en:
       being_destroyed: *status_being_destroyed
 
     new_status: *status_new
-    new: *status_new
     accept_btn: Accept
     accepted: *status_accepted
     reject_btn: Reject

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -854,6 +854,12 @@ sv:
       this_info_missing: "This information is missing:"
       complete: *complete
 
+    company_members:
+      co_members: Företagsmedlemmar
+      business_categories: *business_categories
+      is_member: *member
+      app_status: *state
+
     index:
       title:  Hitta H-märkt företag
       admin_title: Redigera medlemsföretag

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -746,7 +746,6 @@ sv:
       being_destroyed: *status_being_destroyed
 
     new_status: *status_new
-    new: *status_new
     accept_btn: Godkänn
     accepted: *status_accepted
     reject_btn: Avböj

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -746,6 +746,7 @@ sv:
       being_destroyed: *status_being_destroyed
 
     new_status: *status_new
+    new: *status_new
     accept_btn: Godkänn
     accepted: *status_accepted
     reject_btn: Avböj
@@ -855,7 +856,13 @@ sv:
       complete: *complete
 
     company_members:
-      co_members: Företagsmedlemmar
+      title: &co_members Företagsmedlemmar
+      business_categories: *business_categories
+      is_member: *member
+      app_status: *state
+
+    company_applicants:
+      title: &co_applicants Företagssökande
       business_categories: *business_categories
       is_member: *member
       app_status: *state

--- a/features/companies/show-admin-all-applicants.feature
+++ b/features/companies/show-admin-all-applicants.feature
@@ -12,12 +12,12 @@ Feature: Admin sees all applicants connected to a company
     Given the Membership Ethical Guidelines Master Checklist exists
 
     Given the following users exist:
-      | email                              | admin | membership_status | member | agreed_to_membership_guidelines | first_name   | last_name |
-      | member@example.com                 |       | current_member    | true   | yes                             | Current      | Member    |
-      | applicant-new@example.com          |       | not_a_member      | false  | yes                             | New          | Applicant |
-      | applicant-under-review@example.com |       | not_a_member      | false  | yes                             | Under Review | Applicant |
-      | applicant-rejected@example.com     |       | not_a_member      | false  | yes                             | Rejected     | Applicant |
-      | admin@shf.se                       | true  |                   | false  | yes                             | Admin        | Admin     |
+      | email                              | admin | member | agreed_to_membership_guidelines | first_name   | last_name |
+      | member@example.com                 |       | true   | yes                             | Current      | Member    |
+      | applicant-new@example.com          |       | false  | yes                             | New          | Applicant |
+      | applicant-under-review@example.com |       | false  | yes                             | Under Review | Applicant |
+      | applicant-rejected@example.com     |       | false  | yes                             | Rejected     | Applicant |
+      | admin@shf.se                       | true  | false  | yes                             | Admin        | Admin     |
 
     And the following business categories exist
       | name    |
@@ -35,7 +35,7 @@ Feature: Admin sees all applicants connected to a company
       | applicant-rejected@example.com     | 5560360793     | Groomer    | rejected     |
 
 
-    And the following payments exist:
+    And the following payments exist
       | user_email         | start_date | expire_date | payment_type | status | hips_id | company_number |
       | member@example.com | 2021-01-01 | 2021-12-31  | member_fee   | betald | none    |                |
       | member@example.com | 2021-01-01 | 2021-12-31  | branding_fee | betald | none    | 5560360793     |
@@ -45,35 +45,56 @@ Feature: Admin sees all applicants connected to a company
 
   # -----------------------------------------------------------------------------------------------
 
-  Scenario: Admin sees member and 3 applicants on Company page
+  Scenario: Admin sees member and applicants section with 3 applicants on Company page
     Given I am logged in as "admin@shf.se"
     When I am on the page for company number "5560360793"
     Then I should see "No More Snarky Barky" in the h1 title
+    And I should see t("companies.company_members.title")
     And I should see "Current Member"
+    And I should see t("companies.company_applicants.title")
     And I should see "New Applicant"
     And I should see "Under Review Applicant"
     And I should see "Rejected Applicant"
 
 
-  Scenario Outline: Non-admins do not see non-member applicants listed
-    Given I am logged in as "<logged_in_email>"
+  Scenario: Admin sees links to each person and application
+    Given I am logged in as "admin@shf.se"
     When I am on the page for company number "5560360793"
     Then I should see "No More Snarky Barky" in the h1 title
     And I should see "Current Member"
+    And I should see "Current Member" link
+    And I should see t("companies.company_applicants.title")
+    And I should see "New Applicant" link
+    And I should see "Under Review Applicant" link
+    And I should see "Rejected Applicant" link
+
+
+  Scenario Outline: Non-admins do not see non-member applicants listed
+    Given I am <logged_in_status>
+    When I am on the page for company number "5560360793"
+    Then I should see "No More Snarky Barky" in the h1 title
+    And I should see "Current Member"
+    And I should not see t("companies.company_applicants.title")
     And I should not see "New Applicant"
     And I should not see "Under Review Applicant"
     And I should not see "Rejected Applicant"
 
     Scenarios:
-      | logged_in_email    |
-      | member@example.com |
-      | applicant-new@example.com |
+      | logged_in_status                         |
+      | logged in as "member@example.com"        |
+      | logged in as "applicant-new@example.com" |
+      | logged out                               |
 
 
-  Scenario: Visitors do not see non-member applicants listed
-    Given I am logged out
+  Scenario: Non-admins do not see links to each person and application
+    Given I am <logged_in_status>
     When I am on the page for company number "5560360793"
     Then I should see "No More Snarky Barky" in the h1 title
     And I should see "Current Member"
-    And I should not see "New Applicant"
-    And I should not see "Under Review Applicant"
+    And I should not see "Current Member" link
+
+    Scenarios:
+      | logged_in_status                         |
+      | logged in as "member@example.com"        |
+      | logged in as "applicant-new@example.com" |
+      | logged out                               |

--- a/features/companies/show-admin-all-applicants.feature
+++ b/features/companies/show-admin-all-applicants.feature
@@ -57,7 +57,7 @@ Feature: Admin sees all applicants connected to a company
     And I should see "Rejected Applicant"
 
 
-  Scenario: Admin sees links to each person and application
+  Scenario: Admin sees links to each person and application and the date each app was last updated
     Given I am logged in as "admin@shf.se"
     When I am on the page for company number "5560360793"
     Then I should see "No More Snarky Barky" in the h1 title
@@ -67,6 +67,7 @@ Feature: Admin sees all applicants connected to a company
     And I should see "New Applicant" link
     And I should see "Under Review Applicant" link
     And I should see "Rejected Applicant" link
+    And I should see 4 visible "2021-03-02"
 
 
   Scenario Outline: Non-admins do not see non-member applicants listed

--- a/features/companies/show-admin-all-applicants.feature
+++ b/features/companies/show-admin-all-applicants.feature
@@ -1,0 +1,79 @@
+Feature: Admin sees all applicants connected to a company
+
+  As an admin
+  So that I can see everyone that has applied to SHF that has listed a Company
+  Show me all applicants when I view info about a company
+
+
+  PivotalTracker: https://www.pivotaltracker.com/story/show/177251184
+
+  Background:
+    Given the date is set to "2021-03-02"
+    Given the Membership Ethical Guidelines Master Checklist exists
+
+    Given the following users exist:
+      | email                              | admin | membership_status | member | agreed_to_membership_guidelines | first_name   | last_name |
+      | member@example.com                 |       | current_member    | true   | yes                             | Current      | Member    |
+      | applicant-new@example.com          |       | not_a_member      | false  | yes                             | New          | Applicant |
+      | applicant-under-review@example.com |       | not_a_member      | false  | yes                             | Under Review | Applicant |
+      | applicant-rejected@example.com     |       | not_a_member      | false  | yes                             | Rejected     | Applicant |
+      | admin@shf.se                       | true  |                   | false  | yes                             | Admin        | Admin     |
+
+    And the following business categories exist
+      | name    |
+      | Groomer |
+
+    And the following companies exist:
+      | name                 | company_number | email                   | region    | kommun   | city      | visibility     |
+      | No More Snarky Barky | 5560360793     | hello@nosnarkybarky.com | Stockholm | Alingsås | Harplinge | street_address |
+
+    And the following applications exist:
+      | user_email                         | company_number | categories | state        |
+      | member@example.com                 | 5560360793     | Groomer    | accepted     |
+      | applicant-new@example.com          | 5560360793     | Groomer    | new          |
+      | applicant-under-review@example.com | 5560360793     | Groomer    | under_review |
+      | applicant-rejected@example.com     | 5560360793     | Groomer    | rejected     |
+
+
+    And the following payments exist:
+      | user_email         | start_date | expire_date | payment_type | status | hips_id | company_number |
+      | member@example.com | 2021-01-01 | 2021-12-31  | member_fee   | betald | none    |                |
+      | member@example.com | 2021-01-01 | 2021-12-31  | branding_fee | betald | none    | 5560360793     |
+
+
+    # And the following memberships exist:
+
+  # -----------------------------------------------------------------------------------------------
+
+  Scenario: Admin sees member and 3 applicants on Company page
+    Given I am logged in as "admin@shf.se"
+    When I am on the page for company number "5560360793"
+    Then I should see "No More Snarky Barky" in the h1 title
+    And I should see "Current Member"
+    And I should see "New Applicant"
+    And I should see "Under Review Applicant"
+    And I should see "Rejected Applicant"
+
+
+  Scenario Outline: Non-admins do not see non-member applicants listed
+    Given I am logged in as "<logged_in_email>"
+    When I am on the page for company number "5560360793"
+    Then I should see "No More Snarky Barky" in the h1 title
+    And I should see "Current Member"
+    And I should not see "New Applicant"
+    And I should not see "Under Review Applicant"
+    And I should not see "Rejected Applicant"
+
+    Scenarios:
+      | logged_in_email    |
+      | member@example.com |
+      | applicant-new@example.com |
+
+
+  Scenario: Visitors do not see non-member applicants listed
+    Given I am logged out
+    When I am on the page for company number "5560360793"
+    Then I should see "No More Snarky Barky" in the h1 title
+    And I should see "Current Member"
+    And I should not see "New Applicant"
+    And I should not see "Under Review Applicant"


### PR DESCRIPTION
## PT Story:  Admin must see applicants to/with a company
#### PT URL: https://www.pivotaltracker.com/story/show/177251184 


## Changes proposed in this pull request:
1.  Added feature "Admin sees all applicants connected to a company"  `features/companies/show-admin-all-applicants.feature`
2.  Added a section on a Company page that lists all that have applied to the company
    - only the admin can see it
3. Added 2 columns to the Members table that only the admin can see:
   - is a member?
   - application status (linked to application)

  
## Screenshots (Optional):

### Whole Company page with the new "Membership Applicants" section (background = _admin-only blue_) under the list of members 

<img width="491" alt="co-page-with-applicant-section-sv" src="https://user-images.githubusercontent.com/673794/114465617-34532600-9b9c-11eb-91c8-86701ca22f44.png">

---

### Close up of the Membership Applicants section
   - name is linked to user account, application status is linked to application
   
<img width="640" alt="co-applicants-section-sv" src="https://user-images.githubusercontent.com/673794/114617018-704dc000-9c5c-11eb-8ef2-d82aecc3bd08.png">




---
## Ready for review:
@thesuss 
