### PR TITLE
Former members must always complete ethical guidelines checklist

### DIFF
--- a/app/models/user_checklist_manager.rb
+++ b/app/models/user_checklist_manager.rb
@@ -15,9 +15,12 @@
 
 class UserChecklistManager
 
+  # former members MUST complete the guidelines again. (They have not completed the current version)
   def self.completed_membership_guidelines_checklist?(user)
-    if user.in_grace_period? || user.former_member?
+    if user.in_grace_period?
       find_on_or_after_latest_membership_start(user)&.all_completed?
+    elsif user.former_member?
+      false
     else
       membership_guidelines_list_for(user)&.all_completed?
     end

--- a/app/views/users/_ethical_guidelines_link_or_checklist.html.haml
+++ b/app/views/users/_ethical_guidelines_link_or_checklist.html.haml
@@ -14,6 +14,7 @@
 - else
   - user_checklist = UserChecklistManager.send(find_or_create, user).root
   - first_incomplete = UserChecklistManager.first_incomplete_membership_guideline_section_for(user)
+
   = link_to t('users.ethical_guidelines_link_or_checklist.agree_to_guidelines'), user_user_checklist_progress_path(user, first_incomplete), class: 'btn btn-sm btn-primary'
 
   - progress_percent = user_checklist.percent_complete

--- a/app/views/users/_show_for_applicant.html.haml
+++ b/app/views/users/_show_for_applicant.html.haml
@@ -28,13 +28,12 @@
             %p
               %strong.step-info= t(".#{t_key}")
 
-
           - else
             = link_to t('.apply_4_membership'), new_shf_application_path, class: 'btn btn-primary btn-sm'
 
-
+        - find_or_create_checklist = user.former_member? ? :find_or_create_on_or_after_latest_membership_start : :find_or_create_membership_guidelines_list_for
         %li.step.membership-ethical-guidelines= render partial: 'ethical_guidelines_link_or_checklist.html.haml',
-          locals: { user: user, find_or_create_method: :find_or_create_membership_guidelines_list_for }
+          locals: { user: user, find_or_create_method: find_or_create_checklist }
 
         %li.step.pay-membership-fee
           - if user.allowed_to_pay_member_fee?

--- a/features/membership_status/member-status-change.feature
+++ b/features/membership_status/member-status-change.feature
@@ -17,11 +17,11 @@ Feature: Membership status updated due to payments or expiration
     And the Membership Ethical Guidelines Master Checklist exists
 
     Given the following users exist
-      | email                             | admin | membership_status | member | membership_number | agreed_to_membership_guidelines |
-      | emma@mutts.com                    |       | current_member    | true   | 1001              | true                            |
-      | bob-former-member@snarkybarky.com |       | former_member     | true   | 1002              | true                            |
-      | lars@newapp.com                   |       | not_a_member      | false  |                   | true                            |
-      | admin@shf.se                      | true  |                   | false  |                   |                                 |
+      | email                             | admin | membership_status | member | membership_number |
+      | emma@mutts.com                    |       | current_member    | true   | 1001              |
+      | bob-former-member@snarkybarky.com |       | former_member     | true   | 1002              |
+      | lars@newapp.com                   |       | not_a_member      | false  |                   |
+      | admin@shf.se                      | true  |                   | false  |                   |
 
     Given the following companies exist:
       | name                 | company_number | email                  | region    |
@@ -55,6 +55,11 @@ Feature: Membership status updated due to payments or expiration
       | user_email     | file name | description                               |
       | emma@mutts.com | image.png | Image of a class completion certification |
 
+    And the following users have agreed to the Membership Ethical Guidelines:
+      | email                             | date agreed to |
+      | emma@mutts.com                    | 2017-12-31     |
+      | bob-former-member@snarkybarky.com | 2018-02-27     |
+
 
 
   # TODO should these be put into already existing .feature files?
@@ -67,6 +72,7 @@ Feature: Membership status updated due to payments or expiration
     And I am logged in as "emma@mutts.com"
     When I am on the "user details" page for "emma@mutts.com"
     Then I should see "1001"
+    And my membership expiration date should be 2018-12-31
     When I click on t("menus.nav.members.pay_membership")
     And I complete the membership payment
     Then I should see t("payments.success.success")
@@ -117,17 +123,12 @@ Feature: Membership status updated due to payments or expiration
 
 
   @time_adjust
-  Scenario: Membership payment after grace period (after expiration)
+  Scenario: Cannot pay membership fee after grace period (is now a former member)
     Given the date is set to "2021-01-01"
     And I am logged in as "bob-former-member@snarkybarky.com"
-    And I am on the "user details" page for "bob-former-member@snarkybarky.com"
+    And I am on the "user account" page for "bob-former-member@snarkybarky.com"
     And I am not a member
-    When I click on t("menus.nav.members.pay_membership")
-    And I complete the membership payment
-    Then I should see t("payments.success.success")
-    And I should be a member
-    And my membership expiration date should be 2021-12-31
-    And I should see "2021-12-31"
+    Then the link button t("users.show.pay_membership") should be disabled
 
 
   # H-BRANDING (LICENSE) PAYMENT

--- a/features/payments_and_member_status/member_pays_membership_fee.feature
+++ b/features/payments_and_member_status/member_pays_membership_fee.feature
@@ -47,7 +47,7 @@ Feature: Member pays membership fee
 
 
   @time_adjust
-  Scenario: Member pays membership fee after term expires (after prior payment expiration date)
+  Scenario: Member pays membership fee after term expires (in grace pd)
     Given the date is set to "2019-01-02"
     And I am logged in as "emma@mutts.com"
     And I have met all the non-payment requirements for renewing my membership
@@ -68,12 +68,7 @@ Feature: Member pays membership fee
     And I have met all the non-payment requirements for membership
     When I am on the "user account" page
     Then I should see "2018-12-31"
-    When I click on t("menus.nav.members.pay_membership")
-    And I complete the membership payment
-    Then I should see t("payments.success.success")
-    And I should be a current member
-    And my membership expiration date should be 2019-12-31
-    #And I should see t("payors.paying_now_extends_until", fee_name: 'membership fee', term_name: 'membership', extended_end_date: '2019-12-31')
+    Then the link button t("users.show.pay_membership") should not be disabled
 
 
   @selenium

--- a/features/user_account/member-home-account-page.feature
+++ b/features/user_account/member-home-account-page.feature
@@ -96,7 +96,7 @@ Feature:  Member home (account) page
     And I should see t("users.show.is_a_member")
     And I should see t("users.show.membership_term_last_day")
     And the user is paid through "2018-12-31"
-#   TODO And user membership last day is "2018-12-31"
+    And the last day of membership for "emma-member@example.com" should be 2018-12-31
 
 
   # =======================

--- a/features/user_account/user-former-member-home-account-page.feature
+++ b/features/user_account/user-former-member-home-account-page.feature
@@ -1,0 +1,81 @@
+Feature: Former Member home (account) page - version 1.0
+
+  As a former member,
+  my account page needs provide me with the clear ways to complete each step needed for membership:
+  1. This will show my previous application (because we currently allow only 1 application per user)
+  2. I must agree to the ethical guidelines,
+  4. any other requirements
+  5. pay my membership fee once all other requirements are satisfied
+
+
+  Background:
+
+    Given the date is set to "2018-01-01"
+    Given the App Configuration is not mocked and is seeded
+    And the Membership Ethical Guidelines Master Checklist exists
+
+    Given the following users exist:
+      | email                     | admin | membership_status | membership_number | member | first_name | last_name |
+      | former-member@example.com |       | former_member      | 1001              | true   | Former     | Member    |
+      | admin@shf.se              | true  |                   |                   |        |            |           |
+
+    And the following users have agreed to the Membership Ethical Guidelines:
+      | email                     |
+      | former-member@example.com |
+
+    And the following regions exist:
+      | name      |
+      | Stockholm |
+
+    And the following companies exist:
+      | name    | company_number | email            | region    |
+      | Bowsers | 2120000142     | bark@bowsers.com | Stockholm |
+
+
+    And the following business categories exist
+      | name     | description   |
+      | Grooming | grooming dogs |
+
+
+    And the following applications exist:
+      | user_email                | contact_email             | company_number | state    | categories |
+      | former-member@example.com | former-member@bowsers.com | 2120000142     | accepted | Grooming   |
+
+
+    And the following payments exist
+      | user_email                | start_date | expire_date | payment_type | status | hips_id | company_number |
+      | former-member@example.com | 2018-01-1  | 2018-12-31  | member_fee   | betald | none    |                |
+      | former-member@example.com | 2018-01-1  | 2018-12-31  | branding_fee | betald | none    | 2120000142     |
+
+
+    And the following memberships exist
+      | email                     | first_day | last_day   | notes |
+      | former-member@example.com | 2018-01-1 | 2018-12-31 |       |
+
+    And the following users have agreed to the Membership Ethical Guidelines:
+      | email                     | date agreed to |
+      | former-member@example.com | 2017-12-31     |
+
+
+    Given the date is set to "2021-07-07"
+
+  # ---------------------------------------------------------------------------------------------
+
+  Scenario: Former member sees greeting, name, welcome message, existing application, must agree to guidelines
+    Given I am logged in as "former-member@example.com"
+    And I am on the "user account" page for "former-member@example.com"
+    Then I am not a current member
+
+    And I should see t("users.show.hello")
+    And I should see "Former Member"
+    And I should see t("users.show_for_applicant.welcome")
+    And I should see t("users.show_for_applicant.welcome_want_to_have_benefits")
+
+    And I should not see t("users.show_for_applicant.apply_4_membership") link
+
+    And I should see t("application")
+    And I should see t("users.show_for_applicant.app_status_accepted")
+
+    And I should see t("users.ethical_guidelines_link_or_checklist.agree_to_guidelines")
+
+    And the link button t("users.show.pay_membership") should be disabled


### PR DESCRIPTION
## PT Story:  part of Renewals revision
#### PT URL: https://www.pivotaltracker.com/story/show/172131253


## Changes proposed in this pull request:
1.  former members must always complete the ethical guidelines checklist


---
## Ready for review:
@
