### PR TITLE
BUG: Validate user email format, validate email in browser (use HTML5)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,6 +58,8 @@ class User < ApplicationRecord
 
   validates :first_name, :last_name, presence: true, unless: :updating_without_name_changes
   validates :membership_number, uniqueness: true, allow_blank: true
+  validates :email, email: true
+
 
   THIS_PAYMENT_TYPE = Payment::PAYMENT_TYPE_MEMBER
   MOST_RECENT_UPLOAD_METHOD = :created_at

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -6,7 +6,6 @@ class EmailValidator < ActiveModel::EachValidator
   # mailto: a URI and so does not allow characters that an email address does.
 
   def validate_each(object, attribute, value)
-
     if value.to_s !~ URI::MailTo::EMAIL_REGEXP
       object.errors[attribute] << "#{I18n.t('errors.messages.invalid')}: #{value}"
     end

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,8 +1,14 @@
 class EmailValidator < ActiveModel::EachValidator
+  # OLD_EMAIL_REGEXP = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+  # OLD_EMAIL_REGEXP is generally ok, but does not allow domain names without a '.' -- which _are_ technically correct, even if unusual.
+  #   That regexp also did not enforce other restrictions that it should have.
+  # Note that the URI::MailTo::EMAIL_REGEXP is based on RFC 2368 and slightly more restrictive than RFC 5322.
+  # mailto: a URI and so does not allow characters that an email address does.
+
   def validate_each(object, attribute, value)
 
-    unless value.to_s =~ URI::MailTo::EMAIL_REGEXP
-      object.errors[attribute] << I18n.t('errors.messages.invalid')
+    if value.to_s !~ URI::MailTo::EMAIL_REGEXP
+      object.errors[attribute] << "#{I18n.t('errors.messages.invalid')}: #{value}"
     end
   end
 end

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,7 +1,7 @@
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
 
-    unless value.to_s =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+    unless value.to_s =~ URI::MailTo::EMAIL_REGEXP
       object.errors[attribute] << I18n.t('errors.messages.invalid')
     end
   end

--- a/app/views/companies/_company_create_modal.html.haml
+++ b/app/views/companies/_company_create_modal.html.haml
@@ -36,7 +36,7 @@
 
                 .col
 
-                  = f.text_field :email, class: 'form-control', size: 30
+                  = f.email_field :email, class: 'form-control', size: 30
 
         .modal-footer
           = f.submit t('companies.create.create_submit'), class: "btn btn-primary form-control",

--- a/app/views/companies/_form.html.haml
+++ b/app/views/companies/_form.html.haml
@@ -31,7 +31,7 @@
         = f.text_field :phone_number,  class: 'form-control'
       .col.form-group
         = f.label :email, t('companies.show.email'), class: 'required'
-        = f.text_field :email,  class: 'form-control'
+        = f.email_field :email,  class: 'form-control'
     .row
       .col.form-group
         = f.label :website, t('companies.website_include_http')

--- a/db/seed_helpers/users_factory.rb
+++ b/db/seed_helpers/users_factory.rb
@@ -40,7 +40,7 @@ module SeedHelpers
     PAID_THRU_FNAME = 'PaidThrough'
 
     GRACEPERIODMEMBER_LNAME = 'InGracePeriod'
-    GRACEPERIODMEMEBER_FNAME_PREFIX = 'Försenad-Exp'
+    GRACEPERIODMEMEBER_FNAME_PREFIX = 'Forsenad-Exp'
 
     FORMERMEMBER_LNAME = 'FormerMember'
     FORMERMEMBER_FNAME_PREFIX = 'TidigareMedlem-Exp'
@@ -64,7 +64,7 @@ module SeedHelpers
     # --------------------------------------------------------------------------------------------
 
 
-    def initialize(static_data = SeedHelper::StaticDataFactory.new, log = nil)
+    def initialize(static_data = SeedHelpers::StaticDataFactory.new, log = nil)
       @static_data = static_data
       @log = log
       @shf_application_factory = ::SeedHelpers::ShfApplicationFactory.new(static_data, log)

--- a/features/companies/admin_creates_company.feature
+++ b/features/companies/admin_creates_company.feature
@@ -161,7 +161,7 @@ Feature: Admin can create a company
       | name        | org_number | phone      | email                | website                   | error                                                                   |
       | Happy Mutts | 00         | 0706898525 | kicki@gladajyckar.se | http://www.gladajyckar.se | t("errors.messages.wrong_length", count: 10)                            |
       | Happy Mutts | 5562252998 |            | kickiimmi.nu         | http://www.gladajyckar.se | t("errors.messages.invalid")                                            |
-      | Happy Mutts | 5562252998 |            | kicki@imminu         | http://www.gladajyckar.se | t("errors.messages.invalid")                                            |
+      | Happy Mutts | 5562252998 |            | kicki@.imminu         | http://www.gladajyckar.se | t("errors.messages.invalid")                                            |
       | Happy Mutts | 5560360793 | 0706898525 | kicki@imminu.se      | http://www.gladajyckar.se | t("activerecord.errors.models.company.attributes.company_number.taken") |
 
   @time_adjust
@@ -212,7 +212,7 @@ Feature: Admin can create a company
     Scenarios:
       | name        | org_number | phone | email        | website                   | model_attribute                            | error                        |
       | Happy Mutts | 5560360793 |       | kickiimmi.nu | http://www.gladajyckar.se | t("activerecord.attributes.company.email") | t("errors.messages.invalid") |
-      | Happy Mutts | 5560360793 |       | kicki@imminu | http://www.gladajyckar.se | t("activerecord.attributes.company.email") | t("errors.messages.invalid") |
+      | Happy Mutts | 5560360793 |       | kicki@.imminu | http://www.gladajyckar.se | t("activerecord.attributes.company.email") | t("errors.messages.invalid") |
 
 
   Scenario Outline: Admin edits a company: company number is wrong length

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -224,7 +224,6 @@ Feature: Create a new membership application
     And I select files delivery radio button "files_uploaded"
 
     When I click on t("shf_applications.new.submit_button_label")
-
     Then I should see error <model_attribute> <error>
     And I should receive no emails
     And "admin@shf.se" should receive no emails
@@ -234,8 +233,10 @@ Feature: Create a new membership application
       | c_email       | phone      | model_attribute                                                   | error                            |
       |               | 0706898525 | t("activerecord.attributes.shf_application.contact_email")        | t("errors.messages.blank")       |
       |               | 0706898525 | t("activerecord.attributes.shf_application.business_categories")  | t("errors.messages.blank")       |
-      | kicki@imminu  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")        | t("errors.messages.invalid")     |
-      # | kickiimmi.nu  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")        | t("errors.messages.invalid")     |
+
+# The following 2 scenarios cannot happen.  No submission will happen because javascript will not validate the contact email field (form field = f.email_field
+#      | kicki@.imminu  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")        | t("errors.messages.invalid")     |
+#      | kåt@voof.se  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")        | t("errors.messages.invalid")     |
 
   @selenium
   Scenario Outline: Apply for membership with uploads, errors should show please upload again message [SAD PATH]
@@ -301,26 +302,23 @@ Feature: Create a new membership application
     And I click on t("companies.create.create_submit")
     Then I should not see t("shf_applications.uploads.please_upload_again")
 
+
   @selenium
   Scenario Outline: Cannot change locale if there are errors in the new application
     Given I am on the "new application" page
 
     And I fill in the translated form with data:
       | shf_applications.new.contact_email | shf_applications.new.phone_number |
-      | <c_email>                          | <phone>                           |
+      | hello@voof.se                         | 0706898525                          |
 
     And I select files delivery radio button "files_uploaded"
 
     And I click on t("shf_applications.new.submit_button_label")
 
-    Then I should see error <model_attribute> <error>
+    Then I should see error t("activerecord.attributes.shf_application.companies") t("activerecord.errors.models.shf_application.attributes.companies.blank")
     And I should not see t("show_in_swedish") image
     And I should not see t("show_in_english") image
     And I should see t("cannot_change_language") image
-
-    Scenarios:
-      | c_email       | phone      | model_attribute                                             | error                            |
-      | kicki@imminu  | 0706898525 | t("activerecord.attributes.shf_application.contact_email")  | t("errors.messages.invalid")     |
 
 
   Scenario: A member with existing application cannot submit a new application

--- a/features/size_validation.feature
+++ b/features/size_validation.feature
@@ -9,7 +9,7 @@ Feature: Applicant uploads too large a file for their application
 
     Given the following users exist:
       | email                 | admin |
-      | hans@new_applicant.se |       |
+      | hans@new-applicant.se |       |
       | emma@happymutts.se    |       |
 
     And the following business categories exist
@@ -28,7 +28,7 @@ Feature: Applicant uploads too large a file for their application
 
   @selenium
   Scenario: New application - Uploads a file that is too large
-    Given I am logged in as "hans@new_applicant.se"
+    Given I am logged in as "hans@new-applicant.se"
     And I am on the "submit new membership application" page
 
     When I fill in the form with data:
@@ -44,7 +44,7 @@ Feature: Applicant uploads too large a file for their application
 
   @selenium
   Scenario: New application - Uploads a file that is too large then uploads ok file
-    Given I am logged in as "hans@new_applicant.se"
+    Given I am logged in as "hans@new-applicant.se"
     And I am on the "submit new membership application" page
 
     When I fill in the form with data:
@@ -64,7 +64,7 @@ Feature: Applicant uploads too large a file for their application
 
   @selenium
   Scenario: New application - Uploads a file just under the size limit
-    Given I am logged in as "hans@new_applicant.se"
+    Given I am logged in as "hans@new-applicant.se"
     And I am on the "submit new membership application" page
     When I fill in the form with data:
       | shf_application_company_number | shf_application_phone_number | shf_application_contact_email |

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -86,7 +86,7 @@ Capybara.register_driver :selenium_browser do |app|
       browser: :chrome
   )
 end
-# register this driver so that ShowMeTheCookies knows which adapater to use for it
+# register this driver so that ShowMeTheCookies knows which adapter to use for it
 #   have to use the same driver name (symbol)
 ShowMeTheCookies.register_adapter(:selenium_browser, ShowMeTheCookies::SeleniumChrome)
 

--- a/spec/models/shf_application_spec.rb
+++ b/spec/models/shf_application_spec.rb
@@ -93,7 +93,8 @@ RSpec.describe ShfApplication, type: :model do
     it { is_expected.to validate_presence_of(:file_delivery_method).on(:create) }
 
     it { is_expected.to allow_value('user@example.com').for(:contact_email) }
-    it { is_expected.not_to allow_value('userexample.com').for(:contact_email) }
+    it { is_expected.not_to allow_value('userexample@.com').for(:contact_email) }
+    it { is_expected.not_to allow_value('exåmple@example.com').for(:contact_email) }
 
     describe 'uniqueness of user across all applications' do
       subject { FactoryBot.build(:shf_application) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -183,6 +183,18 @@ RSpec.describe User, type: :model do
     it { is_expected.to(validate_presence_of :first_name) }
     it { is_expected.to(validate_presence_of :last_name) }
     it { is_expected.to validate_uniqueness_of :membership_number }
+
+    it 'email' do
+      u = build(:user)
+      expect(u).to allow_values('this@example.com', 'this_too@that.example.com',
+                          'and-this-1@example.com').for(:email)
+      expect(u).not_to allow_value(
+                              'no spaces?!? or punt,uation@example.com',
+                              'nö-äccæñts-or-ün-ascii-chars@example.com',
+                              '日本人@日人日本人@example.com'
+                            ).for(:email)
+    end
+
     it do
       is_expected.to validate_attachment_content_type(:member_photo)
                        .allowing('image/png', 'image/jpeg')
@@ -214,6 +226,7 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
 
   describe 'Associations' do
     it { is_expected.to have_many :uploaded_files }

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe EmailValidator do
       expect { some_model.valid? }
         .to change(some_model.errors, :messages)
               .from({})
-              .to a_hash_including(test_attr: [error_msg])
+              .to a_hash_including(test_attr: ["#{error_msg}: #{invalid_email}"])
     end
   end
 

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe EmailValidator do
   it_behaves_like 'invalid email adds to error messages', 'email.com'
   it_behaves_like 'invalid email adds to error messages', 'email@.com'
   it_behaves_like 'invalid email adds to error messages', 'no spaces@example.com'
-  it_behaves_like 'invalid email adds to error messages', 'nö-äccæñts-or-ün-ascii-chars@example.com'
+  it_behaves_like 'invalid email adds to error messages', 'nö-äccæñts-or-ün-åscii-charsåäöÅÄÖ@example.com'
   it_behaves_like 'invalid email adds to error messages', '日本人@日人日本人@example.com'
 
 

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -14,24 +14,29 @@ RSpec.describe EmailValidator do
     end
   end
 
-  it 'adds error message when email is invalid' do
-    record.test_attr = 'email.com'
-    expect { record.valid? }
-      .to change(record.errors, :messages).from({})
-      .to a_hash_including(test_attr: [error_msg])
+  shared_examples 'invalid email adds to error messages' do | invalid_email|
 
-    record.errors.clear
-    record.test_attr = 'email@.com'
-    expect { record.valid? }
-      .to change(record.errors, :messages).from({})
-      .to a_hash_including(test_attr: [error_msg])
+    it "#{invalid_email} adds to error messages" do
+      some_model = ValidatorHelper.test_model_class.new
+      some_model.class_eval do
+        validates :test_attr, email: true
+      end
 
-    record.errors.clear
-    record.test_attr = 'email.mail.com'
-    expect { record.valid? }
-      .to change(record.errors, :messages).from({})
-      .to a_hash_including(test_attr: [error_msg])
+      some_model.errors.clear
+      some_model.test_attr = invalid_email
+      expect { some_model.valid? }
+        .to change(some_model.errors, :messages)
+              .from({})
+              .to a_hash_including(test_attr: [error_msg])
+    end
   end
+
+  it_behaves_like 'invalid email adds to error messages', 'email.com'
+  it_behaves_like 'invalid email adds to error messages', 'email@.com'
+  it_behaves_like 'invalid email adds to error messages', 'no spaces@example.com'
+  it_behaves_like 'invalid email adds to error messages', 'nö-äccæñts-or-ün-ascii-chars@example.com'
+  it_behaves_like 'invalid email adds to error messages', '日本人@日人日本人@example.com'
+
 
   it 'does not add error message if email is valid' do
     record.test_attr = 'email@mail.com'


### PR DESCRIPTION
## PT Story:  validate user email format, use HTML5 to validate in browser
#### PT URL: https://www.pivotaltracker.com/story/show/178850811


## Changes proposed in this pull request:
1.  use `URI::MailTo::EMAIL_REGEXP` in EmailValidator
2.  set email form fields to `email_field` so that HTML5 validates the format in the browser
3.  seeding: do not use non-ASCII chars in email addresses
4. fix feature that used invalid email address (was never actually valid; we just didn't validate strictly enough)

---
## Ready for review:
@patmbolger 
