### PR TITLE
Admin can update all membership statuses manually

### DIFF
--- a/app/models/reqs_updaters/membership_status_updater.rb
+++ b/app/models/reqs_updaters/membership_status_updater.rb
@@ -96,8 +96,19 @@ class MembershipStatusUpdater
     update_membership_status(user, user, logmsg_user_updated, send_email: send_email)
   end
 
+
   # end of Notifications received from observed classes
   # -----------------------------------------------------------------------------------
+
+  def check_grant_renew_and_status(given_user, notifier = nil, reason_update_happened = nil,
+                                   send_email: send_email_default)
+
+    check_grant_membership_or_renew(given_user, notifier, reason_update_happened,
+                                    send_email: send_email)
+
+    update_membership_status(given_user, notifier, reason_update_happened,
+                             send_email: send_email)
+  end
 
 
   def check_grant_membership_or_renew(given_user, notifier = nil, reason_update_happened = nil,
@@ -106,7 +117,7 @@ class MembershipStatusUpdater
 
     log_and_check("#{__method__}", given_user, [notifier], notifier, reason_update_happened) do |user, _other_args, log|
       # next_membership_start_date =  user.membership_expire_date.nil? ? today : user.membership_expire_date + 1.day
-      if  user.membership_expire_date.nil? || user.membership_expire_date < today
+      if user.membership_expire_date.nil? || user.membership_expire_date < today
         next_membership_start_date = today
       else
         next_membership_start_date = user.membership_expire_date + 1
@@ -190,9 +201,11 @@ class MembershipStatusUpdater
     LOGMSG_PAYMENT_MADE
   end
 
+
   def logmsg_checklist_completed
     LOGMSG_CHECKLIST_COMPLETED
   end
+
 
   # -----------------------------------------------------------------------------------------------
 

--- a/app/views/admin_only/user_account/_update_membership_status_all_modal.html.haml
+++ b/app/views/admin_only/user_account/_update_membership_status_all_modal.html.haml
@@ -1,0 +1,22 @@
+-# This is a Bootstrap 4 modal.
+-# @url https://getbootstrap.com/docs/4.2/components/modal/
+-#
+.modal.fade#update-membership-status-all-modal{ tabindex:'-1', role:'dialog', aria: { labelledby: 'update-membership-status-all-modal-title', hidden: 'true' } }
+
+  .modal-dialog.modal-dialog-centered.modal-sm{ role:'document' }
+    .modal-content
+      .update-membership-status-all
+
+        .modal-header
+          %h4.modal-title#update-membership-status-all-modal-title= t('.title')
+
+        .modal-body
+          %p= t('.body')
+
+        .modal-footer
+          %button.btn-secondary.btn-sm#dismiss{ data: { dismiss:'modal' } }
+            = t('close')
+
+          = link_to t('.confirm_do_updates'),
+                admin_only_update_membership_status_all_path,
+                class: 'button btn-primary btn-sm'

--- a/app/views/admin_only/user_account/update_membership_status_all_success.html.erb
+++ b/app/views/admin_only/user_account/update_membership_status_all_success.html.erb
@@ -1,0 +1,2 @@
+.entry-content.container
+  %h3 success!

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -75,4 +75,6 @@
 
       = render 'cookies_eu/consent_banner', link: 'https://sverigeshundforetagare.se/cookies/', target: '_blank'
 
-      = render 'admin_only/about_modal' if current_user.admin?
+      - if current_user.admin?
+        = render 'admin_only/about_modal'
+        = render 'admin_only/user_account/update_membership_status_all_modal'

--- a/app/views/nav-menus/_login_admin_items.html.haml
+++ b/app/views/nav-menus/_login_admin_items.html.haml
@@ -17,6 +17,10 @@
   %li
     = link_to t('about') + '...', '#', class: nav_link_class, data: { toggle: 'modal', target: '#about-info-modal' }
 
+  %li
+    = link_to t('menus.nav.admin.update_all_membership_status'),
+     admin_only_update_membership_status_all_path, class: nav_link_class,
+     data: { toggle: 'modal', target: '#update-membership-status-all-modal' }
 
   - unless @user.nil?
     %li

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1596,10 +1596,19 @@ en:
         copy_image_url: *copy_image_url
         copied: *copied
 
-
       update:
         error: A problem kept the user account from being updated.
         success: The user account was updated.
+
+      update_membership_status_all_modal:
+        title: "Confirm: Update membership status for all"
+        body: "Do you really want to update the membership status for all users?  This will take a few minutes. Note that no emails will be sent."
+        confirm_do_updates: Yes, update all
+
+      update_membership_status_all:
+        reason_update_happened: Admin Ran Update All M.Statuses
+        success: Membership status for all members was updated. You can check the MembershipStatusUpdater log for the results.
+        error: There was a problem updating membership status for all users.  Please review the logs for details.
 
 
     master_checklists:
@@ -2129,6 +2138,8 @@ en:
         master_checklists: Master Checklists
         dashboard: Dashboard
         all_uploaded_files: All Uploaded Files
+        update_all_membership_status:  Update Membership Status...
+
 
         categories:
           submenu_title: Categories

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1607,6 +1607,16 @@ sv:
         success: Användarens information uppdaterad.
         error: Ett problem hindrade användarinformationen från att uppdateras.
 
+      update_membership_status_all_modal:
+        title: "Confirm: Update membership status for all"
+        body: Do you really want to update the membership status for all users?  This will take a few minutes. Note that no emails will be sent.
+        confirm_do_updates: Yes, update all
+
+      update_membership_status_all:
+        reason_update_happened: Admin Ran Update All M.Statuses
+        success: Membership status for all members was updated. You can check the MembershipStatusUpdater log for the results.
+        error: There was a problem updating membership status for all users.  Please review the logs for details.
+
 
     master_checklists:
       new_item: &new_master_list_item New Master List Item
@@ -2133,6 +2143,7 @@ sv:
         dashboard: Dashboard
         design_guide: Design Guide
         all_uploaded_files: All Uploaded Files
+        update_all_membership_status:  Update Membership Status...
 
         categories:
           submenu_title: Kategorier

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,11 @@ Rails.application.routes.draw do
         get 'payments', to: 'dashboard#payments'
 
         resources :master_checklist_types
-        resources :memberships
+
+        # Update membership status for all users
+        get 'anvandare/update-membership-status-all', to: 'user_account#update_membership_status_all',
+            as: :update_membership_status_all
+
       end
 
 

--- a/features/admin_only/run-membership-status-updater-all-users.feature
+++ b/features/admin_only/run-membership-status-updater-all-users.feature
@@ -1,0 +1,67 @@
+Feature: Update the membership status for all users
+
+  As an admin
+  So I can verify that the membership status is updated correctly
+  When changes are made to user information,
+  I need to be able to update the membership status for all users
+
+  Background:
+#    Given the App Configuration is not mocked and is seeded
+    And the Membership Ethical Guidelines Master Checklist exists
+
+    Given the following users exist
+      | email         | password | admin | membership_status | member | first_name | last_name     | membership_number |
+      | admin@shf.se  | password | true  |                   |        | Admin      | Administrator |                   |
+      | member@shf.se | password | false | current_member    | true   | Mary       | Member        | 1001              |
+
+    Given the following business categories exist
+      | name  | description             |
+      | rehab | physical rehabilitation |
+
+    Given the following companies exist:
+      | name       | company_number | email               | region    |
+      | HappyMutts | 5562252998     | woof@happymutts.com | Stockholm |
+
+    Given the following applications exist:
+      | user_email    | company_number | categories | state    |
+      | member@shf.se | 5562252998     | rehab      | accepted |
+
+
+    Given the following payments exist
+      | user_email    | start_date | expire_date | payment_type | status | hips_id | company_number |
+      | member@shf.se | 2019-1-1   | 2019-12-31  | member_fee   | betald | none    |                |
+      | member@shf.se | 2019-1-1   | 2019-12-31  | branding_fee | betald | none    | 5562252998     |
+
+
+    And the following memberships exist
+      | email         | first_day | last_day   | notes |
+      | member@shf.se | 2019-1-1  | 2019-12-31 |       |
+
+
+    Given I am logged in as "admin@shf.se"
+    And I am on the "business categories" page
+    # It doesn't matter what page the admin is on.  But this one does a smaller query that others.
+
+  # ---------------------------------------------------------------------------------------------
+
+  Scenario: Admin sees modal and confirms they do  want to update all Users, sees success message and is taken to All Users page
+    When I click on t("hello", name: "Admin")
+    And I click on t("menus.nav.admin.update_all_membership_status")
+    Then I should see t("admin_only.user_account.update_membership_status_all_modal.title")
+    When I click on t("admin_only.user_account.update_membership_status_all_modal.confirm_do_updates")
+    And I should be on the "all users" page
+    And I should see t("admin_only.user_account.update_membership_status_all.success")
+
+
+  @selenium
+  Scenario: Admin sees modal and dimisses modal (they do not want to update all Users)
+    Given I am logged in as "admin@shf.se"
+    And I am on the landing page
+    When I click on t("hello", name: "Admin")
+    And I click on t("menus.nav.admin.update_all_membership_status")
+    Then I should see t("admin_only.user_account.update_membership_status_all_modal.title")
+    When I click on t("close")
+    And I should not see t("admin_only.user_account.update_membership_status_all.success")
+    And I should not see t("admin_only.user_account.update_membership_status_all.error")
+
+


### PR DESCRIPTION
## PT Story: Run UpdateMembershipStatus manually
#### PT URL: https://www.pivotaltracker.com/story/show/178111926


## Changes proposed in this pull request:
1.  add a menu item for admins only in the Login menu
2. call MembershipUpdater for all users _except_ former members and admin


---
## Ready for review:
@
