### PR TITLE
Renewal must complete ethical guidelines on or after recent membership first day

### DIFF
--- a/app/models/memberships_manager.rb
+++ b/app/models/memberships_manager.rb
@@ -76,15 +76,19 @@ class MembershipsManager
   end
 
 
-  # ---------------------------------------------------------------------------------
-
   # @return [nil | Membership] - nil if no Memberships,
   # else the one with the latest last day
-  def most_recent_membership(user)
+  def self.most_recent_membership(user)
     memberships = user.memberships
     return nil if memberships.empty?
 
     memberships.order(most_recent_membership_method)&.last
+  end
+
+  # ---------------------------------------------------------------------------------
+
+  def most_recent_membership(user)
+    self.class.most_recent_membership(user)
   end
 
 

--- a/app/models/reqs_updaters/requirements_for_renewal.rb
+++ b/app/models/reqs_updaters/requirements_for_renewal.rb
@@ -21,11 +21,10 @@
 class RequirementsForRenewal < AbstractReqsForMembership
 
   def self.requirements_excluding_payments_met?(user, date = Date.current)
-    # can change membership status to renew (aasm gem)
     user.may_renew? &&
       user.valid_date_for_renewal?(date) &&
       user.has_approved_shf_application? &&
-      membership_guidelines_checklist_done?(user) &&
+      checklist_done_on_or_after_latest_membership_start?(user) &&
       doc_uploaded_during_this_membership_term?(user)
   end
 
@@ -35,5 +34,10 @@ class RequirementsForRenewal < AbstractReqsForMembership
   #   - what if the member paid for 2 terms in advance?
   def self.doc_uploaded_during_this_membership_term?(user)
     user.file_uploaded_during_this_membership_term?
+  end
+
+
+  def self.checklist_done_on_or_after_latest_membership_start?(user)
+    UserChecklistManager.checklist_done_on_or_after_latest_membership_start?(user)
   end
 end

--- a/app/models/user_checklist.rb
+++ b/app/models/user_checklist.rb
@@ -84,6 +84,20 @@ class UserChecklist < ApplicationRecord
     where(master_checklist: AdminOnly::MasterChecklist.latest_membership_guideline_master)
   end
 
+  # Get the most recently completed top level guidelines for the user
+  def self.most_recent_completed_top_level_guideline(user)
+    UserChecklist.top_level_for_current_membership_guidelines
+                 .completed_by_user(user)
+                 .order(:date_completed).last
+  end
+
+  # Get the top level guidelines created on or after the date for the user, ordered by created_at
+  def self.most_recently_created_top_level_guidelines(user, date = Date.current)
+    UserChecklist.top_level_for_current_membership_guidelines
+                 .for_user(user)
+                 .where('created_at >= ?', date)
+                 .order(:created_at)
+  end
   # --------------------------------------------------------------------------------------
 
   # Add .includes to the query used to get all descendants to help avoid N+1 queries

--- a/app/views/users/_ethical_guidelines_link_or_checklist.html.haml
+++ b/app/views/users/_ethical_guidelines_link_or_checklist.html.haml
@@ -1,18 +1,20 @@
--# This partial expects these locals:
--#
--#  user - the user the membership guidelines checklist belongs to
-
+:ruby
+  # This partial expects these locals:
+  #  user - the user the membership guidelines checklist belongs to
+  #  find_or_create_method - method used to find or create the membership guidelines checklist
+  #    defaults to :find_or_create_membership_guidelines_list_for
+- find_or_create = local_assigns.fetch(:find_or_create_method, :find_or_create_membership_guidelines_list_for)
 - if UserChecklistManager.completed_membership_guidelines_checklist?(user)
   %p
     = complete_check_icon(html_options: {class: 'is-complete'})
-    = t('.agreed_to') + ' '
+    = t('users.ethical_guidelines_link_or_checklist.agreed_to', date: UserChecklistManager.membership_guidelines_list_for(user)&.date_completed.to_date.to_s) + ' '
     = link_to  'https://sverigeshundforetagare.se/medlemsatagande/', target: '_blank' do
-      = t('.membership_guidelines')
+      = t('users.ethical_guidelines_link_or_checklist.membership_guidelines')
       %sup= external_link_icon
 - else
-  - user_checklist = UserChecklistManager.find_or_create_membership_guidelines_list_for(user).root
+  - user_checklist = UserChecklistManager.send(find_or_create, user).root
   - first_incomplete = UserChecklistManager.first_incomplete_membership_guideline_section_for(user)
-  = link_to t('.agree_to_guidelines'), user_user_checklist_progress_path(user, first_incomplete), class: 'btn btn-sm btn-primary'
+  = link_to t('users.ethical_guidelines_link_or_checklist.agree_to_guidelines'), user_user_checklist_progress_path(user, first_incomplete), class: 'btn btn-sm btn-primary'
 
   - progress_percent = user_checklist.percent_complete
   .completed-progress-bar

--- a/app/views/users/_renewal.html.haml
+++ b/app/views/users/_renewal.html.haml
@@ -19,7 +19,8 @@
         %h4.steps-title= t('.steps_to_renew')
         %ol.steps
 
-          %li.step.membership-ethical-guidelines= render partial: 'ethical_guidelines_link_or_checklist', locals: { user: user }
+          %li.step.membership-ethical-guidelines= render partial: 'ethical_guidelines_link_or_checklist',
+            locals: { user: user, find_or_create_method: :find_or_create_on_or_after_latest_membership_start }
 
           %li.step.upload-qualification-file= render partial: 'uploaded_files_requirement.html.haml', locals: { user: user }
 

--- a/app/views/users/_show_for_applicant.html.haml
+++ b/app/views/users/_show_for_applicant.html.haml
@@ -33,7 +33,8 @@
             = link_to t('.apply_4_membership'), new_shf_application_path, class: 'btn btn-primary btn-sm'
 
 
-        %li.step.membership-ethical-guidelines= render partial: 'ethical_guidelines_link_or_checklist', locals: {user: user}
+        %li.step.membership-ethical-guidelines= render partial: 'ethical_guidelines_link_or_checklist.html.haml',
+          locals: { user: user, find_or_create_method: :find_or_create_membership_guidelines_list_for }
 
         %li.step.pay-membership-fee
           - if user.allowed_to_pay_member_fee?

--- a/app/views/users/_show_for_member.html.haml
+++ b/app/views/users/_show_for_member.html.haml
@@ -34,7 +34,8 @@
 = render partial: 'shf_applications/show_business_categories',
                   locals: { shf_application: user.shf_application }
 
-%p.membership-guidelines-checklist= render partial: 'ethical_guidelines_link_or_checklist', locals: {user: user} unless show_renewal_info
+%p.membership-guidelines-checklist= render partial: 'ethical_guidelines_link_or_checklist',
+  locals: {user: user, find_or_create_method: :find_or_create_membership_guidelines_list_for } unless show_renewal_info
 
 = render partial: 'show_uploaded_files_section_row_cols',  locals: { user: user }
 

--- a/db/seed_helpers/users_factory.rb
+++ b/db/seed_helpers/users_factory.rb
@@ -337,9 +337,12 @@ module SeedHelpers
 
 
     # Create the Ethical Guidelines checklist and complete it
-    def make_completed_membership_guidelines_for(user, term_first_day)
+    def make_completed_membership_guidelines_for(user, completion_date)
       guidelines_list = UserChecklistManager.find_or_create_membership_guidelines_list_for(user)
-      guidelines_list.set_complete_including_children(term_first_day)
+      guidelines_list.set_complete_including_children(completion_date)
+      # set created_at date to the completion_date because UserChecklistManager checks it
+      guidelines_list.update(created_at: completion_date)
+      guidelines_list.descendants.update_all(created_at: completion_date)
     end
 
 

--- a/features/approve-member.feature
+++ b/features/approve-member.feature
@@ -42,6 +42,8 @@ Feature: Admin approves a member
       | hans@happymutts.se    | 5562252998     | dog grooming | under_review |
       | anna@nosnarkybarky.se | 5560360793     | rehab        | under_review |
 
+    # ====================================================================================
+
   @selenium
   Scenario: Admin approves, no company exists so one is created
     Given I am logged in as "admin@shf.com"
@@ -76,7 +78,7 @@ Feature: Admin approves a member
     Then I am in "anna@nosnarkybarky.se" browser
     And I am logged in as "anna@nosnarkybarky.se"
     And I have agreed to all of the Membership Guidelines
-    And I am on the "user details" page for "anna@nosnarkybarky.se"
+    And I am on the "user account" page for "anna@nosnarkybarky.se"
     Then I click on t("menus.nav.members.pay_membership")
     And I complete the membership payment
     And I should see t("payments.success.success")

--- a/features/checklists/ethical-guidelines/user-membership-guidelines-checklist.feature
+++ b/features/checklists/ethical-guidelines/user-membership-guidelines-checklist.feature
@@ -13,6 +13,7 @@ Feature: User completes all, some, or none of the Membership Ethical Guidelines 
   @selenium @javascript
   Scenario: User checks all guidelines - completes the list
     Given I am logged in as "new_user@example.com"
+    And the date is set to "2021-02-03"
     And I am on the "user account" page for "new_user@example.com"
     When I click on t("users.ethical_guidelines_link_or_checklist.agree_to_guidelines") link
     Then I should be on the "first unchecked membership guideline" page for "new_user@example.com"
@@ -46,7 +47,7 @@ Feature: User completes all, some, or none of the Membership Ethical Guidelines 
 
     When I am on the "user account" page for "new_user@example.com"
     And I should not see t("users.ethical_guidelines_link_or_checklist.agree_to_guidelines")
-    And I should see t("users.ethical_guidelines_link_or_checklist.agreed_to")
+    And I should see t("users.ethical_guidelines_link_or_checklist.agreed_to", date: '2021-02-03')
 
 
   @selenium  @javascript

--- a/features/membership-renewal/member-renews.feature
+++ b/features/membership-renewal/member-renews.feature
@@ -13,15 +13,14 @@ Feature: Member renews their membership
 
 
     Given the following users exist:
-      | email                                           | admin | membership_status | membership_number | member | first_name   | last_name            |
-      | member-all-reqs-met@example.com                 |       | current_member    | 101               | true   | Member       | All-Requirements-met |
-      | member-in-grace-period-all-reqs-met@example.com |       | current_member    | 102               | true   | LapsedMember | All-Requirements-met |
-      | admin@shf.se                                    | true  |                   |                   |        |              |                      |
+      | email                                           | admin | membership_status | membership_number | member | first_name   | last_name                   |
+      | member-all-reqs-met@example.com                 |       | current_member    | 101               | true   | Member       | All-Requirements-met        |
+      | member-in-grace-period-all-reqs-met@example.com |       | current_member    | 102               | true   | LapsedMember | All-Requirements-met        |
+      | member-agreed-before-current-start@example.com  |       | current_member    | 103               | true   | Member       | Agreed-Before-Current-Start |
+      | member-agreed-on-current-start@example.com      |       | current_member    | 104               | true   | Member       | Agreed-On-Current-Start     |
+      | member-agreed-after-current-start@example.com   |       | current_member    | 105               | true   | Member       | Agreed-After-Current-Start  |
+      | admin@shf.se                                    | true  |                   |                   |        |              |                             |
 
-    And the following users have agreed to the Membership Ethical Guidelines:
-      | email                                           |
-      | member-all-reqs-met@example.com                 |
-      | member-in-grace-period-all-reqs-met@example.com |
 
     And the following regions exist:
       | name      |
@@ -38,9 +37,10 @@ Feature: Member renews their membership
 
 
     And the following applications exist:
-      | user_email                                      | contact_email           | company_number | state    | categories |
-      | member-all-reqs-met@example.com                 | emma-member@bowsers.com | 2120000142     | accepted | Grooming   |
-      | member-in-grace-period-all-reqs-met@example.com | lars-member@bowsers.com | 2120000142     | accepted | Grooming   |
+      | user_email                                      | contact_email                    | company_number | state    | categories |
+      | member-all-reqs-met@example.com                 | emma-member@bowsers.com          | 2120000142     | accepted | Grooming   |
+      | member-in-grace-period-all-reqs-met@example.com | lars-member@bowsers.com          | 2120000142     | accepted | Grooming   |
+      | member-agreed-before-current-start@example.com  | member-agreed-before@bowsers.com | 2120000142     | accepted | Grooming   |
 
 
     And the following payments exist
@@ -48,24 +48,33 @@ Feature: Member renews their membership
       | member-all-reqs-met@example.com                 | 2018-01-1  | 2018-12-31  | member_fee   | betald | none    |                |
       | member-all-reqs-met@example.com                 | 2018-01-1  | 2018-12-31  | branding_fee | betald | none    | 2120000142     |
       | member-in-grace-period-all-reqs-met@example.com | 2018-01-1  | 2018-12-31  | member_fee   | betald | none    |                |
+      | member-agreed-before-current-start@example.com  | 2018-01-1  | 2018-12-31  | member_fee   | betald | none    |                |
 
 
     And these files have been uploaded:
       | user_email                                      | file name | description                               |
       | member-all-reqs-met@example.com                 | image.png | Image of a class completion certification |
       | member-in-grace-period-all-reqs-met@example.com | image.png | Image of a class completion certification |
+      | member-agreed-before-current-start@example.com  | image.png | Image of a class completion certification |
 
 
     And the following memberships exist:
       | email                                           | first_day | last_day   |
       | member-all-reqs-met@example.com                 | 2018-01-1 | 2018-12-31 |
       | member-in-grace-period-all-reqs-met@example.com | 2018-01-1 | 2018-12-31 |
+      | member-agreed-before-current-start@example.com  | 2018-01-1 | 2018-12-31 |
 
+
+    And the following users have agreed to the Membership Ethical Guidelines:
+      | email                                           | date agreed to |
+      | member-all-reqs-met@example.com                 |                |
+      | member-in-grace-period-all-reqs-met@example.com |                |
+      | member-agreed-before-current-start@example.com  | 2017-12-31     |
 
     # ---------------------------------------------------------------------------------------------
 
 
-  Scenario Outline: Renews on days around expiration
+  Scenario Outline: Renews on days around expiration (all requirements met)
     Given the date is set to "<the_date>"
     And I am logged in as "member-all-reqs-met@example.com"
     And I am on the "user account" page
@@ -96,3 +105,13 @@ Feature: Member renews their membership
     And I complete the membership payment
     Then I should see t("payments.success.success")
     And the user is paid through "2020-01-04"
+
+
+  Scenario: Must agree to Ethical Guidelines again: last agreed to them 1 day before start of current membership term
+    Given the date is set to "2019-01-05"
+    And I am logged in as "member-agreed-before-current-start@example.com"
+    And I am on the "user account" page
+    Then I should see t("users.renewal.title_renewal_overdue")
+    And I should see t("users.renewal.renewal_overdue_warning")
+    And I should see t("users.ethical_guidelines_link_or_checklist.agree_to_guidelines")
+    And the link button t("users.show.pay_membership") should be disabled

--- a/features/step_definitions/user_checklist_steps.rb
+++ b/features/step_definitions/user_checklist_steps.rb
@@ -220,12 +220,8 @@ end
 # Set all of the Membership Guidelines user checklists to completed for the current user
 # Create the Membership Guidelines user checklist(s) for the user if needed
 And ("I have agreed to all of the Membership Guidelines") do
-  user_guidelines = if (found_guidelines = UserChecklistManager.membership_guidelines_list_for(@user))
-                      found_guidelines
-                    else
-                      AdminOnly::UserChecklistFactory.create_member_guidelines_checklist_for(@user) unless UserChecklistManager.membership_guidelines_list_for(@user)
-                    end
-  user_guidelines.set_complete_including_children
+  user_guidelines = UserChecklistManager.find_or_create_membership_guidelines_list_for(@user)
+  user_guidelines.set_complete_including_children(Date.current)
 end
 
 And("I should{negate} see {capture_string} as the guideline name to agree to") do | negate, guideline_name |

--- a/features/user_account/member-home-account-page.feature
+++ b/features/user_account/member-home-account-page.feature
@@ -58,6 +58,10 @@ Feature:  Member home (account) page
       | email                   | first_day | last_day   | notes |
       | emma-member@example.com | 2018-01-1 | 2018-12-31 |       |
 
+    And the following users have agreed to the Membership Ethical Guidelines:
+      | email                   | date agreed to |
+      | emma-member@example.com | 2018-01-1      |
+
     Given I am logged in as "emma-member@example.com"
     And I am on the "user account" page for "emma-member@example.com"
     Then I am a current member

--- a/features/user_account/member-renewal-due-home-account-page.feature
+++ b/features/user_account/member-renewal-due-home-account-page.feature
@@ -25,10 +25,10 @@ Feature:  Member home (account) page when renewal is due or close to it
       | admin@shf.se                           | true  |                   |                   |        |              |                          |
 
     And the following users have agreed to the Membership Ethical Guidelines:
-      | email                                  |
-      | member-all-reqs-met@example.com        |
-      | member-no-docs-uploaded@example.com    |
-      | member-lapsed-all-reqs-met@example.com |
+      | email                                  | agreed to date |
+      | member-all-reqs-met@example.com        |                |
+      | member-no-docs-uploaded@example.com    |                |
+      | member-lapsed-all-reqs-met@example.com | 2018-06-01     |
 
     And the following regions exist:
       | name      |

--- a/features/user_account/user-applicant-home-account-page.feature
+++ b/features/user_account/user-applicant-home-account-page.feature
@@ -62,6 +62,12 @@ Feature: Applicant home (account) page - version 1.0
       | user_email                        | start_date | expire_date | payment_type | status | hips_id |
       | app-guidelines-payment@random.com | 2020-02-02 | 2021-02-01  | member_fee   | betald | none    |
 
+    And the following users have agreed to the Membership Ethical Guidelines:
+      | email                      | date agreed to |
+      | guidelines-done@random.com | 2020-03-01     |
+      | app-guidelines@random.com  | 2020-03-01     |
+
+
   # ---------------------------------------------------------------------------------------------
 
   Scenario: After logging in, a newly registered user is taken to their account page
@@ -87,7 +93,6 @@ Feature: Applicant home (account) page - version 1.0
     And the link button t("users.show.pay_membership") should be disabled
 
 
-
   Scenario: App has been submitted (not reviewed yet) shows new status for the application
     Given I am logged in as "submitted-app@random.com"
     When I am on the "user account" page
@@ -104,7 +109,6 @@ Feature: Applicant home (account) page - version 1.0
     And I should see t("users.show_for_applicant.app_status_accepted")
     And I should see t("users.ethical_guidelines_link_or_checklist.agree_to_guidelines")
     And the link button t("users.show.pay_membership") should be disabled
-
 
 
   Scenario: App has been rejected
@@ -155,7 +159,7 @@ Feature: Applicant home (account) page - version 1.0
     Given I am logged in as "guidelines-done@random.com"
     When I am on the "user account" page
     Then I should see t("users.show_for_applicant.apply_4_membership") link
-    And I should see t("users.ethical_guidelines_link_or_checklist.agreed_to")
+    And I should see t("users.ethical_guidelines_link_or_checklist.agreed_to", date: '2020-03-01')
     And the link button t("users.show.pay_membership") should be disabled
 
 
@@ -163,7 +167,7 @@ Feature: Applicant home (account) page - version 1.0
     Given I am logged in as "app-guidelines@random.com"
     When I am on the "user account" page
     Then I should see t("users.show_for_applicant.app_status_accepted")
-    And I should see t("users.ethical_guidelines_link_or_checklist.agreed_to")
+    And I should see t("users.ethical_guidelines_link_or_checklist.agreed_to", date: '2020-03-01')
     And I should see t("users.show.pay_membership") link
 
 

--- a/spec/models/memberships_manager_spec.rb
+++ b/spec/models/memberships_manager_spec.rb
@@ -69,7 +69,8 @@ RSpec.describe MembershipsManager, type: :model do
   end
 
 
-  describe 'most_recent_membership' do
+
+  describe '.most_recent_membership' do
     let(:membership_ending_2021_12_31) {  build(:membership, last_day: Date.new(2021, 12, 31)) }
 
     before(:each) do
@@ -80,24 +81,33 @@ RSpec.describe MembershipsManager, type: :model do
 
     it "gets the user's memberships" do
       expect(user).to receive(:memberships).and_return(mock_memberships)
-      subject.most_recent_membership(user)
+      described_class.most_recent_membership(user)
     end
 
     it 'returns nil if there are no memberships for the user' do
       allow(mock_memberships).to receive(:empty?).and_return(true)
-      expect(subject.most_recent_membership(user)).to be_nil
+      expect(described_class.most_recent_membership(user)).to be_nil
     end
 
     it 'sorts them with the most_recent_membership method' do
-      allow(subject).to receive(:most_recent_membership_method)
+      allow(described_class).to receive(:most_recent_membership_method)
                           .and_return(:some_method)
       expect(mock_memberships).to receive(:order).with(:some_method)
-      subject.most_recent_membership(user)
+      described_class.most_recent_membership(user)
     end
 
     it 'returns the last one' do
       expect(mock_memberships).to receive(:last).and_return(membership_ending_2021_12_31)
-      expect(subject.most_recent_membership(user)).to eq membership_ending_2021_12_31
+      expect(described_class.most_recent_membership(user)).to eq membership_ending_2021_12_31
+    end
+  end
+
+
+  describe 'most_recent_membership' do
+    it 'calls the class method' do
+      u = build(:user)
+      expect(described_class).to receive(:most_recent_membership).with(u)
+      subject.most_recent_membership(u)
     end
   end
 

--- a/spec/models/reqs_updaters/abstract_reqs_for_membership_spec.rb
+++ b/spec/models/reqs_updaters/abstract_reqs_for_membership_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe AbstractReqsForMembership, type: :model do
   let(:subject) { AbstractReqsForMembership }
   let(:user) { build(:user) }
   let(:yesterday) { Date.current - 1.day }
-  let(:jan_1) { Date.new(2017,1,1) }
+  let(:jan_1) { Date.new(2017, 1, 1) }
 
   describe '.has_expected_arguments?' do
 
@@ -32,17 +32,16 @@ RSpec.describe AbstractReqsForMembership, type: :model do
   describe '.requirements_excluding_payments_met?' do
 
     it 'subclasses must define this; raises NoMethodError' do
-      expect{subject.requirements_excluding_payments_met?({})}.to raise_error NoMethodError
+      expect { subject.requirements_excluding_payments_met?({ }) }.to raise_error NoMethodError
     end
   end
-
 
   describe '.requirements_met?' do
 
     it 'for a specific date: passes that date to the methods called' do
       expect(subject).to receive(:requirements_excluding_payments_met?)
-                            .with(user, yesterday)
-                            .and_return(true)
+                           .with(user, yesterday)
+                           .and_return(true)
       expect(subject).to receive(:payment_requirements_met?)
                            .with(user, yesterday)
                            .and_return(true)
@@ -58,7 +57,6 @@ RSpec.describe AbstractReqsForMembership, type: :model do
     end
   end
 
-
   describe '.payment_requirements_met?' do
 
     it 'result = user.payments_current_as_of?' do
@@ -73,14 +71,13 @@ RSpec.describe AbstractReqsForMembership, type: :model do
     it 'for a specific date: it passes that date to payments_current_as_of?' do
       u = build(:user)
       expect(u).to receive(:payments_current_as_of?)
-                   .with(yesterday).and_return(true)
+                     .with(yesterday).and_return(true)
       expect(subject.payment_requirements_met?(u, yesterday)).to be_truthy
       expect(u).to receive(:payments_current_as_of?)
-                   .with(yesterday).and_return(false)
+                     .with(yesterday).and_return(false)
       expect(subject.payment_requirements_met?(u, yesterday)).to be_falsey
     end
   end
-
 
   describe '.membership_guidelines_checklist_done?' do
     it 'calls UserChecklistManager to see if the user has completed the Ethical guidelines checklist' do
@@ -89,6 +86,4 @@ RSpec.describe AbstractReqsForMembership, type: :model do
       subject.membership_guidelines_checklist_done?(user)
     end
   end
-
-
 end

--- a/spec/models/user_checklist_manager_spec.rb
+++ b/spec/models/user_checklist_manager_spec.rb
@@ -393,7 +393,6 @@ RSpec.describe UserChecklistManager do
           expect(described_class.checklist_done_on_or_after_latest_membership_start?(u)).to be_truthy
         end
       end
-   end
-
+    end
   end
 end

--- a/spec/models/user_checklist_manager_spec.rb
+++ b/spec/models/user_checklist_manager_spec.rb
@@ -16,40 +16,32 @@ RSpec.describe UserChecklistManager do
   let(:guideline_list_type) { create(:master_checklist_type, name: membership_guidelines_type_name) }
   let(:guideline_master) { create(:master_checklist, master_checklist_type: guideline_list_type) }
 
-
-
-  describe '.first_incomplete_membership_guideline_section_for' do
-
-    it 'nil if all are completed' do
-      user_all_completed =  build(:user, first_name: 'AllCompleted')
-      user_checklist = create(:user_checklist,  user: user_all_completed,
-                              master_checklist: guideline_master,
-                              num_completed_children: 2)
-      allow(AdminOnly::UserChecklistFactory).to receive(:create_member_guidelines_checklist_for)
-                                                  .with(user_all_completed)
-                                                  .and_return(user_checklist)
-      expect(described_class.first_incomplete_membership_guideline_section_for(user_all_completed)).to be_nil
-    end
-
-    it 'first completed guideline (based on the list position) of the membership guidelines' do
-      user_some_completed =  build(:user, first_name: 'SomeCompleted')
-      user_checklist = create(:user_checklist,  user: user_some_completed,
-                              master_checklist: guideline_master,
-                              num_children: 3,
-                              num_completed_children: 2)
-      allow(AdminOnly::UserChecklistFactory).to receive(:create_member_guidelines_checklist_for)
-                                                  .with(user_some_completed)
-                                                  .and_return(user_checklist)
-      allow(described_class).to receive(:membership_guidelines_list_for)
-                                  .with(user_some_completed)
-                                  .and_return(user_checklist)
-      result = described_class.first_incomplete_membership_guideline_section_for(user_some_completed)
-      expect(result.completed?).to be_falsey
-    end
-  end
+  let(:u) { build(:user) }
+  let(:yesterday) { Date.current - 1 }
+  let(:completion_date_20200102) { Date.new(2020, 1, 2) }
 
 
   describe '.completed_membership_guidelines_checklist?' do
+
+    context 'user is in the grace period'  do
+      it 'checklist must be completed after the last membership started (so can renew)' do
+        grace_user = build(:user)
+        allow(grace_user).to receive(:in_grace_period?).and_return(true)
+        expect(described_class).to receive(:find_on_or_after_latest_membership_start)
+                                     .with(grace_user)
+        described_class.completed_membership_guidelines_checklist?(grace_user)
+      end
+    end
+
+    context 'user is not in the grace period' do
+      it 'the latest checklist must be completed' do
+        not_in_grace_user = build(:user)
+        allow(not_in_grace_user).to receive(:in_grace_period?).and_return(false)
+        expect(described_class).to receive(:membership_guidelines_list_for)
+                                     .with(not_in_grace_user)
+        described_class.completed_membership_guidelines_checklist?(not_in_grace_user)
+      end
+    end
 
     it 'returns false if there are no lists for the user' do
       allow(AdminOnly::MasterChecklist).to receive(:latest_membership_guideline_master)
@@ -65,6 +57,126 @@ RSpec.describe UserChecklistManager do
       expect(checklist).to receive(:all_completed?)
 
       described_class.completed_membership_guidelines_checklist?(user_for_checklist)
+    end
+  end
+
+
+  describe '.find_or_create_on_or_after_latest_membership_start' do
+    let(:latest_membership) { build(:membership, user: user, first_day: yesterday) }
+
+    let(:most_recent_checklist) { build(:user_checklist, :completed, user: user,
+                                        date_completed: completion_date_20200102) }
+
+    it 'gets the most recent membership for the user' do
+      allow(described_class).to receive(:create_for_user_if_needed)
+      expect(MembershipsManager).to receive(:most_recent_membership)
+                                      .with(u)
+                                      .and_return(nil)
+      described_class.find_or_create_on_or_after_latest_membership_start(u)
+    end
+
+    it 'creates Membership guideline checklists for the user if there is no recent membership' do
+      allow(MembershipsManager).to receive(:most_recent_membership)
+                                      .with(u)
+                                      .and_return(nil)
+
+      expect(described_class).to receive(:create_for_user_if_needed)
+                                   .with(u)
+      described_class.find_or_create_on_or_after_latest_membership_start(u)
+    end
+
+    context 'there is a recent membershp' do
+      before(:each) do
+        allow(MembershipsManager).to receive(:most_recent_membership)
+                                       .with(u)
+                                       .and_return(latest_membership)
+      end
+
+      it "gets the user's guideline checklists created on or after the first day of the user's latest membership" do
+        top_level_checklists = double("UserChecklist::ActiveRecord_Relation")
+        allow(top_level_checklists).to receive(:uncompleted).and_return([])
+        allow(described_class).to receive(:create_for_user_if_needed)
+        expect(UserChecklist).to receive(:most_recently_created_top_level_guidelines)
+                                   .with(u, latest_membership.first_day)
+                                   .and_return(top_level_checklists)
+        described_class.find_or_create_on_or_after_latest_membership_start(u)
+      end
+
+      context 'no incomplete guideline checklists created on or after the first day of the latest membership' do
+        before(:each) do
+          top_level_checklists = double("UserChecklist::ActiveRecord_Relation")
+          allow(top_level_checklists).to receive(:uncompleted).and_return([])
+        end
+
+        it 'calls create for user if needed with the user and a nil guideline' do
+          expect(described_class).to receive(:create_for_user_if_needed).with(u, guideline: nil)
+          described_class.find_or_create_on_or_after_latest_membership_start(u)
+        end
+      end
+
+      context 'there are incomplete checklists created on or after the first day of the latest membership' do
+        before(:each) do
+          top_level_checklists = double("UserChecklist::ActiveRecord_Relation")
+          allow(UserChecklist).to receive(:most_recently_created_top_level_guidelines)
+                                    .and_return(top_level_checklists)
+          allow(top_level_checklists).to receive(:uncompleted).and_return([most_recent_checklist])
+        end
+
+        it 'calls create for user if needed with the user and the latest found guideline checklist' do
+          expect(described_class).to receive(:create_for_user_if_needed).with(u, guideline: most_recent_checklist)
+          described_class.find_or_create_on_or_after_latest_membership_start(u)
+        end
+      end
+    end
+  end
+
+
+  describe '.first_incomplete_membership_guideline_section_for' do
+
+    it 'nil if all are completed' do
+      user_all_completed = build(:user, first_name: 'AllCompleted')
+      user_checklist = create(:user_checklist, user: user_all_completed,
+                              master_checklist: guideline_master,
+                              num_completed_children: 2)
+      allow(AdminOnly::UserChecklistFactory).to receive(:create_member_guidelines_checklist_for)
+                                                  .with(user_all_completed)
+                                                  .and_return(user_checklist)
+      expect(described_class.first_incomplete_membership_guideline_section_for(user_all_completed)).to be_nil
+    end
+
+    it 'first completed guideline (based on the list position) of the membership guidelines' do
+      user_some_completed = build(:user, first_name: 'SomeCompleted')
+      user_checklist = create(:user_checklist, user: user_some_completed,
+                              master_checklist: guideline_master,
+                              num_children: 3,
+                              num_completed_children: 2)
+      allow(AdminOnly::UserChecklistFactory).to receive(:create_member_guidelines_checklist_for)
+                                                  .with(user_some_completed)
+                                                  .and_return(user_checklist)
+      allow(described_class).to receive(:membership_guidelines_list_for)
+                                  .with(user_some_completed)
+                                  .and_return(user_checklist)
+      result = described_class.first_incomplete_membership_guideline_section_for(user_some_completed)
+      expect(result.completed?).to be_falsey
+    end
+  end
+
+
+  describe 'create_for_user_if_needed' do
+
+    it 'default guideline is nil' do
+      expect(described_class).to receive(:create_for_user).with(u)
+      described_class.create_for_user_if_needed(u)
+    end
+
+    it 'creates a new set of checklists for the user if the guideline is nil' do
+      expect(described_class).to receive(:create_for_user).with(u)
+      described_class.create_for_user_if_needed(u, guideline: nil)
+    end
+
+    it 'returns the given guideline if guideline is not nil' do
+      expect(described_class).not_to receive(:create_for_user)
+      described_class.create_for_user_if_needed(u, guideline: 'blorf')
     end
   end
 
@@ -92,7 +204,6 @@ RSpec.describe UserChecklistManager do
 
   end
 
-
   describe '.completed_guidelines_for' do
 
     it 'empty list if  there is no list for the user' do
@@ -104,13 +215,13 @@ RSpec.describe UserChecklistManager do
       it 'empty list' do
         num_completed = 0
         user_none_completed = build(:user)
-        user_checklist = create(:user_checklist,  user: user_none_completed,
+        user_checklist = create(:user_checklist, user: user_none_completed,
                                 master_checklist: guideline_master,
                                 num_children: 2,
                                 num_completed_children: num_completed)
         allow(AdminOnly::UserChecklistFactory).to receive(:create_member_guidelines_checklist_for)
-                                                     .with(user_none_completed)
-                                                     .and_return(user_checklist)
+                                                    .with(user_none_completed)
+                                                    .and_return(user_checklist)
 
         expect(described_class.completed_guidelines_for(user_none_completed)).to be_empty
       end
@@ -121,9 +232,9 @@ RSpec.describe UserChecklistManager do
         num_completed = 1
         user_some_completed = build(:user, first_name: 'SomeCompleted')
         user_checklist = create(:user_checklist, user: user_some_completed,
-               master_checklist: guideline_master,
-               num_children: 3,
-               num_completed_children: num_completed)
+                                master_checklist: guideline_master,
+                                num_children: 3,
+                                num_completed_children: num_completed)
         allow(AdminOnly::UserChecklistFactory).to receive(:create_member_guidelines_checklist_for)
                                                     .with(user_some_completed)
                                                     .and_return(user_checklist)
@@ -134,7 +245,7 @@ RSpec.describe UserChecklistManager do
     context 'all guidelines completed' do
       it 'list all the guidelines' do
         num_completed = 2
-        user_all_completed =  build(:user, first_name: 'AllCompleted')
+        user_all_completed = build(:user, first_name: 'AllCompleted')
         user_checklist = create(:user_checklist, :completed,
                                 user: user_all_completed,
                                 master_checklist: guideline_master,
@@ -148,7 +259,6 @@ RSpec.describe UserChecklistManager do
       end
     end
   end
-
 
   describe '.not_completed_guidelines_for' do
 
@@ -201,7 +311,7 @@ RSpec.describe UserChecklistManager do
     context 'all guidelines are completed' do
       it 'is empty' do
         num_completed = 2
-        user_all_completed =  build(:user, first_name: 'AllCompleted')
+        user_all_completed = build(:user, first_name: 'AllCompleted')
         user_checklist = create(:user_checklist, :completed,
                                 user: user_all_completed,
                                 master_checklist: guideline_master,
@@ -216,4 +326,74 @@ RSpec.describe UserChecklistManager do
     end
   end
 
+  describe '.checklist_done_on_or_after_latest_membership_start?' do
+    let(:latest_membership) { build(:membership, user: user, first_day: yesterday) }
+
+    let(:most_recent_checklist) { build(:user_checklist, :completed, user: user,
+                                        date_completed: completion_date_20200102) }
+
+    it 'false if there is no recent membership for the user' do
+      expect(MembershipsManager).to receive(:most_recent_membership)
+                                      .with(u)
+                                      .and_return(nil)
+      expect(described_class.checklist_done_on_or_after_latest_membership_start?(u)).to be_falsey
+    end
+
+    context 'there is a recent membership for the user' do
+      before(:each) do
+        allow(MembershipsManager).to receive(:most_recent_membership)
+                                       .with(u)
+                                       .and_return(latest_membership)
+      end
+
+      it "gets the first day for the user's latest membership" do
+        allow(UserChecklist).to receive(:most_recent_completed_top_level_guideline)
+                                  .with(u)
+                                  .and_return(most_recent_checklist)
+
+        expect(latest_membership).to receive(:first_day).and_return(yesterday)
+        described_class.checklist_done_on_or_after_latest_membership_start?(u)
+      end
+
+      it 'false if there is no recently completed guidelines checklist for the user' do
+        allow(UserChecklist).to receive(:most_recent_completed_top_level_guideline)
+                                  .with(u)
+                                  .and_return(nil)
+
+        expect(described_class.checklist_done_on_or_after_latest_membership_start?(u)).to be_falsey
+      end
+
+      context 'there is a most recently completed guidelines checklist for the user' do
+        before(:each) do
+          allow(UserChecklist).to receive(:most_recent_completed_top_level_guideline)
+                                    .with(u)
+                                    .and_return(most_recent_checklist)
+        end
+
+        it 'gets the date the most recently completed checklist was completed' do
+          expect(most_recent_checklist).to receive(:date_completed).and_return(yesterday)
+          described_class.checklist_done_on_or_after_latest_membership_start?(u)
+        end
+
+        it 'false if the checklist was completed before the first day of the recent membership' do
+          allow(latest_membership).to receive(:first_day).and_return(yesterday)
+          allow(most_recent_checklist).to receive(:date_completed).and_return(yesterday - 1)
+          expect(described_class.checklist_done_on_or_after_latest_membership_start?(u)).to be_falsey
+        end
+
+        it 'true if the checklist was completed on the first day of the recent membership' do
+          allow(latest_membership).to receive(:first_day).and_return(yesterday)
+          allow(most_recent_checklist).to receive(:date_completed).and_return(yesterday)
+          expect(described_class.checklist_done_on_or_after_latest_membership_start?(u)).to be_truthy
+        end
+
+        it 'true if the checklist was completed after the first day of the recent membership' do
+          allow(latest_membership).to receive(:first_day).and_return(yesterday)
+          allow(most_recent_checklist).to receive(:date_completed).and_return(yesterday + 1)
+          expect(described_class.checklist_done_on_or_after_latest_membership_start?(u)).to be_truthy
+        end
+      end
+   end
+
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe User, type: :model do
         it 'creates a membership with last day = expiration date' do
           expiry = Date.current + 100
           new_member = create(:member_with_expiration_date, expiration_date: expiry)
-          expect(MembershipsManager.new.most_recent_membership(new_member).last_day).to eq(expiry)
+          expect(MembershipsManager.most_recent_membership(new_member).last_day).to eq(expiry)
         end
 
         it 'sets membership status to current_member if the member has a Membership that covers Date.current' do


### PR DESCRIPTION
## PT Story:  Renewals must also agree to Ethical Guidelines
#### PT URL: https://www.pivotaltracker.com/story/show/172131253

We thought that renewals would only happen if a member had agreed to the guidelines on or after the first day of the most recent membership.  We were wrong.

---
## Ready for review:
@
