### PR TITLE
Feature:  Send/show links to Category questionnaires (for applicants)

### DIFF
--- a/app/assets/javascripts/shf_application.js
+++ b/app/assets/javascripts/shf_application.js
@@ -83,6 +83,6 @@ function enable_submit_button () {
 
 function remove_change_callback_for_radio_buttons (radio_buttons) {
   radio_buttons.each(function () {
-    $(this).off('change');
+    // $(this).off('change');
   });
 }

--- a/app/assets/stylesheets/shf-application-2.scss
+++ b/app/assets/stylesheets/shf-application-2.scss
@@ -11,6 +11,40 @@
   font-size: 16px;
 }
 
+
+.shfapplication {
+
+  .file-delivery-choices {
+
+    .file-delivery-selection {
+      //font-size: 1.2em;
+      //font-weight: bold;
+      //line-height: 2em;
+    }
+
+    .delivery-choice {
+      margin-left: 1em;
+
+      .form-check.form-check-inline {
+        margin-right: 2em;
+        margin-top: 0;
+
+        input {
+          margin-right: .25em;
+        }
+      }
+
+      .file-delivery-footnotes {
+        font-size: smaller;
+        line-height: 3em;
+        margin-left: 2em;
+      }
+    }
+
+  }
+}
+
+
 .edit_shf_application {
 
   .section-instructions {

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -35,7 +35,7 @@
 }
 
 #company-pay-modal p, #company-pay-modal pre {
-margin-bottom:0;
+  margin-bottom: 0;
 }
 
 
@@ -174,8 +174,8 @@ a.btn.disabled, {
 }
 
 .company-story img {
-max-width:100%;
-height:auto!important;
+  max-width: 100%;
+  height: auto !important;
 }
 
 .company_search {
@@ -227,7 +227,7 @@ nav.navbar .dropdown-menu li a {
 }
 
 .form-check-label {
-margin: 5px 0 0 0;
+  margin: 5px 0 0 0;
 }
 
 .files-to-upload-title {
@@ -313,6 +313,24 @@ margin: 5px 0 0 0;
   font-weight: 900;
 }
 
+.addtl-category-qs {
+  .addtl-category-qs-instructions {
+
+  }
+
+  .category-link {
+    a {
+      border-bottom: none;
+      text-decoration: none;
+    }
+
+    i {
+      font-size: 60%;
+      vertical-align: super;
+    }
+  }
+}
+
 .no-padding {
   margin: 0 !important;
   padding: 0 !important;
@@ -369,12 +387,12 @@ margin: 5px 0 0 0;
 }
 
 .table {
-margin-top:20px;
+  margin-top: 20px;
 }
 
 
 .table th {
-  border-top:none;
+  border-top: none;
   padding: .15rem .75rem;
 }
 
@@ -523,12 +541,14 @@ h6 {
 }
 
 label {
-margin-bottom: 0;
-margin-top: .5rem;
+  margin-bottom: 0;
+  margin-top: .5rem;
 }
 
 
-.address label {margin: 0;}
+.address label {
+  margin: 0;
+}
 
 nav.navbar {
   background-color: $white;

--- a/app/controllers/business_categories_controller.rb
+++ b/app/controllers/business_categories_controller.rb
@@ -14,16 +14,12 @@ class BusinessCategoriesController < ApplicationController
 
 
   def show
-
     @companies = @business_category.companies.includes(:addresses).order(:name)
-
     @companies = @companies.searchable unless current_user.admin?
-
   end
 
 
   def new
-
     authorize BusinessCategory
     @business_category = BusinessCategory.new
 
@@ -56,7 +52,6 @@ class BusinessCategoriesController < ApplicationController
     @business_category.parent_id = params[:parent_cat_id] if context == 'subcategory'
 
     saved = @business_category.save
-
     respond_to do |format|
       format.html do
         if saved
@@ -193,7 +188,7 @@ class BusinessCategoriesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def business_category_params
-    params.require(:business_category).permit(:name, :description)
+    params.require(:business_category).permit(:name, :description, :apply_qs_url)
   end
 
 

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -106,27 +106,25 @@ class ShfApplicationsController < ApplicationController
   end
 
 
-  # @todo this logic is ugly. clean. it. up.
+  # @fixme this logic is ugly. clean. it. up.
   def create
     @shf_application = ShfApplication.new(shf_application_params.merge(user: current_user))
 
     numbers_str = params[:company_number]
-    companies_and_numbers, all_valid = validate_company_numbers(@shf_application, numbers_str)
-    @shf_application.companies = companies_and_numbers[:companies] if all_valid
+    companies_and_numbers, co_nums_valid = validate_company_numbers(@shf_application, numbers_str)
+    @shf_application.companies = companies_and_numbers[:companies] if co_nums_valid
 
     file_delivery_selected = user_selected_file_delivery_option?
 
-    if all_valid && @shf_application.save
-      addtl_qs_info = helpers.instructions_for_additional_category_qs(@shf_application, 'shf_applications.create')
+    if co_nums_valid && @shf_application.save
+      add_biz_category_addtl_qs_to_flash(@shf_application.business_categories)
 
       if process_upload_files_without_error?(params)
         set_flash_messages_incl_application_files(@shf_application, file_delivery_selected, 'create')
-        helpers.flash_message(:notice, addtl_qs_info)
         redirect_to user_path(@shf_application.user)
 
       else
         helpers.flash_message(:notice, t('.success_with_file_problem'))
-        helpers.flash_message(:notice, addtl_qs_info)
         load_update_objects(numbers_str)
         render :edit
       end
@@ -138,17 +136,22 @@ class ShfApplicationsController < ApplicationController
   end
 
 
-  # @fixme if a new category(-ies) has been selected, show instructions, send email with link(s)
+  # @fixme duplicates code in create method
+  # @todo Rails 7 is able to track changes to associations. Use that capability instead of manually checking the business_categories than have changed with original_biz_cat_ids and post_save_biz_cat_ids
   def update
     numbers_str = params[:company_number]
-
-    companies_and_numbers, all_valid = validate_company_numbers(@shf_application, numbers_str)
-    @shf_application.companies = companies_and_numbers[:companies] if all_valid
+    companies_and_numbers, co_nums_valid = validate_company_numbers(@shf_application, numbers_str)
+    @shf_application.companies = companies_and_numbers[:companies] if co_nums_valid
 
     file_delivery_selected = user_selected_file_delivery_option?
 
-    if all_valid && @shf_application.update(shf_application_params) && process_upload_files_without_error?(params)
+    original_biz_cat_ids = @shf_application.business_categories.pluck(:id)
+    if co_nums_valid && @shf_application.update(shf_application_params) && process_upload_files_without_error?(params)
       check_and_mark_if_ready_for_review(params['shf_application'])
+
+      post_save_biz_cat_ids = @shf_application.business_categories.pluck(:id)
+      show_and_email_for_new_biz_cats(@shf_application, original_biz_cat_ids, post_save_biz_cat_ids)
+
       set_flash_messages_incl_application_files(@shf_application, file_delivery_selected, 'update')
       redirect_to define_path(evaluate_update(params))
     else
@@ -243,6 +246,7 @@ class ShfApplicationsController < ApplicationController
   private
 
   # Append message to flash if the applicant needs to be warned/notified that they need to still provide files.
+  # @todo rename to something like 'append...' or 'add..' instead of 'set'
   def set_flash_messages_incl_application_files(shf_application, file_delivery_selected, action)
     i18n_scope = "shf_applications.#{action}"
 
@@ -266,6 +270,12 @@ class ShfApplicationsController < ApplicationController
     end
   end
 
+  # Add instructions and info to flash message about additional questions for the business categories
+  def add_biz_category_addtl_qs_to_flash(biz_categories)
+    addtl_qs_info = helpers.instructions_for_additional_category_qs(biz_categories, 'shf_applications.create')
+    helpers.flash_message(:notice, addtl_qs_info)
+  end
+
   def user_selected_file_delivery_option?
     file_delivery_selected = false
 
@@ -280,11 +290,13 @@ class ShfApplicationsController < ApplicationController
     file_delivery_selected
   end
 
+  # @todo rename because this is onlyabout deleting/destroying
   def define_path(user_deleted_file)
     return edit_shf_application_path(@shf_application) if user_deleted_file
     shf_application_path(@shf_application)
   end
 
+  # @todo rename because this is only about deleting/destroying
   def evaluate_update(params)
     params.dig(:shf_application, :uploaded_files_attributes)&.key?('_destroy')
   end
@@ -308,7 +320,7 @@ class ShfApplicationsController < ApplicationController
   def check_and_mark_if_ready_for_review(app_params)
     return unless app_params
 
-    if app_params.fetch('marked_ready_for_review', false) && app_params['marked_ready_for_review'] != "0"
+    if app_params.fetch('marked_ready_for_review', false) && app_params['marked_ready_for_review'] != '0'
       @shf_application.is_ready_for_review!
     end
   end
@@ -376,7 +388,7 @@ class ShfApplicationsController < ApplicationController
     # validation - for the file delivery method - to the model errors hash.
     # This means model errors will have 2 errors for the same problem (File
     # delivery method not selected by the user).  This line removes one of those:
-    @shf_application.errors.delete(:"user.shf_application.file_delivery_method")
+    @shf_application.errors.delete(:'user.shf_application.file_delivery_method')
 
     @shf_application = add_company_errors_to_model(@shf_application,
                                                    companies_and_numbers)
@@ -457,9 +469,19 @@ class ShfApplicationsController < ApplicationController
     [{ companies: companies, numbers: numbers }, ! companies.include?(nil)]
   end
 
+  # Show info about and email links for additional questions for categories that were added
+  def show_and_email_for_new_biz_cats(shf_app, original_biz_ids, post_save_biz_ids)
+    new_biz_cat_ids = post_save_biz_ids - original_biz_ids
+    new_biz_cats = BusinessCategory.where(id: new_biz_cat_ids)
+    add_biz_category_addtl_qs_to_flash(new_biz_cats) unless new_biz_cat_ids.empty?
+    begin
+      ShfApplicationMailer.additional_qs_for_biz_cats(shf_app, new_biz_cats).deliver_now
+    rescue => _mail_error
+      helpers.flash_message(:error, t('mailers.shf_application_mailer.additional_qs_for_biz_cats.error_sending', email: shf_app.user.email))
+    end
+  end
 
   def send_new_app_emails(new_shf_app)
-
     begin
       ShfApplicationMailer.acknowledge_received(new_shf_app).deliver_now
     rescue => _mail_error
@@ -469,7 +491,6 @@ class ShfApplicationsController < ApplicationController
     # No rescue for the following because if there is a problem sending email to the admin,
     # do not display an error to the user
     send_new_shf_application_notice_to_admins(new_shf_app) if AdminOnly::AppConfiguration.config_to_use.email_admin_new_app_received_enabled
-
   end
 
 
@@ -478,5 +499,6 @@ class ShfApplicationsController < ApplicationController
       AdminMailer.new_shf_application_received(new_shf_app, admin).deliver_now
     end
   end
+
 
 end

--- a/app/controllers/shf_applications_controller.rb
+++ b/app/controllers/shf_applications_controller.rb
@@ -472,8 +472,10 @@ class ShfApplicationsController < ApplicationController
   # Show info about and email links for additional questions for categories that were added
   def show_and_email_for_new_biz_cats(shf_app, original_biz_ids, post_save_biz_ids)
     new_biz_cat_ids = post_save_biz_ids - original_biz_ids
+    return if new_biz_cat_ids.empty?
+
     new_biz_cats = BusinessCategory.where(id: new_biz_cat_ids)
-    add_biz_category_addtl_qs_to_flash(new_biz_cats) unless new_biz_cat_ids.empty?
+    add_biz_category_addtl_qs_to_flash(new_biz_cats)
     begin
       ShfApplicationMailer.additional_qs_for_biz_cats(shf_app, new_biz_cats).deliver_now
     rescue => _mail_error

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,7 +32,7 @@ module ApplicationHelper
     if flash[type].instance_of? String
       flash[type] = [flash[type]]
     end
-    flash[type] << text
+    flash[type] << text.html_safe
   end
 
 
@@ -41,7 +41,7 @@ module ApplicationHelper
       flash_value
     else
       flash_value[0] = flash_value[0].html_safe
-      safe_join(flash_value, '<br/>'.html_safe)
+      safe_join(flash_value.map(&:html_safe), '<br/>'.html_safe)
     end
   end
 

--- a/app/helpers/shf_applications_helper.rb
+++ b/app/helpers/shf_applications_helper.rb
@@ -101,11 +101,13 @@ module ShfApplicationsHelper
     "btn btn-sm btn-outline-primary #{other_css_str}"
   end
 
-  # Return the instructions for answering additional questions for categories in the shf application
-  # @return [String] Instructions for answering additonal questions for each category in the application, with HTML tags
-  def instructions_for_additional_category_qs(shf_app, i18n_scope)
+  # Return the instructions for answering additional questions for the given business categories
+  # @return [String] Instructions for answering additional questions for each business category, with HTML tags
+  # @param [Array<BusinessCategory>] business_categories - list of business categories to show
+  # @param [String] i18n_scope - scope for looking up the message(s) to display
+  def instructions_for_additional_category_qs(business_categories, i18n_scope)
     instructions = I18n.t("#{i18n_scope}.success_more_questions_instructions")
-    "<div class='addtl-category-qs'><p class='addtl-category-qs-instructions'>#{instructions}</p>#{links_for_more_category_questions(shf_app.business_categories)}</div>"
+    "<div class='addtl-category-qs'><p class='addtl-category-qs-instructions'>#{instructions}</p>#{links_for_more_category_questions(business_categories)}</div>"
   end
 
   # @return [String] HTML string with a <ul> for the categories, <li> for each category and the category linklink

--- a/app/helpers/shf_applications_helper.rb
+++ b/app/helpers/shf_applications_helper.rb
@@ -16,7 +16,6 @@ module ShfApplicationsHelper
     "#{shf_app_state_translated(shf_app)} - #{displayed_date.strftime('%F')}"
   end
 
-
   def shf_app_state_translated(shf_app)
     # Cannot use '.human_state' because it calls '.display_name',
     # which is cached/memoized.
@@ -26,18 +25,6 @@ module ShfApplicationsHelper
     #  (Another way might be to set up an observer on changing the locale.)
     shf_app_aasm = shf_app.aasm
     shf_app_aasm.state_object_for_name(shf_app_aasm.current_state).localized_name
-  end
-
-  def company_business_categories_str(company)
-    cats_str = ''
-    company&.current_business_categories&.roots.order(:name).each do |category|
-      cats_str += ', ' unless cats_str.empty?
-      cats_str += category.name
-      sub_cats = company&.current_business_categories(category)
-
-      cats_str += subcategories_list_in_parens(sub_cats)
-    end
-    cats_str
   end
 
   def business_categories_str(application)
@@ -60,13 +47,11 @@ module ShfApplicationsHelper
     " (#{t('including')}: #{subcategories.map(&:name).join(', ')})"
   end
 
-
   # The AASM gem caches the display_name for a State.  We cannot do that because
   # the I18n.locale may have changed, so we must get the localized name every time
   def states_selection_list
     ShfApplication.aasm.states.map { |state| [state.localized_name, state.name.to_s] }
   end
-
 
   def reasons_collection(other_reason_value, other_reason_text)
     collection = AdminOnly::MemberAppWaitingReason.all.to_a
@@ -74,11 +59,9 @@ module ShfApplicationsHelper
     collection
   end
 
-
   def selected_reason_value(member_app, other_reason_value)
     (!member_app.custom_reason_text.blank?) ? other_reason_value : member_app.member_app_waiting_reasons_id
   end
-
 
   # the method to use to get the name for a reason, given the locale
   # If no locale is given, the current locale is used.
@@ -87,7 +70,6 @@ module ShfApplicationsHelper
     reason_method 'name', locale
   end
 
-
   # the method to use to get the description for a reason, given the locale
   # If no locale is given, the current locale is used.
   # If the locale given isn't found or defined, the default name method is used
@@ -95,13 +77,11 @@ module ShfApplicationsHelper
     reason_method 'description', locale
   end
 
-
   # a collection of arrays with [the name of the reasons for waiting, the reason (object)]
   # in the locale
   def reasons_for_waiting_names(use_locale = I18n.locale)
     reasons_for_waiting_info('name', use_locale)
   end
-
 
   # a collection of arrays with [the descriptions of the reasons for waiting,  the reason (object)]
   # in the locale
@@ -109,17 +89,36 @@ module ShfApplicationsHelper
     reasons_for_waiting_info('description', use_locale)
   end
 
-
-  def list_app_categories application, separator=', '
+  def list_app_categories application, separator = ', '
     if application&.business_categories.any?
       application.business_categories.roots.includes(:shf_applications)
-        .map(&:name).sort.join(separator)
+                 .map(&:name).sort.join(separator)
     end
   end
 
   # @return [String] - standarize the classes used for the Admin (review) status buttons
   def admin_status_btn_css(other_css_str = '')
     "btn btn-sm btn-outline-primary #{other_css_str}"
+  end
+
+  # Return the instructions for answering additional questions for categories in the shf application
+  # @return [String] Instructions for answering additonal questions for each category in the application, with HTML tags
+  def instructions_for_additional_category_qs(shf_app, i18n_scope)
+    instructions = I18n.t("#{i18n_scope}.success_more_questions_instructions")
+    "<div class='addtl-category-qs'><p class='addtl-category-qs-instructions'>#{instructions}</p>#{links_for_more_category_questions(shf_app.business_categories)}</div>"
+  end
+
+  # @return [String] HTML string with a <ul> for the categories, <li> for each category and the category linklink
+  def links_for_more_category_questions(categories = [], ul_class: 'category-links', li_class: 'category-link')
+    ul_items = categories.map { |cat| link_for_more_category_questions(cat, li_class: li_class) }
+    "<ul class='#{ul_class}'>#{ul_items.join}</ul>"
+  end
+
+  def link_for_more_category_questions(category, li_class: 'category-link')
+    a_href_open = "<a href=#{category.apply_qs_url} target='_blank'>"
+    href_name = "<span class=name>#{category.name}</span>"
+    href_link = "#{category.apply_qs_url} #{external_link_icon}"
+    "<li class='#{li_class}'>#{a_href_open}#{href_name} #{href_link}</a></li>"
   end
 
   # --------------------------------------------------------------------------------------------
@@ -131,7 +130,6 @@ module ShfApplicationsHelper
     (AdminOnly::MemberAppWaitingReason.new.respond_to?(possible_method) ? possible_method : AdminOnly::MemberAppWaitingReason.send("default_#{method_prefix}_method".to_sym))
   end
 
-
   def reasons_for_waiting_info(method_prefix, locale)
     method_name = reason_method(method_prefix, locale)
     AdminOnly::MemberAppWaitingReason.all.map { |r| [r.id, r.send(method_name)] }
@@ -139,36 +137,21 @@ module ShfApplicationsHelper
 
   def file_delivery_radio_buttons_collection(locale = I18n.locale)
     collection = []
-    footnotes = ''
-
     # Default option will be the first (left-most) button in the set
     AdminOnly::FileDeliveryMethod.order('default_option DESC').each do |delivery_method|
-
       option_text = delivery_method.description_for_locale(locale)
-
-      if delivery_method.email?
-
-        option_text += '*'
-        footnotes += '*' + mail_to(ENV['SHF_MEMBERSHIP_EMAIL'], nil,
-                  subject: t('shf_applications.new.email_files_subject'))
-
-      elsif delivery_method.mail?
-
-        option_text += '**'
-        footnotes += '&nbsp; &nbsp; **' + t('shf_applications.new.where_to_mail_files')
-      end
-
-      collection << [ delivery_method.id, option_text ]
+      option_text += '*' if delivery_method.email?
+      option_text += '**' if delivery_method.mail?
+      collection << [delivery_method.id, option_text]
     end
-
-    [ collection, footnotes.html_safe ]
+    collection
   end
 
   def file_delivery_method_status(application, locale = I18n.locale)
 
     fdm = application.file_delivery_method
     fdm_desc = fdm ? fdm.description_for_locale(locale) : t('none_plur')
-    status = t('shf_applications.show.files_delivery_method')+ ': ' + fdm_desc
+    status = t('shf_applications.show.files_delivery_method') + ': ' + fdm_desc
 
     if fdm
       status += ' ' +

--- a/app/mailers/shf_application_mailer.rb
+++ b/app/mailers/shf_application_mailer.rb
@@ -2,7 +2,6 @@
 class ShfApplicationMailer < ApplicationMailer
 
   def acknowledge_received(shf_application)
-    @shf_application = shf_application
     send_mail_for __method__, shf_application, t('mailers.shf_application_mailer.acknowledge_received.subject')
   end
 

--- a/app/mailers/shf_application_mailer.rb
+++ b/app/mailers/shf_application_mailer.rb
@@ -12,6 +12,10 @@ class ShfApplicationMailer < ApplicationMailer
     send_mail_for __method__, shf_application, t('mailers.shf_application_mailer.app_approved.subject')
   end
 
+  def additional_qs_for_biz_cats(shf_application, added_biz_categories)
+    @added_biz_categories = added_biz_categories
+    send_mail_for __method__, shf_application, t('mailers.shf_application_mailer.additional_qs_for_biz_cats.subject')
+  end
   # --------------------------------------------------------------------------------------------------
 
   private

--- a/app/mailers/shf_application_mailer.rb
+++ b/app/mailers/shf_application_mailer.rb
@@ -1,37 +1,27 @@
 # Emails about SHF Applications (has been received, approved, etc.)
 class ShfApplicationMailer < ApplicationMailer
 
-
   def acknowledge_received(shf_application)
-
     @shf_application = shf_application
     send_mail_for __method__, shf_application, t('mailers.shf_application_mailer.acknowledge_received.subject')
-
   end
 
-
   def app_approved(shf_application)
-
     # branding_fee_paid is used in the mail view
     @branding_fee_paid = shf_application.company_branding_fee_paid?
 
     send_mail_for __method__, shf_application, t('mailers.shf_application_mailer.app_approved.subject')
-
   end
 
+  # --------------------------------------------------------------------------------------------------
 
   private
 
-
   def send_mail_for(method_name, shf_application, subject)
-
     set_mail_info method_name, shf_application.user
 
     # shf_app is used in the mail view
     @shf_app = shf_application
     mail to: @recipient_email, subject: subject
-
   end
-
-
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -312,7 +312,7 @@ class Company < ApplicationRecord
     return current_categories(include_subcategories).map(&:name).uniq.sort unless include_subcategories
 
     names = []
-    cats.each do |category|
+    current_categories.each do |category|
       names << category.name
       names += category.children.order(:name).pluck(:name)
     end

--- a/app/views/application/_flash.html.haml
+++ b/app/views/application/_flash.html.haml
@@ -3,6 +3,6 @@
     .alert.alert-dismissable.center{ class: "alert-#{flash_class(key)}", role: 'alert' }
       %button.close{ type: 'button', 'data-dismiss' => 'alert' }
         %span &times;
-      = render_flash_message(value)
+      = h render_flash_message(value)
 
   - flash.clear

--- a/app/views/business_categories/_cat_table_head.html.haml
+++ b/app/views/business_categories/_cat_table_head.html.haml
@@ -4,9 +4,10 @@
 %thead
   %tr
     %th.name.col-width-25pc
-      = parent_category ? t('activerecord.models.business_category.one') : ''
+      = parent_category ? t('.name') : ''
     %th.description.col-width-40pc
-      = parent_category ? t('activerecord.attributes.business_category.description') : ''
+      = parent_category ? t('.description') : ''
+    %th.apply-qs-url= parent_category ? t('.apply_qs_url') : ''
     %th.col-width-20pc
     %th.col-width-5pc
     %th.col-width-5pc

--- a/app/views/business_categories/_category_display_row.html.haml
+++ b/app/views/business_categories/_category_display_row.html.haml
@@ -14,13 +14,14 @@
 
   - if context == 'category'
     %td.description= business_category.description
+    %td.addtl_qs_link= business_category.apply_qs_url
     %td.add_subcategory
       = link_to add_subcat_title,
                 new_business_category_path(parent_cat_id: business_category.id),
                 remote: true,
                 class: 'btn btn-sm btn-light new-category-button'
   - else
-    %td.description{ colspan: 2 }= business_category.description
+    %td.description{ colspan: 3 }= business_category.description
 
 
   %td.view

--- a/app/views/business_categories/_category_edit_row.html.haml
+++ b/app/views/business_categories/_category_edit_row.html.haml
@@ -26,27 +26,36 @@
           %tr
             %td
               .form-group
-                = f.label :name, t('activerecord.attributes.business_category.name') , class: 'required'
+                = f.label :name, t('.name') , class: 'required'
                 = f.text_field :name, class: 'form-control'
-            %td
+          %tr
+            %td{ colspan: 4 }
               .form-group
-                = f.label :description, t('activerecord.attributes.business_category.description')
+                = f.label :description, t('.description')
                 = f.text_field :description, class: 'form-control'
-
             %td
               = hidden_field_tag :parent_cat_id, parent_cat_id
+          %tr
+            %td{ colspan: 4 }
+              :ruby
+                # @todo validate URL format
+                # @todo tooltip that explains that this is exactly what the applicants will see, so be sure it's accurate
+              .form-group
+                = f.label :apply_qs_url, t('.apply_qs_url')
+                = f.text_field :apply_qs_url, class: 'form-control'
 
-            %td.border-right.border-dark
-              .float-right
-                = f.submit t('save'), class: 'btn btn-success btn-sm'
-                %br
-                %br
+          %tr
+            %td
+              .text-center
+                - btn_classes = 'btn btn-sm'
+                = f.submit t('save'), class: "#{btn_classes} btn-success"
+
                 - if record_type == 'existing_category'
                   = link_to t('cancel'),
                             get_display_row_business_category_path(business_category),
                             remote: true,
-                            class: 'edit-category-cancel-button btn btn-danger btn-sm mt-1',
+                            class:  "#{btn_classes} edit-category-cancel-button btn-danger",
                             id: "cancel-category-edit-#{business_category.id}"
                 - else
                   = link_to t('cancel'), {}, href: '#',
-                            class: 'new-category-cancel-button btn btn-danger btn-sm mb-1'
+                            class:  "#{btn_classes} new-category-cancel-button btn-danger"

--- a/app/views/business_categories/_form.html.haml
+++ b/app/views/business_categories/_form.html.haml
@@ -1,11 +1,15 @@
+-# @fixme is this used anymore? Seems javascript pop-up is used on the index page
 = form_for @business_category do |f|
 
   != model_errors_helper(@business_category)
   .form-group
-    = f.label :name, t('activerecord.attributes.business_category.name') , class: 'required'
+    = f.label :name, t('.name') , class: 'required'
     = f.text_field :name, class: 'form-control'
   .form-group
-    = f.label :description, t('activerecord.attributes.business_category.description')
+    = f.label :description, t('.description')
     = f.text_field :description, class: 'form-control'
+  .form-group
+    = f.label :apply_qs_url, t('.apply_qs_url')
+    = f.text_field :apply_qs_url, class: 'form-control'
   .form-group
     = f.submit t('business_categories.form.save'), class: 'btn btn-primary mb-2 form-control'

--- a/app/views/shf_application_mailer/_additional_questions_for_categories.html.haml
+++ b/app/views/shf_application_mailer/_additional_questions_for_categories.html.haml
@@ -1,0 +1,11 @@
+:ruby
+  # This view expects these locals:
+  #  categories [Array<BusinessCategory>] list of categories that we need to show
+  #  i18n_scope [String] the scope to use for I18n.t calls
+
+.additional-questions-for-categories
+  .instructions
+    %p= t('more_questions_instructions', scope: i18n_scope)
+    %ul.category-links
+      - categories.each do |category|
+        %li.category-link= link_to("#{category.name} #{category.apply_qs_url}", category.apply_qs_url)

--- a/app/views/shf_application_mailer/_your_submitted_info.html.haml
+++ b/app/views/shf_application_mailer/_your_submitted_info.html.haml
@@ -1,0 +1,8 @@
+:ruby
+  # This partial expects these locals:
+  #   i18n_scope [String] - the scope to use to look up translations
+  #   shf_app [ShfApplication] - the Shf Application to show the details for
+%p= t('your_submitted_info', scope: i18n_scope)
+.shf-application-info
+  %p= shf_app_to_html(shf_app)
+

--- a/app/views/shf_application_mailer/acknowledge_received.html.haml
+++ b/app/views/shf_application_mailer/acknowledge_received.html.haml
@@ -6,11 +6,8 @@
   %p= t('message_text', scope: i18n_scope)
 
   %hr
-  %p= t('your_submitted_info', scope: i18n_scope)
-  .shf-application-info
-    %p
-      = shf_app_to_html(@shf_application)
+  = render 'your_submitted_info', i18n_scope: i18n_scope, shf_app: @shf_app
   %hr
 
   = render 'mailers_shared/newapp_login_upload_files_instruction', email: @recipient_email
-  = render 'additional_questions_for_categories', categories: @shf_application.business_categories, i18n_scope: i18n_scope
+  = render 'additional_questions_for_categories', categories: @shf_app.business_categories, i18n_scope: i18n_scope

--- a/app/views/shf_application_mailer/acknowledge_received.html.haml
+++ b/app/views/shf_application_mailer/acknowledge_received.html.haml
@@ -13,3 +13,4 @@
   %hr
 
   = render 'mailers_shared/newapp_login_upload_files_instruction', email: @recipient_email
+  = render 'additional_questions_for_categories', categories: @shf_application.business_categories, i18n_scope: i18n_scope

--- a/app/views/shf_application_mailer/additional_qs_for_biz_cats.html.haml
+++ b/app/views/shf_application_mailer/additional_qs_for_biz_cats.html.haml
@@ -1,0 +1,10 @@
+- provide :signoff do
+  = render 'application_mailer/signoff'
+
+- i18n_scope = 'mailers.shf_application_mailer.additional_qs_for_biz_cats.message_text'
+= render layout: 'layouts/mail_from_membership' do
+  %p= t('youve_add_categories', scope: i18n_scope)
+  = render 'additional_questions_for_categories', categories: @added_biz_categories, i18n_scope: i18n_scope
+  %hr
+  = render 'your_submitted_info', i18n_scope: i18n_scope, shf_app: @shf_app
+  %hr

--- a/app/views/shf_applications/_shf_application_fields.html.haml
+++ b/app/views/shf_applications/_shf_application_fields.html.haml
@@ -1,16 +1,21 @@
 
-.app-section
+.app-section#business-categories
   - unless association_empty?(all_business_categories)
-    %h2= t('shf_applications.new.application_dog_category')
-    %p= t('shf_applications.new.clue_selected_categories')
+    %h2= t('.business_categories.section_title')
+    %p.instructions= t('.business_categories.instructions')
+    %p.instructions= t('.business_categories.instructions2')
+
     .checkbox.col-xs-offset-1
       = f.collection_check_boxes :business_category_ids, all_business_categories, :id, :name do |b|
         = b.check_box(class: 'text-nicelabel', position_class: 'text_checkbox') + b.label
 
 .app-section#supporting-files
-  %h2= t('shf_applications.new.upload_files_section')
+  %h2= t('.supporting_files.section_title')
   .answers
-    %p= t('shf_applications.new.upload_files_instructions')
+    %p.instructions= t('.supporting_files.instructions')
+    %p.email-membership-with-qs
+      = t('.supporting_files.email_membership_with_qs')
+      = mail_to(ENV['SHF_MEMBERSHIP_EMAIL'])
 
     .files
       .container.mt-3
@@ -43,25 +48,29 @@
           .col-md-6
             = render 'uploaded_files_list', shf_application: @shf_application
     %br
-    %p
-      %span.file-delivery-selection
-        = t('shf_applications.new.file_delivery_selection')
-      %br
 
-      - radio_buttons_collection, footnotes = file_delivery_radio_buttons_collection
+    .file-delivery-choices
+      %h3.file-delivery-selection= t('shf_applications.new.file_delivery_selection')
 
-      = f.collection_radio_buttons(:file_delivery_method_id,
-                                   radio_buttons_collection,
-                                   :first, :second, {}) do |rb|
-        = rb.label(class: 'form-check form-check-inline') do
-          %small= rb.radio_button + ' ' + rb.text + ' '
-      %small.file-delivery-footnotes
-        = footnotes
+      - radio_buttons_collection = file_delivery_radio_buttons_collection
+
+      .delivery-choice
+        = f.collection_radio_buttons(:file_delivery_method_id,
+                                     radio_buttons_collection,
+                                     :first, :second, {}) do |rb|
+          = rb.label(class: 'form-check form-check-inline') do
+            = rb.radio_button + ' ' + rb.text + ' '
+
+        %p.file-delivery-footnotes
+          = ('*' + mail_to(ENV['SHF_MEMBERSHIP_EMAIL'], nil, subject: t('shf_applications.new.email_files_subject'))).html_safe
+          = ('&nbsp; &nbsp; **' + t('shf_applications.new.where_to_mail_files')).html_safe
 
     %p.upload-more-note.instructions= t('shf_applications.new.upload_more_files') if controller.action_name == 'new'
 
 .app-section
   %h2= t('shf_applications.new.section_title_about_you')
+  .is-required= render 'application/required_fields'
+
   .answers
 
     = f.label :company_number, t('shf_applications.show.company_number'), class: 'required'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -609,11 +609,7 @@ en:
       contact_email: *contact_email
 
       can_be_same_email: Can be the same that you logged in with, but need not be.
-      application_dog_category: &application_dog_category "Services You Provide"
-      clue_selected_categories: &clue_selected_categories "Blue box = selected categories"
 
-      upload_files_section: Documents to support your application (certifications, etc.)
-      upload_files_instructions: 'The documents are very important for us to assess your application. We use them to authenticate your skills and education. This ensures that our membership standards remain high, which in turn means that the public know that the Swedish dog business is professional and reliable.'
       upload_files: 'Upload files from your computer:'
       upload_allowed_file_types: *upload_allowed_types
       upload_more_files: 'You can upload more files. After you submit your application, you may still edit the application and upload more files.'
@@ -640,6 +636,8 @@ en:
       success_with_app_files_missing: YOUR APPLICATION WAS CREATED, BUT REQUIRED FILES ARE MISSING
       upload_file_or_select_method: &upload_files Please upload files or select another delivery method
       remember_to_deliver_files: &chosen_method Please remember to deliver files via the chosen delivery method
+      success_more_questions_instructions: &category_more_qs_instructions "You will now have to fill out a Google form for each category, in which you guarantee that you have gone through all the required subjects and elements required for approval. Your application is not complete until you have filled out your form(-s)."
+      success_category_link: &category_link "%{category}:  %{link}"
 
     edit:
       title: Edit Membership Application
@@ -738,8 +736,15 @@ en:
       company_name: *name
 
     shf_application_fields:
-      company_numbers_tooltip: You can enter multiple company numbers, separated by
-        a comma or blank spaces
+      company_numbers_tooltip: You can enter multiple company numbers, separated by a comma or blank spaces
+      business_categories:
+        section_title: &business_categories_title "Services You Provide"
+        instructions: &clue_selected_categories "Blue field = selected. Relevant member category needs to be filled in for us to be able to handle your application."
+        instructions2: You will need to submit documentation the proves you are qualified in each category you select. Instructions are in the next section.
+      supporting_files:
+        section_title: Documents to support your application (certifications, etc.)
+        instructions: "Please upload evidence which proves that your have successfully completed all the education that you mentioned in the category-forms. A common type of evidence is signed diplomas. You can take a picture of your diploma or scan it into your computer. "
+        email_membership_with_qs: "If you’re having trouble with this, please send an email to "
 
     start_review:
       success: The review has been started.
@@ -1039,10 +1044,13 @@ en:
       success: Category deleted.
 
     form:
+      name: *business_category
+      description: *description
+      apply_qs_url: *category_addtl_qs_link
       save: *save
 
     form_collection_checkboxes:
-      title: *application_dog_category
+      title: *business_categories_title
       clue_selected_categories: *clue_selected_categories
 
     new_business_category: New business category
@@ -2030,6 +2038,8 @@ en:
         need_to_upload: "You need to upload your files. Here's how:"
         can_upload_more: "You can upload more files. Here's how:"
         error_sending: &shf_email_error "There was a problem sending email to you at {%email} about your application."
+        more_questions_instructions: *category_more_qs_instructions
+        category_link: *category_link
 
       app_approved:
         subject: Your application to Sveriges Hundföretagare is approved

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -652,6 +652,8 @@ en:
       success_with_app_files_missing: YOUR APPLICATION WAS UPDATED, BUT REQUIRED FILES ARE MISSING
       upload_file_or_select_method: *upload_files
       remember_to_deliver_files: *chosen_method
+      success_more_questions_instructions: *category_more_qs_instructions
+      success_category_link: *category_link
 
     show:
       title: Application from %{user_full_name}
@@ -2031,8 +2033,8 @@ en:
 
       acknowledge_received:
         subject: Your application to Sveriges Hundföretagare has been received
-        message_text: "Your application has been received.  We are all working hard, so it might take a while before we get to it. So do not worry if it takes a while before you hear from us."
-        your_submitted_info: "As a reminder, here is what you submitted:"
+        message_text: &app_been_recieved "Your application has been received.  We are all working hard, so it might take a while before we get to it. So do not worry if it takes a while before you hear from us."
+        your_submitted_info: &your_submitted_info "As a reminder, here is what you submitted:"
         review_after_recevied_files: *review_after_recevied_files
         upload_choice_intro: "Your choice for providing files: "
         need_to_upload: "You need to upload your files. Here's how:"
@@ -2052,6 +2054,13 @@ en:
           thanks: "Thank you for wanting to be a member and contributing to a Sweden with an ethical dog industry."
           error_sending: *shf_email_error
 
+      additional_qs_for_biz_cats:
+        subject: Additional questions for new Sveriges Hundföretagare business categories
+        message_text:
+          youve_add_categories: Thanks for updating your application. You've added new business categories.
+          more_questions_instructions: *category_more_qs_instructions
+          your_submitted_info: *your_submitted_info
+        error_sending: *shf_email_error
 
     member_mailer:
       member_account_link: "%{account_link} (You may need to login first before the link works. Your login is %{login_email}.)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -293,12 +293,12 @@ en:
         dinkurs_key: &dinkurs_company_key Dinkurs Company key
         dinkurs_company_id: Dinkurs company key
 
-
       business_category:
         name: &business_category_name  Name
         description: *description
         subcategory: &subcategory Subcategory
         subcategories: Subcategories
+        apply_qs_url: &category_addtl_qs_link  Link for additional questions
 
       shf_document:
         title: &title Title
@@ -999,7 +999,6 @@ en:
     show_not: (Showing Dinkurs events on this page has been disabled.  Edit the company to enable that.)
 
   business_categories:
-
     index:
       title: Company Categories
       name: *business_category_name
@@ -1020,7 +1019,9 @@ en:
 
     new:
       title: New business category
+      name: *business_category_name
       description: *description
+      apply_qs_url: *category_addtl_qs_link
       no_one_applied_category: *category_no_one_applied
 
     create:
@@ -1047,6 +1048,22 @@ en:
     new_business_category: New business category
     new_business_subcategory: New subcategory
     all_business_categories: All categories
+
+    cat_table_head:
+      name: *business_category
+      description: *description
+      apply_qs_url: *category_addtl_qs_link
+
+    category_new_row:
+      name: *business_category
+      description: *description
+      apply_qs_url: *category_addtl_qs_link
+
+    category_edit_row:
+      name: *business_category
+      description: *description
+      apply_qs_url: *category_addtl_qs_link
+
 
   users:
     edit_user_account: &edit_user_account "Edit the account for %{name}"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -297,6 +297,7 @@ sv:
         description: *description
         subcategory: &subcategory Underkategori
         subcategories: Underkategorier
+        apply_qs_url: &category_addtl_qs_link Link for additional questions
 
       shf_document:
         title: &title Titel
@@ -1008,7 +1009,6 @@ sv:
               Redigera företaget för att aktivera visning av händelser.)
 
   business_categories:
-
     index:
       title: &business_category Företagstyp
       name: *business_category_name
@@ -1029,7 +1029,9 @@ sv:
 
     new:
       title: Ny företagstyp (kategori)
+      name: *business_category_name
       description: *description
+      apply_qs_url: *category_addtl_qs_link
       no_one_applied_category: *category_no_one_applied
 
 
@@ -1057,6 +1059,21 @@ sv:
     new_business_category: Skapa ny företagstyp (kategori)
     new_business_subcategory: Ny underkategori
     all_business_categories: Alla kategorier
+
+    cat_table_head:
+      name: *business_category
+      description: *description
+      apply_qs_url: *category_addtl_qs_link
+
+    category_new_row:
+      name: *business_category
+      description: *description
+      apply_qs_url: *category_addtl_qs_link
+
+    category_edit_row:
+      name: *business_category
+      description: *description
+      apply_qs_url: *category_addtl_qs_link
 
   users:
     edit_user_account: &edit_user_account Redigera kontot för %{name}

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -658,6 +658,8 @@ sv:
       success_with_app_files_missing: "!! Din ansökan laddades upp men den saknar filer !!"
       upload_file_or_select_method: *upload_files
       remember_to_deliver_files: *chosen_method
+      success_more_questions_instructions: *category_more_qs_instructions
+      success_category_link: *category_link
 
     show:
       title: Ansökan från %{user_full_name}
@@ -2036,8 +2038,8 @@ sv:
 
       acknowledge_received:
         subject: Din ansökan till Sveriges Hundföretagare är mottagen
-        message_text: "Din ansökan är mottagen. Vi hanterar den så fort vi kan. Säkerställ att du laddat upp eller mailar in allt relevant underlag."
-        your_submitted_info: "Här är vad du har laddat upp:"
+        message_text: &app_been_recieved "Din ansökan är mottagen. Vi hanterar den så fort vi kan. Säkerställ att du laddat upp eller mailar in allt relevant underlag."
+        your_submitted_info: &your_submitted_info "Här är vad du har laddat upp:"
         review_after_recevied_files: *review_after_recevied_files
         upload_choice_intro: "Ditt val för att tillhandahålla underlag: "
         need_to_upload: "Du måste ladda upp dina filer. Här är hur:"
@@ -2045,7 +2047,6 @@ sv:
         error_sending: &shf_email_error  "Det gick inte att skicka e-post till dig på {% email} om din ansökan."
         more_questions_instructions: *category_more_qs_instructions
         category_link: *category_link
-
 
       app_approved:
         subject: Din ansökan till Sveriges Hundföretagare är godkänd.
@@ -2057,6 +2058,14 @@ sv:
           h_branding_not_paid: "När detta är gjort behöver du göra färdigt din företagssida och betala din H-märkesavgift. Mer information om hur du gör det kommer i ett mail efter att du betalt din medlemsavgift."
           thanks:  "Tack för att du vill vara medlem och bidrar till ett kvalitetssäkrat hundsverige."
           error_sending: *shf_email_error
+
+      additional_qs_for_biz_cats:
+        subject: Additional questions for new Sveriges Hundföretagare business categories
+        message_text:
+          youve_add_categories: Thanks for updating your application. You've added new business categories.
+          more_questions_instructions: *category_more_qs_instructions
+          your_submitted_info: *your_submitted_info
+        error_sending: *shf_email_error
 
 
     member_mailer:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -617,11 +617,7 @@ sv:
       contact_email: *contact_email
 
       can_be_same_email: Kan vara samma som du loggar in med, men behöver inte vara det.
-      application_dog_category: &application_dog_category "Ansöker som:"
-      clue_selected_categories: &clue_selected_categories "Blå fält = valda. Relevant medlemskategori behöver fyllas i för att vi ska kunna hantera din ansökan."
 
-      upload_files_section:  Underlag för att styrka min ansökan
-      upload_files_instructions: 'Dokumenten är mycket viktiga för att vi ska kunna bedöma din ansökan. Vi använder dem för att verifiera dina kunskaper och utbildningar. Detta säkerställer att vår medlemsstandard är fortsatt hög, vilket i förlängningen innebär att allmänheten vet att Sveriges hundföretagare är professionella och att lita på.'
       upload_files: 'Ladda upp filer från datorn (VIKTIGT)'
       upload_allowed_file_types: *upload_allowed_types
       upload_more_files: Du kan ladda upp fler filer genom att redigera din ansökan efter att du skickat in den.
@@ -646,6 +642,8 @@ sv:
       success_with_app_files_missing: "!! Din ansökan har sparats, men den saknar nödvändiga filer !!"
       upload_file_or_select_method: &upload_files Var god ladda upp filer eller välj en annan leveransmetod
       remember_to_deliver_files: &chosen_method Kom ihåg att leverera filer via den valda leveransmetoden
+      success_more_questions_instructions: &category_more_qs_instructions "You will now have to fill out a Google form for each category, in which you guarantee that you have gone through all the required subjects and elements required for approval. Your application is not complete until you have filled out your form(-s)."
+      success_category_link: &category_link "%{category}: %{link}"
 
     edit:
       title: Redigera ansökan om medlemskap
@@ -746,8 +744,16 @@ sv:
       company_name: *name
 
     shf_application_fields:
-      company_numbers_tooltip: Du kan ange flera företagsnummer, åtskilda av
-                               ett kommatecken eller tomma mellanslag
+      company_numbers_tooltip: Du kan ange flera företagsnummer, åtskilda av ett kommatecken eller tomma mellanslag
+      business_categories:
+        section_title: &business_categories_title "Ansöker som:"
+        instructions:  &clue_selected_categories "Blå fält = valda. Relevant medlemskategori behöver fyllas i för att vi ska kunna hantera din ansökan."
+        instructions2: You will need to submit documentation the proves you are qualified in each category you select. Instructions are in the next section.
+      supporting_files:
+        section_title: Underlag för att styrka min ansökan
+        instructions: "Please upload evidence which proves that your have successfully completed all the education that you mentioned in the category-forms. A common type of evidence is signed diplomas. You can take a picture of your diploma or scan it into your computer. "
+        email_membership_with_qs: "If you’re having trouble with this, please send an email to "
+
 
     start_review:
       success: Granskningen har påbörjats.
@@ -1051,9 +1057,12 @@ sv:
 
     form:
       save: *save
+      name: *business_category
+      description: *description
+      apply_qs_url: *category_addtl_qs_link
 
     form_collection_checkboxes:
-      title: *application_dog_category
+      title: *business_categories_title
       clue_selected_categories: *clue_selected_categories
 
     new_business_category: Skapa ny företagstyp (kategori)
@@ -2034,6 +2043,9 @@ sv:
         need_to_upload: "Du måste ladda upp dina filer. Här är hur:"
         can_upload_more: "Du kan ladda upp fler filer. Här är hur:"
         error_sending: &shf_email_error  "Det gick inte att skicka e-post till dig på {% email} om din ansökan."
+        more_questions_instructions: *category_more_qs_instructions
+        category_link: *category_link
+
 
       app_approved:
         subject: Din ansökan till Sveriges Hundföretagare är godkänd.

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -2062,7 +2062,7 @@ sv:
       additional_qs_for_biz_cats:
         subject: Ytterligare frågor för nya Sveriges Hundföretagare kategorier
         message_text:
-          youve_add_categories: Tack för att du uppdaterat din ansökan. Du har lagt till ny(a) kategori(er).
+          youve_add_categories: Tack för att du uppdaterat din ansökan. Du har ansökt om ny(a) kategori(er).
           more_questions_instructions: *category_more_qs_instructions
           your_submitted_info: *your_submitted_info
         error_sending: *shf_email_error

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -297,7 +297,7 @@ sv:
         description: *description
         subcategory: &subcategory Underkategori
         subcategories: Underkategorier
-        apply_qs_url: &category_addtl_qs_link Link for additional questions
+        apply_qs_url: &category_addtl_qs_link Länk till formulär
 
       shf_document:
         title: &title Titel
@@ -642,7 +642,7 @@ sv:
       success_with_app_files_missing: "!! Din ansökan har sparats, men den saknar nödvändiga filer !!"
       upload_file_or_select_method: &upload_files Var god ladda upp filer eller välj en annan leveransmetod
       remember_to_deliver_files: &chosen_method Kom ihåg att leverera filer via den valda leveransmetoden
-      success_more_questions_instructions: &category_more_qs_instructions "You will now have to fill out a Google form for each category, in which you guarantee that you have gone through all the required subjects and elements required for approval. Your application is not complete until you have filled out your form(-s)."
+      success_more_questions_instructions: &category_more_qs_instructions "Har du inte bifogat formulär från din utbildare behöver du nu fylla i ett Google formulär for varje kategori, där du intygar att du har behörighet för allt inom den kategorin. Din ansökan är inte klar förrän du skickat in relevant(a) formulär."
       success_category_link: &category_link "%{category}: %{link}"
 
     edit:
@@ -750,11 +750,11 @@ sv:
       business_categories:
         section_title: &business_categories_title "Ansöker som:"
         instructions:  &clue_selected_categories "Blå fält = valda. Relevant medlemskategori behöver fyllas i för att vi ska kunna hantera din ansökan."
-        instructions2: You will need to submit documentation the proves you are qualified in each category you select. Instructions are in the next section.
+        instructions2: Du behöver bifoga underlag som visar att du är behörig för den/de kategori(er) du väljer. Instruktioner nedan.
       supporting_files:
         section_title: Underlag för att styrka min ansökan
-        instructions: "Please upload evidence which proves that your have successfully completed all the education that you mentioned in the category-forms. A common type of evidence is signed diplomas. You can take a picture of your diploma or scan it into your computer. "
-        email_membership_with_qs: "If you’re having trouble with this, please send an email to "
+        instructions: "Ladda upp underlag som visar att du har genomfört all relevant utbildning. Ett vanligt underlag är signerade examensbevis. Du kan ta ett foto på ditt examensbevis eller skanna in det i din dator."
+        email_membership_with_qs: "Om du upplever problem, skriv en rad till: "
 
 
     start_review:
@@ -2060,9 +2060,9 @@ sv:
           error_sending: *shf_email_error
 
       additional_qs_for_biz_cats:
-        subject: Additional questions for new Sveriges Hundföretagare business categories
+        subject: Ytterligare frågor för nya Sveriges Hundföretagare kategorier
         message_text:
-          youve_add_categories: Thanks for updating your application. You've added new business categories.
+          youve_add_categories: Tack för att du uppdaterat din ansökan. Du har lagt till ny(a) kategori(er).
           more_questions_instructions: *category_more_qs_instructions
           your_submitted_info: *your_submitted_info
         error_sending: *shf_email_error

--- a/db/migrate/20220602221644_add_apply_qs_link_to_business_categories.rb
+++ b/db/migrate/20220602221644_add_apply_qs_link_to_business_categories.rb
@@ -1,0 +1,5 @@
+class AddApplyQsLinkToBusinessCategories < ActiveRecord::Migration[5.2]
+  def change
+    add_column :business_categories, :apply_qs_url, :string, comment: 'URL for gathering additional info when applicant applies for this category'
+  end
+end

--- a/features/business_categories/business_subcategory.feature
+++ b/features/business_categories/business_subcategory.feature
@@ -15,42 +15,43 @@ Feature: Admin can create and delete business subcategories
       | admin@shf.com        | true  |
 
     And the following business categories exist
-      | name         | description      | subcategories          |
-      | dog grooming | grooming dogs    | light trim, custom cut |
+      | name         | description   | subcategories          |
+      | dog grooming | grooming dogs | light trim, custom cut |
 
     And I am logged in as "admin@shf.com"
 
   @selenium
   Scenario Outline: Admin creates new Business Subcategories
     Given I am on the "business categories" page
-    And I click the icon with CSS class "add-entity-button" for the row with "dog grooming"
-    And I should see t("business_categories.index.add_subcategory")
-    When I fill in the translated form with data:
-      | activerecord.attributes.business_category.name | activerecord.attributes.business_category.description |
-      | <subcategory_name>                             | <subcategory_description>                             |
+    When I click the icon with CSS class "add-entity-button" for the row with "dog grooming"
+    Then I should see t("business_categories.index.add_subcategory")
 
-    When I click on t("save")
+    When I fill in the translated form with data:
+      | business_categories.category_edit_row.name | business_categories.category_edit_row.description |
+      | <subcategory_name>                         | <subcategory_description>                         |
+
+    And I click on t("save")
     Then I should see "<subcategory_name>"
 
     Scenarios:
-      | subcategory_name    | subcategory_description         |
-      | overall grooming    | full service grooming           |
-      | trim nails          | so you don't get scratched!     |
-      | light trim          | make him or her presentable     |
-      | custom cut          | impress your friends            |
+      | subcategory_name | subcategory_description     |
+      | overall grooming | full service grooming       |
+      | trim nails       | so you don't get scratched! |
+      | light trim       | make him or her presentable |
+      | custom cut       | impress your friends        |
 
 
   @selenium
   Scenario Outline: Create new subcategory - when things go wrong
     Given I am on the "business categories" page
-    And I click the icon with CSS class "add-entity-button" for the row with "dog grooming"
-    And I should see t("business_categories.index.add_subcategory")
+    When I click the icon with CSS class "add-entity-button" for the row with "dog grooming"
+    Then I should see t("business_categories.index.add_subcategory")
 
     When I fill in the translated form with data:
-      | activerecord.attributes.business_category.name | activerecord.attributes.business_category.description |
-      | <subcategory_name>                             | <subcategory_description>                             |
+      | business_categories.category_edit_row.name | business_categories.category_edit_row.description |
+      | <subcategory_name>                         | <subcategory_description>                         |
 
-    When I click on t("save")
+    And I click on t("save")
     Then I should see <error>
 
     Scenarios:
@@ -71,4 +72,4 @@ Feature: Admin can create and delete business subcategories
   Scenario: Indicate required field
     Given I am on the "business categories" page
     And I click the icon with CSS class "add-entity-button" for the row with "dog grooming"
-    Then the field t("activerecord.attributes.business_category.name") should have a required field indicator
+    Then the field t("business_categories.category_edit_row.name") should have a required field indicator

--- a/features/business_categories/create_business_category.feature
+++ b/features/business_categories/create_business_category.feature
@@ -16,29 +16,36 @@ Feature: Admin creates business categories; access
 
     And I am logged in as "admin@shf.com"
 
+  # =================================================================================================
+
+  @selenium @admin
   Scenario Outline: Admin creates a new Business Category
     Given I am on the "business categories" page
     And I click on t("business_categories.new.title")
     When I fill in the translated form with data:
-      | activerecord.attributes.business_category.name | activerecord.attributes.business_category.description |
-      | <category_name>                        | <category_description>                        |
+      | business_categories.category_new_row.name | business_categories.category_new_row.description | business_categories.category_new_row.apply_qs_url |
+      | <category_name>                           | <category_description>                           | <link>                                            |
     And I click on t("business_categories.form.save")
-    And I should see t("business_categories.create.success")
-    And I should see "<category_name>"
+
+    Then I should see "<category_name>"
+    And I should see "<category_description>"
+    And I should see "<link>"
 
     Scenarios:
-      | category_name    | category_description                                                                                |
-      | dog grooming     | washing, brushing, cutting, and trimming hair and nails on dogs                                     |
-      | agility training | training dogs to complete agility courses, from beginners to expert competition level               |
-      | dog psychology   | addresses behavioural issues of dogs, including the emotional, cognitive, and psycho-social aspects |
-      | carting/drafting |                                                                                                     |
+      | category_name    | category_description                                                                                | link                       |
+      | dog grooming     | washing, brushing, cutting, and trimming hair and nails on dogs                                     |                            |
+      | agility training | training dogs to complete agility courses, from beginners to expert competition level               | http://example.com/agility |
+      | dog psychology   | addresses behavioural issues of dogs, including the emotional, cognitive, and psycho-social aspects |                            |
+      | carting/drafting |                                                                                                     | http://example.com         |
 
+
+  @selenium @admin
   Scenario Outline: Create a new category - when things go wrong
     Given I am on the "business categories" page
     And I click on t("business_categories.new.title")
     When I fill in the translated form with data:
-      | activerecord.attributes.business_category.name | activerecord.attributes.business_category.description |
-      | <category_name>                        | <category_description>                        |
+      | business_categories.category_new_row.name | business_categories.category_new_row.description |
+      | <category_name>                           | <category_description>                           |
     When I click on t("business_categories.form.save")
     Then I should see <error>
 
@@ -47,16 +54,22 @@ Feature: Admin creates business categories; access
       |               |                      | t("errors.messages.blank") |
       |               | some description     | t("errors.messages.blank") |
 
-  Scenario: Indicate required field
+
+  @selenium @admin
+  Scenario: Category name is a required field
     Given I am on the "business categories" page
     And I click on t("business_categories.new.title")
-    Then the field t("activerecord.attributes.business_category.name") should have a required field indicator
+    Then the field t("business_categories.category_new_row.name") should have a required field indicator
 
+
+  @user
   Scenario: Listing Business Categories restricted for Non-admins
     Given I am logged in as "applicant@random.com"
     And I am on the "business categories" page
     Then I should see a message telling me I am not allowed to see that page
 
+
+  @visitor
   Scenario: Listing Business Categories restricted for visitors
     Given I am Logged out
     And I am on the "business categories" page

--- a/features/business_categories/edit_business_category.feature
+++ b/features/business_categories/edit_business_category.feature
@@ -25,9 +25,9 @@ Feature: Admin edits business categories
     And I am on the "business categories" page
     When I click the icon with CSS class "edit" for the row with "dog grooming"
     Then I should see t("business_categories.index.edit_category")
-    And I fill in t("activerecord.attributes.business_category.name") with "doggy grooming"
+    When I fill in t("business_categories.category_edit_row.name") with "doggy grooming"
     And I click on t("save")
-    And I should see "doggy grooming"
+    Then I should see "doggy grooming"
 
   @selenium
   Scenario: Admin makes a mistake when editing a business category = sad path
@@ -35,10 +35,10 @@ Feature: Admin edits business categories
     And I am on the "business categories" page
     Then I should see "dog crooning"
     And I should see "dog grooming"
-    When I click the icon with CSS class "edit" for the row with "dog crooning"
 
+    When I click the icon with CSS class "edit" for the row with "dog crooning"
     Then I should see t("business_categories.index.edit_category")
-    And I fill in t("activerecord.attributes.business_category.name") with ""
+    When I fill in t("business_categories.category_edit_row.name") with ""
     And I click on t("save")
     Then I should see error t("activerecord.attributes.business_category.name") t("errors.messages.blank")
 

--- a/features/create_membership_application.feature
+++ b/features/create_membership_application.feature
@@ -352,7 +352,7 @@ Feature: Create a new membership application
     And I click the icon with CSS class "add-entity-button" for the row with "Groomer"
     And I should see t("business_categories.index.add_subcategory")
     When I fill in the translated form with data:
-      | activerecord.attributes.business_category.name | activerecord.attributes.business_category.description |
+      | business_categories.category_edit_row.name | business_categories.category_edit_row.description |
       | overall grooming                               | full service grooming                                 |
 
     When I click on t("save")

--- a/features/edit_shf_application.feature
+++ b/features/edit_shf_application.feature
@@ -222,7 +222,7 @@ Feature: Edit SHF Application
     And I click the icon with CSS class "add-entity-button" for the row with "Groomer"
     And I should see t("business_categories.index.add_subcategory")
     When I fill in the translated form with data:
-      | activerecord.attributes.business_category.name | activerecord.attributes.business_category.description |
+      | business_categories.category_edit_row.name | business_categories.category_edit_row.description |
       | overall grooming                               | full service grooming                                 |
 
     When I click on t("save")

--- a/features/links-for-each-category-applied-for/applicant_sees_links_confirmation_ack_email.feature
+++ b/features/links-for-each-category-applied-for/applicant_sees_links_confirmation_ack_email.feature
@@ -8,7 +8,7 @@ Feature: Applicant sees link for each category they applied for in submission co
       | applicant@example.com |       | Applicant  | Applicant |
 
     And the following business categories exist
-      | name         | link for additional questions |
+      | name         | apply_qs_url |
       | Groomer      | https://example.com/groomer   |
       | Psychologist | https://example.com/psych     |
       | Blorf        | https://example.com/blorf     |
@@ -23,20 +23,20 @@ Feature: Applicant sees link for each category they applied for in submission co
     And I am on the "user account" page
     And I click on first t("menus.nav.users.apply_for_membership") link
     And I fill in the translated form with data:
-      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | shf_applications.show.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
       | 5560360793                          | 031-1234567                       | applicant@example.com              |
+
+    And I select files delivery radio button "upload_later"
 
   # =================================================================================================
 
   @selenium @applicant @user
   Scenario: Applicant applies for 1 category, sees the instructions and 1 link in confirmation message displayed
     Given I select "Groomer" Category
-    And I select files delivery radio button "upload_later"
-    And I click on t("shf_applications.new.submit_button_label")
-
+    When I click on t("shf_applications.new.submit_button_label")
     Then I should see t("shf_applications.create.success_with_app_files_missing")
     And I should see t("shf_applications.create.success_more_questions_instructions")
-    And I should see t("shf_applications.create.success_category_link", category: "Groomer", link: "https://example.com/groomer")
+    And I should see "Groomer https://example.com/groomer"
 
 
   @selenium @applicant @user
@@ -44,30 +44,26 @@ Feature: Applicant sees link for each category they applied for in submission co
     Given I select "Groomer" Category
     And I select "Psychologist" Category
     And I select "Blorf" Category
-    And I select files delivery radio button "upload_later"
-    And I click on t("shf_applications.new.submit_button_label")
-
+    When I click on t("shf_applications.new.submit_button_label")
     Then I should see t("shf_applications.create.success_with_app_files_missing")
     And I should see t("shf_applications.create.success_more_questions_instructions")
-    And I should see t("shf_applications.create.success_category_link", category: "Groomer", link: "https://example.com/groomer")
-    And I should see t("shf_applications.create.success_category_link", category: "Psychologist", link: "https://example.com/psych")
-    And I should see t("shf_applications.create.success_category_link", category: "Blorf", link: "https://example.com/blorf")
+    And I should see "Psychologist https://example.com/psych"
+    And I should see "Groomer https://example.com/groomer"
+    And I should see "Blorf https://example.com/blorf"
 
 
   @selenium @applicant @user
   Scenario: Applicant applies for 1 category, sees the instructions and 1 link in the acknowledgment email
     Given I select "Groomer" Category
-    And I select files delivery radio button "upload_later"
-    And I click on t("shf_applications.new.submit_button_label")
-
+    When I click on t("shf_applications.new.submit_button_label")
     Then I should see t("shf_applications.create.success_with_app_files_missing")
-    And I should be on the "user account" page for "applicant@example.com"
+
     And "applicant@example.com" should receive an email
 
     When I open the email
     Then I should see t("mailers.shf_application_mailer.acknowledge_received.subject") in the email subject
     And I should see t("mailers.shf_application_mailer.acknowledge_received.more_questions_instructions") in the email body
-    And I should see t("mailers.shf_application_mailer.acknowledge_received.category_link", category: "Groomer", link: "https://example.com/groomer") in the email body
+    And I should see "Groomer https://example.com/groomer" in the email body
 
 
   @selenium @applicant @user
@@ -85,6 +81,6 @@ Feature: Applicant sees link for each category they applied for in submission co
     When I open the email
     Then I should see t("mailers.shf_application_mailer.acknowledge_received.subject") in the email subject
     And I should see t("mailers.shf_application_mailer.acknowledge_received.more_questions_instructions") in the email body
-    And I should see t("mailers.shf_application_mailer.acknowledge_received.category_link", category: "Groomer", link: "https://example.com/groomer") in the email body
-    And I should see t("mailers.shf_application_mailer.acknowledge_received.category_link", category: "Psychologist", link: "https://example.com/psych") in the email body
-    And I should see t("mailers.shf_application_mailer.acknowledge_received.category_link", category: "Blorf", link: "https://example.com/blorf") in the email body
+    And I should see "Groomer https://example.com/groomer" in the email body
+    And I should see "Psychologist https://example.com/psych" in the email body
+    And I should see "Blorf https://example.com/blorf" in the email body

--- a/features/links-for-each-category-applied-for/applicant_sees_links_confirmation_ack_email.feature
+++ b/features/links-for-each-category-applied-for/applicant_sees_links_confirmation_ack_email.feature
@@ -37,7 +37,7 @@ Feature: Applicant sees link for each category they applied for in submission co
     Then I should see t("shf_applications.create.success_with_app_files_missing")
     And I should see t("shf_applications.create.success_more_questions_instructions")
     And I should see "Groomer https://example.com/groomer"
-
+    And I should see t("shf_applications.create.success_more_questions_instructions")
 
   @selenium @applicant @user
   Scenario: Applicant applies for 3 categories, sees the instructions once and the 3 links in confirmation message displayed
@@ -58,11 +58,10 @@ Feature: Applicant sees link for each category they applied for in submission co
     When I click on t("shf_applications.new.submit_button_label")
     Then I should see t("shf_applications.create.success_with_app_files_missing")
 
-    And "applicant@example.com" should receive an email
+    And "applicant@example.com" should receive an email with subject t("mailers.shf_application_mailer.acknowledge_received.subject")
 
     When I open the email
-    Then I should see t("mailers.shf_application_mailer.acknowledge_received.subject") in the email subject
-    And I should see t("mailers.shf_application_mailer.acknowledge_received.more_questions_instructions") in the email body
+    Then I should see t("mailers.shf_application_mailer.acknowledge_received.more_questions_instructions") in the email body
     And I should see "Groomer https://example.com/groomer" in the email body
 
 
@@ -76,11 +75,10 @@ Feature: Applicant sees link for each category they applied for in submission co
 
     Then I should see t("shf_applications.create.success_with_app_files_missing")
     And I should be on the "user account" page for "applicant@example.com"
-    And "applicant@example.com" should receive an email
+    And "applicant@example.com" should receive an email with subject t("mailers.shf_application_mailer.acknowledge_received.subject")
 
     When I open the email
-    Then I should see t("mailers.shf_application_mailer.acknowledge_received.subject") in the email subject
-    And I should see t("mailers.shf_application_mailer.acknowledge_received.more_questions_instructions") in the email body
+    Then I should see t("mailers.shf_application_mailer.acknowledge_received.more_questions_instructions") in the email body
     And I should see "Groomer https://example.com/groomer" in the email body
     And I should see "Psychologist https://example.com/psych" in the email body
     And I should see "Blorf https://example.com/blorf" in the email body

--- a/features/links-for-each-category-applied-for/applicant_sees_links_confirmation_ack_email.feature
+++ b/features/links-for-each-category-applied-for/applicant_sees_links_confirmation_ack_email.feature
@@ -1,0 +1,90 @@
+Feature: Applicant sees link for each category they applied for in submission confirmation and aknowledgement email
+
+  Background:
+    Given the Membership Ethical Guidelines Master Checklist exists
+
+    Given the following users exist:
+      | email                 | admin | first_name | last_name |
+      | applicant@example.com |       | Applicant  | Applicant |
+
+    And the following business categories exist
+      | name         | link for additional questions |
+      | Groomer      | https://example.com/groomer   |
+      | Psychologist | https://example.com/psych     |
+      | Blorf        | https://example.com/blorf     |
+
+    And the following companies exist:
+      | name                 | company_number | email                  | region    |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.com | Stockholm |
+
+    And the application file upload options exist
+
+    And I am logged in as "applicant@example.com"
+    And I am on the "user account" page
+    And I click on first t("menus.nav.users.apply_for_membership") link
+    And I fill in the translated form with data:
+      | shf_applications.new.company_number | shf_applications.new.phone_number | shf_applications.new.contact_email |
+      | 5560360793                          | 031-1234567                       | applicant@example.com              |
+
+  # =================================================================================================
+
+  @selenium @applicant @user
+  Scenario: Applicant applies for 1 category, sees the instructions and 1 link in confirmation message displayed
+    Given I select "Groomer" Category
+    And I select files delivery radio button "upload_later"
+    And I click on t("shf_applications.new.submit_button_label")
+
+    Then I should see t("shf_applications.create.success_with_app_files_missing")
+    And I should see t("shf_applications.create.success_more_questions_instructions")
+    And I should see t("shf_applications.create.success_category_link", category: "Groomer", link: "https://example.com/groomer")
+
+
+  @selenium @applicant @user
+  Scenario: Applicant applies for 3 categories, sees the instructions once and the 3 links in confirmation message displayed
+    Given I select "Groomer" Category
+    And I select "Psychologist" Category
+    And I select "Blorf" Category
+    And I select files delivery radio button "upload_later"
+    And I click on t("shf_applications.new.submit_button_label")
+
+    Then I should see t("shf_applications.create.success_with_app_files_missing")
+    And I should see t("shf_applications.create.success_more_questions_instructions")
+    And I should see t("shf_applications.create.success_category_link", category: "Groomer", link: "https://example.com/groomer")
+    And I should see t("shf_applications.create.success_category_link", category: "Psychologist", link: "https://example.com/psych")
+    And I should see t("shf_applications.create.success_category_link", category: "Blorf", link: "https://example.com/blorf")
+
+
+  @selenium @applicant @user
+  Scenario: Applicant applies for 1 category, sees the instructions and 1 link in the acknowledgment email
+    Given I select "Groomer" Category
+    And I select files delivery radio button "upload_later"
+    And I click on t("shf_applications.new.submit_button_label")
+
+    Then I should see t("shf_applications.create.success_with_app_files_missing")
+    And I should be on the "user account" page for "applicant@example.com"
+    And "applicant@example.com" should receive an email
+
+    When I open the email
+    Then I should see t("mailers.shf_application_mailer.acknowledge_received.subject") in the email subject
+    And I should see t("mailers.shf_application_mailer.acknowledge_received.more_questions_instructions") in the email body
+    And I should see t("mailers.shf_application_mailer.acknowledge_received.category_link", category: "Groomer", link: "https://example.com/groomer") in the email body
+
+
+  @selenium @applicant @user
+  Scenario: Applicant applies for 3 categories, sees the instructions once and the 3 links in the acknowledgment email
+    Given I select "Groomer" Category
+    And I select "Psychologist" Category
+    And I select "Blorf" Category
+    And I select files delivery radio button "upload_later"
+    And I click on t("shf_applications.new.submit_button_label")
+
+    Then I should see t("shf_applications.create.success_with_app_files_missing")
+    And I should be on the "user account" page for "applicant@example.com"
+    And "applicant@example.com" should receive an email
+
+    When I open the email
+    Then I should see t("mailers.shf_application_mailer.acknowledge_received.subject") in the email subject
+    And I should see t("mailers.shf_application_mailer.acknowledge_received.more_questions_instructions") in the email body
+    And I should see t("mailers.shf_application_mailer.acknowledge_received.category_link", category: "Groomer", link: "https://example.com/groomer") in the email body
+    And I should see t("mailers.shf_application_mailer.acknowledge_received.category_link", category: "Psychologist", link: "https://example.com/psych") in the email body
+    And I should see t("mailers.shf_application_mailer.acknowledge_received.category_link", category: "Blorf", link: "https://example.com/blorf") in the email body

--- a/features/links-for-each-category-applied-for/links_if_shf_app_biz_cats_changed.feature
+++ b/features/links-for-each-category-applied-for/links_if_shf_app_biz_cats_changed.feature
@@ -1,0 +1,77 @@
+Feature: Applicant sees links and gets email about additional questions if business categories are changed
+
+  If an applicant edits their application and adds or removes the business categories for it
+  then the applicatn should see a (flash) message about the additional questions for any business categories added
+  and they should get an email with the additional question links, too.
+
+  The admin does not get any email because the business categories can only be changed if it is not under review or accepted or rejected
+
+
+  Background:
+    Given the Membership Ethical Guidelines Master Checklist exists
+    And the application file upload options exist
+
+    Given the following users exist:
+      | email                 | admin | first_name | last_name |
+      | applicant@example.com |       | Applicant  | Applicant |
+
+    And the following business categories exist
+      | name         | apply_qs_url                |
+      | Groomer      | https://example.com/groomer |
+      | Psychologist | https://example.com/psych   |
+      | Trim         | https://example.com/trim    |
+      | Butik        | https://example.com/butik   |
+      | Blorf        | https://example.com/blorf   |
+
+    And the following companies exist:
+      | name                 | company_number | email                  | region    |
+      | No More Snarky Barky | 5560360793     | snarky@snarkybarky.com | Stockholm |
+
+    And the following applications exist:
+      | user_email            | company_number | state | categories            | uploaded file names |
+      | applicant@example.com | 5560360793     | new   | Groomer, Psychologist | diploma.pdf         |
+
+
+    And I am logged in as "applicant@example.com"
+    And I am on the "edit my application" page
+
+  # =================================================================================================
+
+  @selenium @applicant @user
+  Scenario: Two business categories are added; message shows info about both and email is sent
+    Given I select "Butik" Category
+    And I select "Blorf" Category
+
+    When I click on t("shf_applications.edit.submit_button_label")
+    Then I should see t("shf_applications.update.success")
+    And I should see t("shf_applications.update.success_more_questions_instructions")
+    And I should see "Butik https://example.com/butik"
+    And I should see "Blorf https://example.com/blorf"
+    And "applicant@example.com" should receive an email with subject t("mailers.shf_application_mailer.additional_qs_for_biz_cats.subject")
+
+    When I open the email
+    Then I should see t("mailers.shf_application_mailer.acknowledge_received.more_questions_instructions") in the email body
+    And I should see "Butik https://example.com/butik" in the email body
+    And I should see "Blorf https://example.com/blorf" in the email body
+    And I should not see "Groomer https://example.com/groomer" in the email body
+    And I should not see "Psychologist https://example.com/psych" in the email body
+
+
+  @selenium @applicant @user
+  Scenario: One business category is removed; no message or email about additional questions
+    Given I unselect "Groomer" Category
+
+    When I click on t("shf_applications.edit.submit_button_label")
+    Then I should see t("shf_applications.update.success")
+    And I should not see t("shf_applications.update.success_more_questions_instructions")
+    And "applicant@example.com" should receive no email with subject t("shf_application_mailer.additional_qs_for_biz_cats.subject")
+
+
+  @selenium @applicant @user
+  Scenario: Business categories are not changed; no message or email about additional questions
+    Given I fill in t("shf_applications.show.contact_email") with "changedemail@example.com"
+
+    When I click on t("shf_applications.edit.submit_button_label")
+    Then I should see t("shf_applications.update.success")
+    And I should not see t("shf_applications.update.success_more_questions_instructions")
+    And "applicant@example.com" should receive no email with subject t("shf_application_mailer.additional_qs_for_biz_cats.subject")

--- a/features/links-for-each-category-applied-for/links_if_shf_app_biz_cats_changed.feature
+++ b/features/links-for-each-category-applied-for/links_if_shf_app_biz_cats_changed.feature
@@ -64,7 +64,7 @@ Feature: Applicant sees links and gets email about additional questions if busin
     When I click on t("shf_applications.edit.submit_button_label")
     Then I should see t("shf_applications.update.success")
     And I should not see t("shf_applications.update.success_more_questions_instructions")
-    And "applicant@example.com" should receive no email with subject t("shf_application_mailer.additional_qs_for_biz_cats.subject")
+    And "applicant@example.com" should receive no email with subject t("mailers.shf_application_mailer.additional_qs_for_biz_cats.subject")
 
 
   @selenium @applicant @user
@@ -74,4 +74,4 @@ Feature: Applicant sees links and gets email about additional questions if busin
     When I click on t("shf_applications.edit.submit_button_label")
     Then I should see t("shf_applications.update.success")
     And I should not see t("shf_applications.update.success_more_questions_instructions")
-    And "applicant@example.com" should receive no email with subject t("shf_application_mailer.additional_qs_for_biz_cats.subject")
+    And "applicant@example.com" should receive no email with subject t("mailers.shf_application_mailer.additional_qs_for_biz_cats.subject")

--- a/features/step_definitions/business_category_steps.rb
+++ b/features/step_definitions/business_category_steps.rb
@@ -2,9 +2,8 @@ And(/^the following business categories exist$/) do |table|
   table.hashes.each do |business_category|
 
     subcategories = business_category.delete('subcategories')
-    link_for_addtl_category_qs = business_category.delete('link for additional questions')
 
-    cat = FactoryBot.create(:business_category, business_category, apply_qs_url: link_for_addtl_category_qs)
+    cat = FactoryBot.create(:business_category, business_category)
     if subcategories
       subcategories.split(/\s*,\s*/).each do |subcategory_name|
         FactoryBot.create(:business_category, name: subcategory_name, parent_id: cat.id)

--- a/features/step_definitions/business_category_steps.rb
+++ b/features/step_definitions/business_category_steps.rb
@@ -2,11 +2,10 @@ And(/^the following business categories exist$/) do |table|
   table.hashes.each do |business_category|
 
     subcategories = business_category.delete('subcategories')
+    link_for_addtl_category_qs = business_category.delete('link for additional questions')
 
-    cat = FactoryBot.create(:business_category, business_category)
-
+    cat = FactoryBot.create(:business_category, business_category, apply_qs_url: link_for_addtl_category_qs)
     if subcategories
-
       subcategories.split(/\s*,\s*/).each do |subcategory_name|
         FactoryBot.create(:business_category, name: subcategory_name, parent_id: cat.id)
       end
@@ -23,7 +22,7 @@ end
 And(/^I select "([^"]*)" Category/) do |element|
   # You must use a driver that supports javascript if using this step.
 
-  # 5/27/2018 - we are using "collection_check_boxes" helper in the appication
+  # 5/27/2018 - we are using "collection_check_boxes" helper in the application
   # form.  This sets a hidden field that ensures that business_categories (for
   # the membership application) is updated even if no categories are checked in
   # the form (see "Gotcha" in documentation for that method).
@@ -50,7 +49,7 @@ And(/^I select "([^"]*)" Category/) do |element|
   # TODO is it really necessary to run a java script to do this?  Why not use ele.check ?
   #
   ele = find :field, element, visible: :any
-  page.evaluate_script("$(#{ele[:id]}).prop('checked', true)")
+  page.evaluate_script("$(#{ele[:id]}).prop('checked', true)") # ex: $(shf_application_business_category_ids_1).prop('checked', true)
 end
 
 And(/^I unselect "([^"]*)" Category/) do |element|

--- a/spec/factories/business_categories.rb
+++ b/spec/factories/business_categories.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :business_category do
     name { "Business Category" }
     description { "business category description" }
+    apply_qs_url { 'https://example.com/more-questions-for-application' }
   end
 end

--- a/spec/helpers/shf_applications_helper_spec.rb
+++ b/spec/helpers/shf_applications_helper_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe ShfApplicationsHelper, type: :helper do
   describe 'instructions_for_additional_category_qs' do
     it 'gets the links for all of the shf application categories' do
       expect(helper).to receive(:links_for_more_category_questions).with(app_3_cats.business_categories)
-      helper.instructions_for_additional_category_qs(app_3_cats, 'sv.shf_applications.create')
+      helper.instructions_for_additional_category_qs(app_3_cats.business_categories, 'sv.shf_applications.create')
     end
   end
 

--- a/spec/mailers/previews/shf_application_mailer_preview.rb
+++ b/spec/mailers/previews/shf_application_mailer_preview.rb
@@ -52,6 +52,12 @@ class ShfApplicationMailerPreview < ActionMailer::Preview
     ShfApplicationMailer.acknowledge_received(app_with_uploads)
   end
 
+  def additional_qs_for_biz_cats
+    shf_app = random_shf_app(:new)
+    ShfApplicationMailer.additional_qs_for_biz_cats(shf_app, [shf_app.business_categories.first])
+  end
+
+
   private
 
   def get_new_app


### PR DESCRIPTION
## PT Story:  Send/show links to Category questionnaires
#### PT URL: https://www.pivotaltracker.com/story/show/182229286


## Changes proposed in this pull request:
1.  Admin can add/edit the URL for each business category
2. When submitting a new application, applicant sees instructions and links in the (flash) message and sees the instructions and links in the acknowledgement email.
3. If an applicant edits their application and adds categories, they will see instructions and links in the (flash) message and get an email with instructions and links.

## Screenshots (Optional):

### 1. Admin can edit the URL (link) for each business category
<img width="885" alt="admin-edit-category-link" src="https://user-images.githubusercontent.com/673794/172958478-8d2796f9-20e6-49e9-be43-a0e783eb8b5e.png">

---

### 2. Message with instruction and links after app submitted

<img width="827" alt="message-cat-links-instructions" src="https://user-images.githubusercontent.com/673794/172958491-5aa9a844-a922-47a0-855b-278f725f356b.png">


---

### 3. Instructions and links in Application received/acknowledgement email

<img width="548" alt="ack-email-cat-instructions-links" src="https://user-images.githubusercontent.com/673794/172958525-911e0bf5-2d13-4b71-97de-89e737cab6cc.png">

---

### 4. Email received if new categories added

<img width="714" alt="cats-added-email-cat-instructions-links" src="https://user-images.githubusercontent.com/673794/172958543-728295e7-e3a4-42f9-bb68-136c823d8ec9.png">


---
## Ready for review:
@patmbolger @thesuss @RobertCram 
